### PR TITLE
feat(src): add flag to disable the folding range

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -33,7 +33,10 @@ impl RequestHandler for NoOpHandler {
 }
 
 impl Handler {
-    pub fn new(logger: Rc<RefCell<dyn Logger>>) -> Handler {
+    pub fn new(
+        logger: Rc<RefCell<dyn Logger>>,
+        disable_folding: bool,
+    ) -> Handler {
         let mut mapping: HashMap<String, Box<dyn RequestHandler>> =
             HashMap::new();
         mapping.insert(
@@ -62,7 +65,7 @@ impl Handler {
         );
         mapping.insert(
             "initialize".to_string(),
-            Box::new(InitializeHandler::default()),
+            Box::new(InitializeHandler::new(disable_folding)),
         );
         mapping.insert(
             "shutdown".to_string(),

--- a/src/handlers/initialize.rs
+++ b/src/handlers/initialize.rs
@@ -4,7 +4,15 @@ use crate::protocol::requests::{
 };
 use crate::protocol::responses::{InitializeResult, Response};
 
-pub struct InitializeHandler {}
+pub struct InitializeHandler {
+    disable_folding: bool,
+}
+
+impl InitializeHandler {
+    pub fn new(disable_folding: bool) -> InitializeHandler {
+        InitializeHandler { disable_folding }
+    }
+}
 
 impl RequestHandler for InitializeHandler {
     fn handle(
@@ -13,19 +21,12 @@ impl RequestHandler for InitializeHandler {
     ) -> Result<Option<String>, String> {
         let _: Request<InitializeParams> =
             Request::from_json(prequest.data.as_str())?;
-
-        let result = InitializeResult::default();
+        let result = InitializeResult::new(!self.disable_folding);
         let response =
             Response::new(prequest.base_request.id, Some(result));
 
         let json = response.to_json()?;
 
         Ok(Some(json))
-    }
-}
-
-impl Default for InitializeHandler {
-    fn default() -> Self {
-        InitializeHandler {}
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,18 +29,27 @@ impl Server {
         logger: Rc<RefCell<dyn Logger>>,
         reader: Box<dyn ServerInput>,
         writer: Box<dyn Write>,
+        disable_folding: bool,
     ) -> Server {
         Server {
             reader,
             writer,
             logger: logger.clone(),
-            handler: Handler::new(logger.clone()),
+            handler: Handler::new(logger.clone(), disable_folding),
         }
     }
 
-    pub fn with_stdio(logger: Rc<RefCell<dyn Logger>>) -> Server {
+    pub fn with_stdio(
+        logger: Rc<RefCell<dyn Logger>>,
+        disable_folding: bool,
+    ) -> Server {
         let reader = BufReader::new(io::stdin());
-        Server::new(logger, Box::new(reader), Box::new(io::stdout()))
+        Server::new(
+            logger,
+            Box::new(reader),
+            Box::new(io::stdout()),
+            disable_folding,
+        )
     }
 
     fn write(&mut self, s: String) -> io::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,15 @@ fn main() {
                 .long("logfile")
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("disable-folding")
+            .help("set this flag to disable the range folding capacity")
+            .long("disable-folding")
+            .takes_value(false),
+        )
         .get_matches();
     let logger: Rc<RefCell<dyn loggers::Logger>>;
-
+    let disable_folding = flags.is_present("disable-folding");
     if let Some(ref logfile) = flags.value_of("logfile") {
         logger = Rc::new(RefCell::new(
             loggers::FileLogger::new(logfile).unwrap(),
@@ -28,7 +34,6 @@ fn main() {
         logger =
             Rc::new(RefCell::new(loggers::DefaultLogger::default()));
     }
-
-    let mut server = Server::with_stdio(logger);
+    let mut server = Server::with_stdio(logger, disable_folding);
     server.start();
 }

--- a/src/protocol/responses.rs
+++ b/src/protocol/responses.rs
@@ -41,14 +41,14 @@ pub struct InitializeResult {
     pub capabilities: ServerCapabilities,
 }
 
-impl Default for InitializeResult {
-    fn default() -> Self {
+impl InitializeResult {
+    pub fn new(folding_range_provider: bool) -> Self {
         InitializeResult {
             capabilities: ServerCapabilities {
                 definition_provider: true,
                 references_provider: true,
                 rename_provider: true,
-                folding_range_provider: true,
+                folding_range_provider,
             },
         }
     }

--- a/tests/handlers.rs
+++ b/tests/handlers.rs
@@ -23,7 +23,7 @@ impl Logger for TestLogger {
 
 fn create_handler() -> Handler {
     let logger = Rc::new(RefCell::new(TestLogger {}));
-    Handler::new(logger)
+    Handler::new(logger, false)
 }
 
 fn flux_fixture_uri(filename: &'static str) -> String {
@@ -77,7 +77,7 @@ fn test_initialize() {
     let response = handler.handle(request).unwrap().unwrap();
     let expected = Response {
         id: 1,
-        result: Some(InitializeResult::default()),
+        result: Some(InitializeResult::new(true)),
         jsonrpc: "2.0".to_string(),
     };
     let expected_json = expected.to_json().unwrap();


### PR DESCRIPTION
VScode runs better when folding range provider is disabled, this feature provides a flag, to disable the server's folding range capacity.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
