### PR TITLE
dep: remove dependency on flux master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.3.0"
-source = "git+https://github.com/influxdata/flux#835605719299ec5c5353966277ebc7da868b03c7"
+source = "git+https://github.com/influxdata/flux?rev=91e6a79#91e6a7991bf2c21c3e8bddd757811380c2cdc81b"
 dependencies = [
  "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -204,7 +204,7 @@ name = "flux-lsp"
 version = "0.1.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "flux 0.3.0 (git+https://github.com/influxdata/flux)",
+ "flux 0.3.0 (git+https://github.com/influxdata/flux?rev=91e6a79)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -699,7 +699,7 @@ dependencies = [
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum flatbuffers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc1af59fd8248b59beb048d614a869ce211315c195f5412334e47f5b7e22726"
-"checksum flux 0.3.0 (git+https://github.com/influxdata/flux)" = "<none>"
+"checksum flux 0.3.0 (git+https://github.com/influxdata/flux?rev=91e6a79)" = "<none>"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ path = "src/main.rs"
 serde_json = "1.0"
 clap = "2.31.2"
 serde = { version = "1.0.101", features = ["derive"] }
-flux = { git = "https://github.com/influxdata/flux", branch = "master" }
+flux = { git = "https://github.com/influxdata/flux", rev = "91e6a79" }
 url = "2.1.0"


### PR DESCRIPTION
`flux::semantic::analyze_source` was recently updated with a breaking change. This commit updates the flux dependency to a stable commit.
