### PR TITLE
fix(src/protocol): add server cap of text sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -443,6 +444,16 @@ dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -734,6 +745,7 @@ dependencies = [
 "checksum serde-aux 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae50f53d4b01e854319c1f5b854cd59471f054ea7e554988850d3f36ca1dc852"
 "checksum serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
 "checksum serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)" = "1a3351dcbc1f067e2c92ab7c3c1f288ad1a4cffc470b5aaddb4c2e0a3ae80043"
+"checksum serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 serde_json = "1.0"
+serde_repr = "0.1"
 clap = "2.31.2"
 serde = { version = "1.0.101", features = ["derive"] }
 flux = { git = "https://github.com/influxdata/flux", rev = "91e6a79" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,14 +107,25 @@ impl Server {
 
         let content_size = utils::get_content_size(line.clone())?;
         let content_body = self.read_content_body(content_size)?;
+        self.logger
+            .borrow_mut()
+            .info(format!("Resquest -> {}", content_body.clone()))?;
         let request = utils::parse_request(content_body)?;
         let option = self.handler.handle(request.clone())?;
 
         if let Some(msg) = option {
+            let resp = msg.clone();
             match self.write(msg) {
-                Ok(_) => return Ok(()),
+                Ok(_) => {
+                    self.logger
+                        .borrow_mut()
+                        .info(format!("Response -> {}", resp))?;
+                    return Ok(());
+                }
                 Err(_) => {
-                    return Err("Failed to write response".to_string())
+                    return Err(
+                        "Failed to write response".to_string()
+                    );
                 }
             }
         }

--- a/src/protocol/properties.rs
+++ b/src/protocol/properties.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
 fn default_version() -> u32 {
     1
@@ -81,8 +82,29 @@ pub struct Location {
     pub range: Range,
 }
 
-#[derive(Serialize, Deserialize, Clone, Default)]
+#[derive(Serialize_repr, Deserialize_repr, PartialEq, Clone)]
+#[repr(u8)]
+pub enum TextDocumentSyncKind {
+    /**
+     * Documents should not be synced at all.
+     */
+    None = 0,
+    /**
+     * Documents are synced by always sending the full content of the document.
+     */
+    Full = 1,
+    /**
+     * Documents are synced by sending the full content on open. After that only incremental
+     * updates to the document are sent.
+     */
+    Incremental = 2,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
 pub struct ServerCapabilities {
+    #[serde(rename = "textDocumentSync")]
+    pub text_document_sync: TextDocumentSyncKind,
+
     #[serde(rename = "referencesProvider")]
     pub references_provider: bool,
 

--- a/src/protocol/responses.rs
+++ b/src/protocol/responses.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::protocol::properties::{ServerCapabilities, TextEdit};
+use crate::protocol::properties::{
+    ServerCapabilities, TextDocumentSyncKind, TextEdit,
+};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Response<T> {
@@ -49,6 +51,7 @@ impl InitializeResult {
                 references_provider: true,
                 rename_provider: true,
                 folding_range_provider,
+                text_document_sync: TextDocumentSyncKind::Full,
             },
         }
     }


### PR DESCRIPTION
Closes #https://github.com/influxdata/flux-lsp/issues/64

Vscode plugin doesn't auto send didOpen request, is due to we are missing a server capacity described in https://github.com/microsoft/language-server-protocol/blob/master/versions/protocol-2-x.md

TextDocumentSyncKind

This pr will fix the issue, manually tested. 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
