### PR TITLE
fix(wasm-build.sh): check exists before delete

### DIFF
--- a/wasm-build.sh
+++ b/wasm-build.sh
@@ -2,8 +2,8 @@
 
 source $HOME/.cargo/env
 
-rm -rf pkg-node
-rm -rf pkg-browser
+[ ! -e pkg-node ] || rm -rf pkg-node
+[ ! -e pkg-browser ] || rm -rf pkg-browser
 
 wasm-pack build -t nodejs -d pkg-node --out-name flux-lsp-node --scope influxdata
 wasm-pack build -t browser -d pkg-browser --out-name flux-lsp-browser --scope influxdata


### PR DESCRIPTION
Linux user can run wasm-build.sh without docker. however it will fail for the first time builders. This fix checks the existence of those folders before rm. manually tested. 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
