### PR TITLE
chore(config): bump the flux version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.3.0"
-source = "git+https://github.com/influxdata/flux?rev=4827c2b#4827c2b91bdbaf95422e2164e5de5de8c0ceca46"
+source = "git+https://github.com/influxdata/flux?rev=b12a6fe#b12a6fe0684fdaa6339397ec7e7bb6d942040676"
 dependencies = [
  "bindgen 0.49.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -225,11 +225,11 @@ version = "0.3.0"
 dependencies = [
  "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "combinations 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "flux 0.3.0 (git+https://github.com/influxdata/flux?rev=4827c2b)",
+ "flux 0.3.0 (git+https://github.com/influxdata/flux?rev=b12a6fe)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libstd 0.1.0 (git+https://github.com/influxdata/flux?rev=4827c2b)",
+ "libstd 0.1.0 (git+https://github.com/influxdata/flux?rev=b12a6fe)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -403,10 +403,10 @@ dependencies = [
 [[package]]
 name = "libstd"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/flux?rev=4827c2b#4827c2b91bdbaf95422e2164e5de5de8c0ceca46"
+source = "git+https://github.com/influxdata/flux?rev=b12a6fe#b12a6fe0684fdaa6339397ec7e7bb6d942040676"
 dependencies = [
  "flatbuffers 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "flux 0.3.0 (git+https://github.com/influxdata/flux?rev=4827c2b)",
+ "flux 0.3.0 (git+https://github.com/influxdata/flux?rev=b12a6fe)",
 ]
 
 [[package]]
@@ -936,7 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum flatbuffers 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a788f068dd10687940565bf4b5480ee943176cbd114b12e811074bcf7c04e4b9"
-"checksum flux 0.3.0 (git+https://github.com/influxdata/flux?rev=4827c2b)" = "<none>"
+"checksum flux 0.3.0 (git+https://github.com/influxdata/flux?rev=b12a6fe)" = "<none>"
 "checksum futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
 "checksum futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
 "checksum futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
@@ -957,7 +957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)" = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-"checksum libstd 0.1.0 (git+https://github.com/influxdata/flux?rev=4827c2b)" = "<none>"
+"checksum libstd 0.1.0 (git+https://github.com/influxdata/flux?rev=b12a6fe)" = "<none>"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ path = "src/lib.rs"
 serde_json = "1.0"
 serde_repr = "0.1"
 serde = { version = "1.0.104", features = ["derive"] }
-flux = { git = "https://github.com/influxdata/flux", rev = "4827c2b" }
-libstd = { git = "https://github.com/influxdata/flux", rev = "4827c2b" }
+flux = { git = "https://github.com/influxdata/flux", rev = "b12a6fe" }
+libstd = { git = "https://github.com/influxdata/flux", rev = "b12a6fe" }
 url = "2.1.1"
 lazy_static = "1.4.0"
 wasm-bindgen = "0.2.58"


### PR DESCRIPTION
Closes https://github.com/influxdata/flux-lsp/issues/104

bump the version, manually tested


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
