### PR TITLE
chore: update readme and extend makefile with ability to target tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ install:
 	cargo install --path . --force
 
 test:
-	cargo test -- --test-threads=1 --nocapture
+	# tests arg can be used to run specific tests, for example:
+	#	make test tests=Find_references::test_returns_correct_response
+	# if no tests arg provided will run entire suite
+	cargo test $(tests) -- test  --test-threads=1 --nocapture
 
 manual-test: test install
 	vim me.flux

--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,11 @@
 
 An implementation of the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) for the [Flux language](https://github.com/influxdata/flux).
 
+# LSP Development
+
+* LSP development requires rust version of 1.40.0 or newer.
+* run tests with `make test`
+
 # Installing command line server
 
 ```


### PR DESCRIPTION
Small PR to add ability to run specific tests using make command.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass