### PR TITLE
chore: add test to verify completions do not include variables out of scope

### DIFF
--- a/src/handlers/completion.rs
+++ b/src/handlers/completion.rs
@@ -120,7 +120,6 @@ fn get_user_completables(
     let mut visitor = CompletableFinderVisitor::new(pos);
 
     walk::walk(&mut visitor, walker);
-
     if let Ok(state) = visitor.state.lock() {
         return Ok((*state).completables.clone());
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,6 +34,12 @@ pub fn is_in_node(pos: Position, base: &flux::ast::BaseNode) -> bool {
         return false;
     }
 
+    println!(
+        "base line_start: {}  line_end: {}  char: {}",
+        start_line, end_line, start_col
+    );
+    println!("pos line: {}\tchar: {}", pos.line, pos.character);
+
     true
 }
 

--- a/src/visitors/ast/mod.rs
+++ b/src/visitors/ast/mod.rs
@@ -150,3 +150,13 @@ impl<'a> Visitor<'a> for IdentFinderVisitor<'a> {
         Some(self.clone())
     }
 }
+
+pub struct AstVisitor<'a> {
+    pub state: Rc<RefCell<IdentFinderState<'a>>>,
+}
+
+impl<'a> Visitor<'a> for AstVisitor<'a> {
+    fn visit(&self, node: Rc<walk::Node<'a>>) -> Option<Self> {
+        
+    }
+}

--- a/src/visitors/semantic/completion/mod.rs
+++ b/src/visitors/semantic/completion/mod.rs
@@ -37,6 +37,14 @@ impl<'a> Visitor<'a> for CompletableFinderVisitor {
                 return true;
             }
 
+            if let Node::FunctionExpr(_) = node.as_ref() {
+                println!("visitor func expr")
+            }
+
+            if let Node::FunctionParameter(_) = node.as_ref() {
+                println!("visitor func parameter")
+            }
+
             if let Node::VariableAssgn(assgn) = node.as_ref() {
                 let name = assgn.id.name.clone();
                 if let Some(var_type) = get_var_type(&assgn.init) {
@@ -201,7 +209,12 @@ fn get_var_type(expr: &Expression) -> Option<VarType> {
         Expression::Object(_) => Some(VarType::Object),
         Expression::Regexp(_) => Some(VarType::Regexp),
         Expression::Duration(_) => Some(VarType::Duration),
+        Expression::Function(_) => {
+            println!("i'm a func");
+            Some(VarType::Function)
+        }
         Expression::Call(c) => {
+            println!("enter call");
             let result_type = utils::follow_function_pipes(c);
 
             match result_type {
@@ -210,6 +223,10 @@ fn get_var_type(expr: &Expression) -> Option<VarType> {
                 MonoType::Bool => Some(VarType::Bool),
                 MonoType::Arr(_) => Some(VarType::Array),
                 MonoType::Duration => Some(VarType::Duration),
+                MonoType::Fun(_) => {
+                    println!("nested fun");
+                    Some(VarType::Function)
+                }
                 MonoType::Row(_) => Some(VarType::Row),
                 MonoType::String => Some(VarType::String),
                 MonoType::Uint => Some(VarType::Uint),
@@ -243,17 +260,18 @@ fn create_function_result(
 
 #[derive(Clone)]
 enum VarType {
-    Int,
-    String,
     Array,
-    Float,
     Bool,
     Duration,
+    Float,
+    Function,
+    Int,
     Object,
     Regexp,
     Row,
-    Uint,
+    String,
     Time,
+    Uint,
 }
 
 #[derive(Clone)]
@@ -269,6 +287,7 @@ impl VarResult {
             VarType::Bool => "Boolean".to_string(),
             VarType::Duration => "Duration".to_string(),
             VarType::Float => "Float".to_string(),
+            VarType::Function => "Function".to_string(),
             VarType::Int => "Integer".to_string(),
             VarType::Object => "Object".to_string(),
             VarType::Regexp => "Regular Expression".to_string(),

--- a/tests/fixtures/completion_in_function.flux
+++ b/tests/fixtures/completion_in_function.flux
@@ -1,0 +1,21 @@
+import "strings"
+import "csv"
+
+aTen = 10
+env = "prod01-us-west-2"
+
+gamma = (alpha, beta) =>
+    
+
+errorCounts = from(bucket:"kube-infra/monthly")
+    |> range(start: -3d)
+    |> filter(fn: (r) => r._measurement == "query_log" and
+                         r.error != "" and
+                         r._field == "responseSize" and
+                         r.env == env)
+    |> group(columns:["env", "error"])
+    |> count()
+    |> group(columns:["env", "_stop", "_start"])
+
+errorCounts
+    |> filter(fn: (r) => strings.containsStr(v: r.error, substr: "AppendMappedRecordWithNulls"))

--- a/tests/fixtures/completion_scope.flux
+++ b/tests/fixtures/completion_scope.flux
@@ -1,0 +1,23 @@
+import "strings"
+import "csv"
+
+aTen = 10
+env = "prod01-us-west-2"
+
+gamma = (alpha, beta) => 
+    alpha - beta + 1
+
+b
+
+errorCounts = from(bucket:"kube-infra/monthly")
+    |> range(start: -3d)
+    |> filter(fn: (r) => r._measurement == "query_log" and
+                         r.error != "" and
+                         r._field == "responseSize" and
+                         r.env == env)
+    |> group(columns:["env", "error"])
+    |> count()
+    |> group(columns:["env", "_stop", "_start"])
+
+errorCounts
+    |> filter(fn: (r) => strings.containsStr(v: r.error, substr: "AppendMappedRecordWithNulls"))


### PR DESCRIPTION
for instance when the following flux is present:

```flux
	gamma = (alpha, beta) =>
	    alpha - beta + 1

	b
```

the beta variable show not be included in the available completions. It turns out I could nto get a failing test here. The completables already exclude function args that are out of scope

Closes #98 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
