### PR TITLE
refactor(lsp): Replace MonoType::Row with MonoType::Record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ checksum = "728b7ab3119b5167cc60a4aad16b6086b762278f5571cc650e7eed2e89a23a15"
 [[package]]
 name = "core"
 version = "0.4.0"
-source = "git+https://github.com/influxdata/flux?rev=85bd204#85bd20484b1698dbb10863fe6a2d2d7ab2c0424c"
+source = "git+https://github.com/influxdata/flux?tag=v0.87.0#61aef88194b32c1ead674ac7b9cf44f699c37787"
 dependencies = [
  "bindgen",
  "cc",
@@ -239,7 +239,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.5.1"
-source = "git+https://github.com/influxdata/flux?rev=85bd204#85bd20484b1698dbb10863fe6a2d2d7ab2c0424c"
+source = "git+https://github.com/influxdata/flux?tag=v0.87.0#61aef88194b32c1ead674ac7b9cf44f699c37787"
 dependencies = [
  "core",
  "flatbuffers",
@@ -247,11 +247,12 @@ dependencies = [
  "serde-aux",
  "serde_derive",
  "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "flux-lsp"
-version = "0.5.19"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "combinations",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "flux-lsp"
 version = "0.5.20"
-authors = [
-	"Sean Brickley <sbrickley@influxdata.com",
-	"Brandon Farmer <bthesorceror@gmail.com>",
-]
+authors = ["Flux Developers <flux-developers@influxdata.com>"]
 edition = "2018"
 license = "MIT"
 description = "LSP support for the flux language"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "flux-lsp"
-version = "0.5.19"
-authors = ["Brandon Farmer <bthesorceror@gmail.com>"]
+version = "0.5.20"
+authors = [
+	"Sean Brickley <sbrickley@influxdata.com",
+	"Brandon Farmer <bthesorceror@gmail.com>",
+]
 edition = "2018"
 license = "MIT"
 description = "LSP support for the flux language"
@@ -18,7 +21,7 @@ path = "src/lib.rs"
 serde_json = "1.0"
 serde_repr = "0.1"
 serde = { version = "1.0.106", features = ["derive"] }
-flux = { git = "https://github.com/influxdata/flux", rev = "85bd204" }
+flux = { git = "https://github.com/influxdata/flux", tag = "v0.87.0" }
 url = "2.1.1"
 lazy_static = "1.4.0"
 wasm-bindgen = "0.2.62"

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -10,7 +10,7 @@ use crate::visitors::semantic::Import;
 
 use flux::imports;
 use flux::prelude;
-use flux::semantic::types::{MonoType, Row};
+use flux::semantic::types::{MonoType, Record};
 
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
@@ -517,8 +517,8 @@ fn walk(
     list: &mut Vec<Box<dyn Completable + Send + Sync>>,
     t: MonoType,
 ) {
-    if let MonoType::Row(row) = t {
-        if let Row::Extension { head, tail } = *row {
+    if let MonoType::Record(record) = t {
+        if let Record::Extension { head, tail } = *record {
             match head.v {
                 MonoType::Fun(f) => {
                     list.push(Box::new(FunctionResult {
@@ -669,8 +669,8 @@ fn walk_package_functions(
     list: &mut Vec<Function>,
     t: MonoType,
 ) {
-    if let MonoType::Row(row) = t {
-        if let Row::Extension { head, tail } = *row {
+    if let MonoType::Record(record) = t {
+        if let Record::Extension { head, tail } = *record {
             if let MonoType::Fun(f) = head.v {
                 let mut params = vec![];
 
@@ -741,8 +741,8 @@ fn walk_functions(
     list: &mut Vec<FunctionInfo>,
     t: MonoType,
 ) {
-    if let MonoType::Row(row) = t {
-        if let Row::Extension { head, tail } = *row {
+    if let MonoType::Record(record) = t {
+        if let Record::Extension { head, tail } = *record {
             if let MonoType::Fun(f) = head.v {
                 if let Some(package_name) =
                     get_package_name(package.clone())

--- a/src/visitors/semantic/completion/results.rs
+++ b/src/visitors/semantic/completion/results.rs
@@ -124,7 +124,7 @@ pub enum VarType {
     Duration,
     Object,
     Regexp,
-    Row,
+    Record,
     Uint,
     Time,
 }
@@ -146,7 +146,7 @@ impl VarResult {
             VarType::Object => "Object".to_string(),
             VarType::Regexp => "Regular Expression".to_string(),
             VarType::String => "String".to_string(),
-            VarType::Row => "Row".to_string(),
+            VarType::Record => "Record".to_string(),
             VarType::Time => "Time".to_string(),
             VarType::Uint => "Unsigned Integer".to_string(),
         }
@@ -205,7 +205,7 @@ pub fn get_var_type(expr: &Expression) -> Option<VarType> {
                 MonoType::Bool => Some(VarType::Bool),
                 MonoType::Arr(_) => Some(VarType::Array),
                 MonoType::Duration => Some(VarType::Duration),
-                MonoType::Row(_) => Some(VarType::Row),
+                MonoType::Record(_) => Some(VarType::Record),
                 MonoType::String => Some(VarType::String),
                 MonoType::Uint => Some(VarType::Uint),
                 MonoType::Time => Some(VarType::Time),

--- a/tests/handlers.rs
+++ b/tests/handlers.rs
@@ -702,7 +702,7 @@ speculate! {
                 let returned_items = returned.result.unwrap().items;
 
                 assert_eq!(
-                    113,
+                    115,
                     returned_items.len(),
                     "expects completion items"
                 );
@@ -763,7 +763,7 @@ speculate! {
                 let returned_items = returned.result.unwrap().items;
 
                 assert_eq!(
-                    114,
+                    119,
                     returned_items.len(),
                     "expects completion items"
                 );
@@ -875,7 +875,7 @@ speculate! {
                 let returned_items = returned.result.unwrap().items;
 
                 assert_eq!(
-                    112,
+                    115,
                     returned_items.len(),
                     "expects completion items"
                 );


### PR DESCRIPTION
Closes #169 

Helps with #170 

This PR accomplishes 3 things:

- Imports the latest release of Flux
- Replaces `MonoType::Row` with `MonoType::Record` and mirrors that rename in `VarType` enum
- Changes expected results in a few tests in `tests/handlers.rs`

Some of the tests in `tests/handlers.rs` are flimsy, and will need to be replaced with more more robust tests (as per #174). Changing the expected result should be sufficient for now, but it should be noted that this is only a temporary solution.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
