### PR TITLE
refactor(cache): removes global cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,14 +252,13 @@ dependencies = [
 
 [[package]]
 name = "flux-lsp"
-version = "0.5.2"
+version = "0.5.20"
 dependencies = [
  "async-trait",
  "combinations",
  "flux",
  "futures",
  "js-sys",
- "lazy_static",
  "serde",
  "serde_json",
  "serde_repr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ serde_repr = "0.1"
 serde = { version = "1.0.106", features = ["derive"] }
 flux = { git = "https://github.com/influxdata/flux", tag = "v0.87.0" }
 url = "2.1.1"
-lazy_static = "1.4.0"
 wasm-bindgen = "0.2.62"
 combinations = "0.1.0"
 js-sys = "0.3.39"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:
 	@echo ""
 	@echo ""
 
-	cargo test $(tests) -- test  --test-threads=1 --nocapture
+	cargo test $(tests) -- test  --nocapture
 
 manual-test: test install
 	vim me.flux

--- a/src/handlers/completion.rs
+++ b/src/handlers/completion.rs
@@ -297,19 +297,17 @@ async fn find_completions(
             CompletionType::Import => {
                 let infos = get_package_infos();
 
-                let current = get_imports_removed(
+                let imports = get_imports_removed(
                     uri,
                     info.position,
                     ctx,
                     cache,
-                )?
-                .into_iter()
-                .map(|x| x.path)
-                .collect::<Vec<String>>();
+                )?;
 
                 let mut items = vec![];
                 for info in infos {
-                    if !current.contains(&info.name) {
+                    if !(&imports).iter().any(|x| x.path == info.name)
+                    {
                         items.push(new_string_arg_completion(
                             info.path,
                             get_trigger(params.clone()),

--- a/src/handlers/completion_resolve.rs
+++ b/src/handlers/completion_resolve.rs
@@ -1,3 +1,4 @@
+use crate::cache::Cache;
 use crate::handlers::RequestHandler;
 use crate::protocol::requests::{PolymorphicRequest, Request};
 use crate::protocol::responses::{CompletionItem, Response};
@@ -13,6 +14,7 @@ impl RequestHandler for CompletionResolveHandler {
         &self,
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
+        _: &Cache,
     ) -> Result<Option<String>, String> {
         let req: Request<CompletionItem> =
             Request::from_json(prequest.data.as_str())?;

--- a/src/handlers/document_close.rs
+++ b/src/handlers/document_close.rs
@@ -1,4 +1,4 @@
-use crate::cache;
+use crate::cache::Cache;
 use crate::handlers::RequestHandler;
 use crate::protocol::requests::{
     PolymorphicRequest, Request, TextDocumentParams,
@@ -18,13 +18,16 @@ fn parse_close_request(
     Ok(request)
 }
 
-fn handle_close(data: String) -> Result<Option<String>, String> {
+fn handle_close(
+    data: String,
+    cache: &Cache,
+) -> Result<Option<String>, String> {
     let request = parse_close_request(data)?;
 
     if let Some(params) = request.params {
         let uri = params.text_document.uri;
 
-        cache::remove(uri)?;
+        cache.remove(uri.as_str())?;
 
         return Ok(None);
     }
@@ -38,7 +41,8 @@ impl RequestHandler for DocumentCloseHandler {
         &self,
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
+        cache: &Cache,
     ) -> Result<Option<String>, String> {
-        handle_close(prequest.data)
+        handle_close(prequest.data, cache)
     }
 }

--- a/src/handlers/document_formatting.rs
+++ b/src/handlers/document_formatting.rs
@@ -1,4 +1,4 @@
-use crate::cache;
+use crate::cache::Cache;
 use crate::handlers::RequestHandler;
 use crate::protocol::properties::{Position, Range, TextEdit};
 use crate::protocol::requests::{
@@ -40,13 +40,14 @@ impl RequestHandler for DocumentFormattingHandler {
         &self,
         prequest: PolymorphicRequest,
         _ctx: crate::shared::RequestContext,
+        cache: &Cache,
     ) -> Result<Option<String>, String> {
         let request: Request<DocumentFormattingParams> =
             Request::from_json(prequest.data.as_str())?;
 
         if let Some(params) = request.params {
-            let uri = params.text_document.uri;
-            let cache_value = cache::get(uri)?;
+            let uri = params.text_document.uri.as_str();
+            let cache_value = cache.get(uri)?;
             let file_contents = cache_value.contents;
             let range = create_range(file_contents.clone());
 

--- a/src/handlers/document_open.rs
+++ b/src/handlers/document_open.rs
@@ -1,4 +1,4 @@
-use crate::cache;
+use crate::cache::Cache;
 use crate::handlers::RequestHandler;
 use crate::protocol::requests::{
     PolymorphicRequest, Request, TextDocumentParams,
@@ -21,16 +21,17 @@ fn parse_open_request(
 fn handle_open(
     data: String,
     ctx: RequestContext,
+    cache: &Cache,
 ) -> Result<Option<String>, String> {
     let request = parse_open_request(data)?;
 
     if let Some(params) = request.params {
-        let uri = params.text_document.uri;
+        let uri = params.text_document.uri.as_str();
         let version = params.text_document.version;
         let text = params.text_document.text;
 
-        cache::force(uri.clone(), version, text)?;
-        let msg = create_diagnoistics(uri, ctx)?;
+        cache.force(uri, version, text)?;
+        let msg = create_diagnoistics(uri, ctx, cache)?;
 
         let json = msg.to_json()?;
 
@@ -46,7 +47,8 @@ impl RequestHandler for DocumentOpenHandler {
         &self,
         prequest: PolymorphicRequest,
         ctx: crate::shared::RequestContext,
+        cache: &Cache,
     ) -> Result<Option<String>, String> {
-        handle_open(prequest.data, ctx)
+        handle_open(prequest.data, ctx, cache)
     }
 }

--- a/src/handlers/document_save.rs
+++ b/src/handlers/document_save.rs
@@ -1,3 +1,4 @@
+use crate::cache::Cache;
 use crate::handlers::RequestHandler;
 use crate::protocol::requests::{
     PolymorphicRequest, Request, TextDocumentSaveParams,
@@ -19,11 +20,12 @@ impl RequestHandler for DocumentSaveHandler {
         &self,
         prequest: PolymorphicRequest,
         ctx: crate::shared::RequestContext,
+        cache: &Cache,
     ) -> Result<Option<String>, String> {
         let request = parse_save_request(prequest.data)?;
         if let Some(params) = request.params {
-            let uri = params.text_document.uri;
-            let msg = create_diagnoistics(uri, ctx)?;
+            let uri = params.text_document.uri.as_str();
+            let msg = create_diagnoistics(uri, ctx, cache)?;
             let json = msg.to_json()?;
 
             return Ok(Some(json));

--- a/src/handlers/hover.rs
+++ b/src/handlers/hover.rs
@@ -1,3 +1,4 @@
+use crate::cache::Cache;
 use crate::handlers::RequestHandler;
 use crate::protocol::requests::{
     HoverParams, PolymorphicRequest, Request,
@@ -13,6 +14,7 @@ impl RequestHandler for HoverHandler {
         &self,
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
+        _: &Cache,
     ) -> Result<Option<String>, String> {
         let req: Request<HoverParams> =
             Request::from_json(prequest.data.as_str())?;

--- a/src/handlers/initialize.rs
+++ b/src/handlers/initialize.rs
@@ -1,3 +1,4 @@
+use crate::cache::Cache;
 use crate::handlers::RequestHandler;
 use crate::protocol::requests::{
     InitializeParams, PolymorphicRequest, Request,
@@ -20,6 +21,7 @@ impl RequestHandler for InitializeHandler {
         &self,
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
+        _: &Cache,
     ) -> Result<Option<String>, String> {
         let _: Request<InitializeParams> =
             Request::from_json(prequest.data.as_str())?;

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -18,6 +18,7 @@ pub mod signature_help;
 
 pub use router::Router;
 
+use crate::cache::Cache;
 use crate::protocol::notifications::{
     create_diagnostics_notification, Notification,
     PublishDiagnosticsParams,
@@ -39,6 +40,7 @@ pub trait RequestHandler {
         &self,
         prequest: PolymorphicRequest,
         ctx: RequestContext,
+        cache: &Cache,
     ) -> Result<Option<String>, String>;
 }
 

--- a/src/handlers/rename.rs
+++ b/src/handlers/rename.rs
@@ -1,3 +1,4 @@
+use crate::cache::Cache;
 use crate::handlers::references::find_references;
 use crate::handlers::RequestHandler;
 use crate::protocol::properties::TextEdit;
@@ -17,6 +18,7 @@ impl RequestHandler for RenameHandler {
         &self,
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
+        cache: &Cache,
     ) -> Result<Option<String>, String> {
         let request: Request<RenameParams> =
             Request::from_json(prequest.data.as_str())?;
@@ -26,9 +28,10 @@ impl RequestHandler for RenameHandler {
         };
 
         if let Some(params) = request.params {
-            let uri = params.text_document.uri;
+            let uri = params.text_document.uri.as_str();
             let new_name = params.new_name;
-            let locations = find_references(uri, params.position)?;
+            let locations =
+                find_references(uri, params.position, cache)?;
 
             for location in locations.iter() {
                 let uri = location.uri.clone();

--- a/src/handlers/router.rs
+++ b/src/handlers/router.rs
@@ -1,3 +1,4 @@
+use crate::cache::Cache;
 use crate::handlers::completion::CompletionHandler;
 use crate::handlers::completion_resolve::CompletionResolveHandler;
 use crate::handlers::document_change::DocumentChangeHandler;
@@ -28,6 +29,7 @@ use async_trait::async_trait;
 pub struct Router {
     mapping: HashMap<String, Box<dyn RequestHandler>>,
     default_handler: Box<dyn RequestHandler>,
+    cache: Cache,
 }
 
 #[derive(Default)]
@@ -39,6 +41,7 @@ impl RequestHandler for NoOpHandler {
         &self,
         _: PolymorphicRequest,
         _: RequestContext,
+        _: &Cache,
     ) -> Result<Option<String>, String> {
         Ok(None)
     }
@@ -117,6 +120,7 @@ impl Router {
         Router {
             mapping,
             default_handler: Box::new(NoOpHandler::default()),
+            cache: Cache::default(),
         }
     }
 
@@ -131,7 +135,7 @@ impl Router {
             None => &self.default_handler,
         };
 
-        let resp = handler.handle(request, ctx).await?;
+        let resp = handler.handle(request, ctx, &self.cache).await?;
 
         Ok(resp)
     }

--- a/src/handlers/shutdown.rs
+++ b/src/handlers/shutdown.rs
@@ -1,3 +1,4 @@
+use crate::cache::Cache;
 use crate::handlers::RequestHandler;
 use crate::protocol::requests::PolymorphicRequest;
 use crate::protocol::responses::{Response, ShutdownResult};
@@ -10,6 +11,7 @@ impl RequestHandler for ShutdownHandler {
         &self,
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
+        _: &Cache,
     ) -> Result<Option<String>, String> {
         let id = prequest.base_request.id;
         let response: Response<ShutdownResult> =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 pub mod cache;
 pub mod handlers;
 pub mod protocol;

--- a/src/shared/ast.rs
+++ b/src/shared/ast.rs
@@ -37,19 +37,15 @@ pub fn create_ast_package(
     let values =
         cache.get_package(uri, ctx.support_multiple_files)?;
 
-    let pkgs = values
-        .into_iter()
-        .map(|v: cache::CacheValue| {
-            crate::shared::conversion::create_file_node_from_text(
-                v.uri.as_str(),
-                v.contents,
-            )
-        })
-        .collect::<Vec<flux::ast::Package>>();
+    let pkgs = values.into_iter().map(|v: cache::CacheValue| {
+        crate::shared::conversion::create_file_node_from_text(
+            v.uri.as_str(),
+            v.contents,
+        )
+    });
 
-    let pkg = pkgs.into_iter().fold(
-        None,
-        |acc: Option<flux::ast::Package>, pkg| {
+    let pkg =
+        pkgs.fold(None, |acc: Option<flux::ast::Package>, pkg| {
             if let Some(mut p) = acc {
                 let mut files = pkg.files;
                 p.files.append(&mut files);
@@ -57,13 +53,12 @@ pub fn create_ast_package(
             }
 
             Some(pkg)
-        },
-    );
+        });
 
     if let Some(mut pkg) = pkg {
         let mut files = pkg.files;
         files.sort_by(|a, _b| {
-            if a.name == uri.clone() {
+            if a.name == uri {
                 std::cmp::Ordering::Greater
             } else {
                 std::cmp::Ordering::Less

--- a/src/shared/ast.rs
+++ b/src/shared/ast.rs
@@ -1,4 +1,5 @@
 use crate::cache;
+use crate::cache::Cache;
 use crate::shared::structs::RequestContext;
 
 use crate::protocol::properties::Position;
@@ -29,17 +30,18 @@ pub fn is_in_node(pos: Position, base: &flux::ast::BaseNode) -> bool {
 }
 
 pub fn create_ast_package(
-    uri: String,
+    uri: &'_ str,
     ctx: RequestContext,
+    cache: &Cache,
 ) -> Result<flux::ast::Package, String> {
     let values =
-        cache::get_package(uri.clone(), ctx.support_multiple_files)?;
+        cache.get_package(uri, ctx.support_multiple_files)?;
 
     let pkgs = values
         .into_iter()
         .map(|v: cache::CacheValue| {
             crate::shared::conversion::create_file_node_from_text(
-                v.uri.clone(),
+                v.uri.as_str(),
                 v.contents,
             )
         })

--- a/src/shared/conversion.rs
+++ b/src/shared/conversion.rs
@@ -31,10 +31,10 @@ pub fn map_node_to_location(uri: String, node: Rc<Node>) -> Location {
 }
 
 pub fn create_file_node_from_text(
-    uri: String,
+    uri: &'_ str,
     text: String,
 ) -> Package {
-    parse_string(uri.as_str(), text.as_str()).into()
+    parse_string(uri, text.as_str()).into()
 }
 
 pub fn flux_position_to_position(

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -102,12 +102,7 @@ impl Completable for VarResult {
             return true;
         }
 
-        let current_imports = imports
-            .into_iter()
-            .map(|x| x.path)
-            .collect::<Vec<String>>();
-
-        if !current_imports.contains(&self.package.clone()) {
+        if !imports.into_iter().any(|x| self.package == x.path) {
             return false;
         }
 
@@ -329,14 +324,10 @@ impl Completable for FunctionResult {
         let imports = info.imports;
         let mut additional_text_edits = vec![];
 
-        let current_imports = imports
-            .into_iter()
-            .map(|x| x.path)
-            .collect::<Vec<String>>();
+        let contains_pkg =
+            imports.into_iter().any(|x| self.package == x.path);
 
-        if !current_imports.contains(&self.package)
-            && self.package != BUILTIN_PACKAGE
-        {
+        if !contains_pkg && self.package != BUILTIN_PACKAGE {
             additional_text_edits.push(TextEdit {
                 new_text: format!("import \"{}\"\n", self.package),
                 range: Range {
@@ -377,13 +368,11 @@ impl Completable for FunctionResult {
             return true;
         }
 
-        let current_imports = imports
+        if !imports
             .clone()
             .into_iter()
-            .map(|x| x.path)
-            .collect::<Vec<String>>();
-
-        if !current_imports.contains(&self.package.clone()) {
+            .any(|x| self.package == x.path)
+        {
             return false;
         }
 

--- a/src/visitors/ast/package_finder.rs
+++ b/src/visitors/ast/package_finder.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 use flux::ast::walk::walk_rc;
 use flux::ast::walk::{Node, Visitor};
 
+use crate::cache::Cache;
 use crate::protocol::properties::Position;
 use crate::shared::ast::create_ast_package;
 use crate::shared::conversion::flux_position_to_position;
@@ -27,10 +28,11 @@ pub struct PackageFinderVisitor {
 
 impl PackageFinderVisitor {
     pub fn find(
-        uri: String,
+        uri: &'_ str,
         ctx: RequestContext,
+        cache: &Cache,
     ) -> Result<Option<PackageInfo>, String> {
-        let package = create_ast_package(uri, ctx)?;
+        let package = create_ast_package(uri, ctx, cache)?;
         for file in package.files {
             let walker = Rc::new(flux::ast::walk::Node::File(&file));
             let visitor = PackageFinderVisitor::default();

--- a/src/visitors/semantic/utils.rs
+++ b/src/visitors/semantic/utils.rs
@@ -143,7 +143,7 @@ where
         .files
         .into_iter()
         .map(|mut file| {
-            if file.name == uri.clone() {
+            if file.name == uri {
                 file.body = file
                     .body
                     .into_iter()

--- a/src/visitors/semantic/utils.rs
+++ b/src/visitors/semantic/utils.rs
@@ -1,4 +1,4 @@
-use crate::cache;
+use crate::cache::Cache;
 use crate::protocol::properties::Position;
 use crate::shared::ast::is_in_node;
 use crate::shared::RequestContext;
@@ -66,11 +66,12 @@ fn remove_character(source: String, pos: Position) -> String {
 }
 
 pub fn create_completion_package_removed(
-    uri: String,
+    uri: &'_ str,
     pos: Position,
     ctx: RequestContext,
+    cache: &Cache,
 ) -> Result<Package, String> {
-    let cv = cache::get(uri.clone())?;
+    let cv = cache.get(uri)?;
     let contents = remove_character(cv.contents, pos.clone());
     let mut file = parse_string("", contents.as_str());
 
@@ -86,8 +87,7 @@ pub fn create_completion_package_removed(
         .filter(|x| valid_node(x.base(), pos.clone()))
         .collect();
 
-    let mut pkg =
-        crate::shared::create_ast_package(uri.clone(), ctx)?;
+    let mut pkg = crate::shared::create_ast_package(uri, ctx, cache)?;
 
     pkg.files = pkg
         .files
@@ -104,20 +104,22 @@ pub fn create_completion_package_removed(
 }
 
 pub fn create_completion_package(
-    uri: String,
+    uri: &'_ str,
     pos: Position,
     ctx: RequestContext,
+    cache: &Cache,
 ) -> Result<Package, String> {
-    create_filtered_package(uri, ctx, |x| {
+    create_filtered_package(uri, ctx, cache, |x| {
         valid_node(x.base(), pos.clone())
     })
 }
 
 pub fn create_clean_package(
-    uri: String,
+    uri: &'_ str,
     ctx: RequestContext,
+    cache: &Cache,
 ) -> Result<Package, String> {
-    create_filtered_package(uri, ctx, |x| {
+    create_filtered_package(uri, ctx, cache, |x| {
         if let flux::ast::Statement::Bad(_) = x {
             return false;
         }
@@ -126,15 +128,16 @@ pub fn create_clean_package(
 }
 
 fn create_filtered_package<F>(
-    uri: String,
+    uri: &'_ str,
     ctx: RequestContext,
+    cache: &Cache,
     mut filter: F,
 ) -> Result<Package, String>
 where
     F: FnMut(&flux::ast::Statement) -> bool,
 {
     let mut ast_pkg =
-        crate::shared::create_ast_package(uri.clone(), ctx)?;
+        crate::shared::create_ast_package(uri, ctx, cache)?;
 
     ast_pkg.files = ast_pkg
         .files
@@ -159,9 +162,10 @@ where
 }
 
 pub fn create_semantic_package(
-    uri: String,
+    uri: &'_ str,
+    cache: &Cache,
 ) -> Result<Package, String> {
-    let cv = cache::get(uri)?;
+    let cv = cache.get(uri)?;
     let pkg = analyze_source(cv.contents.as_str())?;
 
     Ok(pkg)

--- a/tests/handlers.rs
+++ b/tests/handlers.rs
@@ -32,26 +32,6 @@ speculate! {
         let mut router = create_router();
     }
 
-    describe "multiple packages" {
-        before {
-            flux_lsp::cache::clear().unwrap();
-            let uri1 = flux_fixture_uri("incomplete_option");
-            let uri2 = flux_fixture_uri("options_function");
-            open_file(uri1.clone(), &mut router);
-            open_file(uri2.clone(), &mut router);
-        }
-
-        after {
-            close_file(uri1, &mut router);
-            close_file(uri2, &mut router);
-        }
-
-        it "returns packages in directory" {
-            let files = flux_lsp::cache::get_package(uri1.clone(), true).unwrap();
-            assert_eq!(files.len(), 2, "returns correct number of files");
-        }
-    }
-
     describe "unknown request" {
         it "returns correct response" {
             let request = PolymorphicRequest {
@@ -123,8 +103,8 @@ speculate! {
     describe "Document open" {
         describe "when ok" {
             before {
-                flux_lsp::cache::clear().unwrap();
                 let uri = flux_fixture_uri("ok");
+                let uri = uri.as_str();
             }
 
             after {
@@ -137,7 +117,7 @@ speculate! {
                     method: "textDocument/didOpen".to_string(),
                     params: Some(TextDocumentParams {
                         text_document: TextDocument {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                             language_id: "flux".to_string(),
                             version: 1,
                             text: "".to_string(),
@@ -157,7 +137,7 @@ speculate! {
 
                 let response = block_on(router.route(request, create_request_context())).unwrap().unwrap();
                 let expected_json =
-                    create_diagnostics_notification(uri.clone(), vec![])
+                    create_diagnostics_notification(uri.to_string(), vec![])
                     .to_json()
                     .unwrap();
 
@@ -170,8 +150,8 @@ speculate! {
 
         describe "when incomplete option" {
             before {
-                flux_lsp::cache::clear().unwrap();
                 let uri = flux_fixture_uri("incomplete_option");
+                let uri = uri.as_str();
             }
 
             after {
@@ -179,13 +159,13 @@ speculate! {
             }
 
             it "returns an error" {
-                let text = get_file_contents_from_uri(uri.clone()).unwrap();
+                let text = get_file_contents_from_uri(uri).unwrap();
                 let did_open_request = Request {
                     id: 1,
                     method: "textDocument/didOpen".to_string(),
                     params: Some(TextDocumentParams {
                         text_document: TextDocument {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                             language_id: "flux".to_string(),
                             version: 1,
                             text,
@@ -222,7 +202,7 @@ speculate! {
                 }];
 
                 let expected_json =
-                    create_diagnostics_notification(uri.clone(), diagnostics)
+                    create_diagnostics_notification(uri.to_string(), diagnostics)
                     .to_json()
                     .unwrap();
 
@@ -236,8 +216,8 @@ speculate! {
 
         describe "when there is an error" {
             before {
-                flux_lsp::cache::clear().unwrap();
                 let uri = flux_fixture_uri("error");
+                let uri = uri.as_str();
             }
 
             after {
@@ -245,13 +225,13 @@ speculate! {
             }
 
             it "returns an error" {
-                let text = get_file_contents_from_uri(uri.clone()).unwrap();
+                let text = get_file_contents_from_uri(uri).unwrap();
                 let did_open_request = Request {
                     id: 1,
                     method: "textDocument/didOpen".to_string(),
                     params: Some(TextDocumentParams {
                         text_document: TextDocument {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                             language_id: "flux".to_string(),
                             version: 1,
                             text,
@@ -288,7 +268,7 @@ speculate! {
                 }];
 
                 let expected_json =
-                    create_diagnostics_notification(uri.clone(), diagnostics)
+                    create_diagnostics_notification(uri.to_string(), diagnostics)
                     .to_json()
                     .unwrap();
 
@@ -304,9 +284,9 @@ speculate! {
     describe "Formatting request" {
         describe "when ok" {
             before {
-                flux_lsp::cache::clear().unwrap();
                 let uri = flux_fixture_uri("formatting");
-                open_file(uri.clone(), &mut router);
+                let uri = uri.as_str();
+                open_file(uri, &mut router);
             }
 
             after {
@@ -318,7 +298,7 @@ speculate! {
                     method: "textDocument/formatting".to_string(),
                     params: Some(DocumentFormattingParams {
                         text_document: TextDocumentIdentifier {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                         }
                     }),
                 };
@@ -339,7 +319,7 @@ speculate! {
                 let text = edit.new_text.clone();
 
 
-                let file_text = get_file_contents_from_uri(uri.clone()).unwrap();
+                let file_text = get_file_contents_from_uri(uri).unwrap();
                 let formatted_text = flux::formatter::format(file_text).unwrap();
 
                 assert_eq!(text, formatted_text, "returns formatted text");
@@ -350,9 +330,9 @@ speculate! {
     describe "Signature help request" {
         describe "when ok" {
             before {
-                flux_lsp::cache::clear().unwrap();
                 let uri = flux_fixture_uri("signatures");
-                open_file(uri.clone(), &mut router);
+                let uri = uri.as_str();
+                open_file(uri, &mut router);
             }
 
             after {
@@ -370,7 +350,7 @@ speculate! {
                             character: 5,
                         },
                         text_document: TextDocumentIdentifier {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                         }
                     }),
                 };
@@ -399,11 +379,10 @@ speculate! {
     describe "Completion request" {
         describe "when object completing params" {
             before {
-                flux_lsp::cache::clear().unwrap();
 
                 let uri = flux_fixture_uri("object_param_completion");
-
-                open_file(uri.clone(), &mut router);
+                let uri = uri.as_str();
+                open_file(uri, &mut router);
             }
 
             after {
@@ -424,7 +403,7 @@ speculate! {
                             line: 4,
                         },
                         text_document: TextDocumentIdentifier {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                         }
                     }),
                 };
@@ -463,11 +442,10 @@ speculate! {
 
         describe "when completing params" {
             before {
-                flux_lsp::cache::clear().unwrap();
 
                 let uri = flux_fixture_uri("param_completion");
-
-                open_file(uri.clone(), &mut router);
+                let uri = uri.as_str();
+                open_file(uri, &mut router);
             }
 
             after {
@@ -488,7 +466,7 @@ speculate! {
                             line: 2,
                         },
                         text_document: TextDocumentIdentifier {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                         }
                     }),
                 };
@@ -527,13 +505,14 @@ speculate! {
 
         describe "when there are multiple files" {
             before {
-                flux_lsp::cache::clear().unwrap();
 
                 let uri1 = flux_fixture_uri("multiple_1");
+                let uri1 = uri1.as_str();
                 let uri2 = flux_fixture_uri("multiple_2");
+                let uri2 = uri2.as_str();
 
-                open_file(uri1.clone(), &mut router);
-                open_file(uri2.clone(), &mut router);
+                open_file(uri1, &mut router);
+                open_file(uri2, &mut router);
             }
 
             after {
@@ -555,7 +534,7 @@ speculate! {
                             line: 0,
                         },
                         text_document: TextDocumentIdentifier {
-                            uri: uri2.clone(),
+                            uri: uri2.to_string(),
                         }
                     }),
                 };
@@ -582,9 +561,9 @@ speculate! {
         }
         describe "when completion a package" {
             before {
-                flux_lsp::cache::clear().unwrap();
                 let uri = flux_fixture_uri("package_completion");
-                open_file(uri.clone(), &mut router);
+                let uri = uri.as_str();
+                open_file(uri, &mut router);
             }
 
             after {
@@ -605,7 +584,7 @@ speculate! {
                             line: 2,
                         },
                         text_document: TextDocumentIdentifier {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                         }
                     }),
                 };
@@ -633,9 +612,9 @@ speculate! {
 
         describe "when ok" {
             before {
-                flux_lsp::cache::clear().unwrap();
                 let uri = flux_fixture_uri("completion");
-                open_file(uri.clone(), &mut router);
+                let uri = uri.as_str();
+                open_file(uri, &mut router);
             }
 
             after {
@@ -653,7 +632,7 @@ speculate! {
                             line: 8,
                         },
                         text_document: TextDocumentIdentifier {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                         }
                     }),
                 };
@@ -679,7 +658,7 @@ speculate! {
                             character: 1,
                             line: 8,
                         },
-                        uri: uri.clone(),
+                        uri: uri.to_string(),
                 };
 
 
@@ -723,9 +702,9 @@ speculate! {
 
         describe "when an option can be completed" {
             before {
-                flux_lsp::cache::clear().unwrap();
                 let uri = flux_fixture_uri("options");
-                open_file(uri.clone(), &mut router);
+                let uri = uri.as_str();
+                open_file(uri, &mut router);
             }
 
             after {
@@ -743,7 +722,7 @@ speculate! {
                             line: 16,
                         },
                         text_document: TextDocumentIdentifier {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                         }
                     }),
                 };
@@ -778,9 +757,9 @@ speculate! {
 
         describe "when an option members can be completed" {
             before {
-                flux_lsp::cache::clear().unwrap();
                 let uri = flux_fixture_uri("options_object_members");
-                open_file(uri.clone(), &mut router);
+                let uri = uri.as_str();
+                open_file(uri, &mut router);
             }
 
             after {
@@ -801,7 +780,7 @@ speculate! {
                             line: 16,
                         },
                         text_document: TextDocumentIdentifier {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                         }
                     }),
                 };
@@ -835,9 +814,9 @@ speculate! {
 
         describe "when an option functions can be completed" {
             before {
-                flux_lsp::cache::clear().unwrap();
                 let uri = flux_fixture_uri("options_function");
-                open_file(uri.clone(), &mut router);
+                let uri = uri.as_str();
+                open_file(uri, &mut router);
             }
 
             after {
@@ -855,7 +834,7 @@ speculate! {
                             line: 10,
                         },
                         text_document: TextDocumentIdentifier {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                         }
                     }),
                 };
@@ -886,9 +865,9 @@ speculate! {
     describe "Document change" {
         describe "when ok" {
             before {
-                flux_lsp::cache::clear().unwrap();
                 let uri = flux_fixture_uri("ok");
-                open_file(uri.clone(), &mut router);
+                let uri = uri.as_str();
+                open_file(uri, &mut router);
             }
 
             after {
@@ -896,14 +875,14 @@ speculate! {
             }
 
             it "returns the correct response" {
-                let text = get_file_contents_from_uri(uri.clone()).unwrap();
+                let text = get_file_contents_from_uri(uri).unwrap();
 
                 let did_change_request = Request {
                     id: 1,
                     method: "textDocument/didChange".to_string(),
                     params: Some(TextDocumentChangeParams {
                         text_document: VersionedTextDocumentIdentifier {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                             version: 1,
                         },
                         content_changes: vec![ContentChange {
@@ -925,7 +904,7 @@ speculate! {
                 };
                 let response = block_on(router.route(request, create_request_context())).unwrap();
                 let expected_json =
-                    create_diagnostics_notification(uri.clone(), vec![])
+                    create_diagnostics_notification(uri.to_string(), vec![])
                     .to_json()
                     .unwrap();
 
@@ -939,9 +918,9 @@ speculate! {
 
         describe "when there is an error" {
             before {
-                flux_lsp::cache::clear().unwrap();
                 let uri = flux_fixture_uri("error");
-                open_file(uri.clone(), &mut router);
+                let uri = uri.as_str();
+                open_file(uri, &mut router);
             }
 
             after {
@@ -949,14 +928,14 @@ speculate! {
             }
 
             it "returns the correct response" {
-                let text = get_file_contents_from_uri(uri.clone()).unwrap();
+                let text = get_file_contents_from_uri(uri).unwrap();
 
                 let did_change_request = Request {
                     id: 1,
                     method: "textDocument/didChange".to_string(),
                     params: Some(TextDocumentChangeParams {
                         text_document: VersionedTextDocumentIdentifier {
-                            uri: uri.clone(),
+                            uri: uri.to_string(),
                             version: 1,
                         },
                         content_changes: vec![ContentChange {
@@ -995,7 +974,7 @@ speculate! {
                 }];
 
                 let expected_json =
-                    create_diagnostics_notification(uri.clone(), diagnostics)
+                    create_diagnostics_notification(uri.to_string(), diagnostics)
                     .to_json()
                     .unwrap();
 
@@ -1044,9 +1023,9 @@ speculate! {
 
     describe "Rename" {
         before {
-            flux_lsp::cache::clear().unwrap();
             let uri = flux_fixture_uri("ok");
-            open_file(uri.clone(), &mut router);
+            let uri = uri.as_str();
+            open_file(uri, &mut router);
         }
 
         after {
@@ -1060,7 +1039,7 @@ speculate! {
                 method: "textDocument/rename".to_string(),
                 params: Some(RenameParams {
                     text_document: TextDocument {
-                        uri: uri.clone(),
+                        uri: uri.to_string(),
                         language_id: "flux".to_string(),
                         version: 1,
                         text: "".to_string(),
@@ -1116,7 +1095,7 @@ speculate! {
                 },
                 ];
 
-            expected_changes.insert(uri.clone(), edits);
+            expected_changes.insert(uri.to_string(), edits);
 
             let workspace_edit = WorkspaceEditResult {
                 changes: expected_changes,
@@ -1138,9 +1117,9 @@ speculate! {
 
     describe "Folding" {
         before {
-            flux_lsp::cache::clear().unwrap();
             let uri = flux_fixture_uri("ok");
-            open_file(uri.clone(), &mut router);
+            let uri = uri.as_str();
+            open_file(uri, &mut router);
         }
 
         after {
@@ -1153,7 +1132,7 @@ speculate! {
                 method: "textDocument/foldingRange".to_string(),
                 params: Some(FoldingRangeParams {
                     text_document: TextDocument {
-                        uri: uri.clone(),
+                        uri: uri.to_string(),
                         language_id: "flux".to_string(),
                         version: 1,
                         text: "".to_string(),
@@ -1202,9 +1181,9 @@ speculate! {
 
     describe "Goto definition" {
         before {
-            flux_lsp::cache::clear().unwrap();
             let uri = flux_fixture_uri("ok");
-            open_file(uri.clone(), &mut router);
+            let uri = uri.as_str();
+            open_file(uri, &mut router);
         }
 
         after {
@@ -1217,7 +1196,7 @@ speculate! {
                 method: "textDocument/definition".to_string(),
                 params: Some(TextDocumentPositionParams {
                     text_document: TextDocument {
-                        uri: uri.clone(),
+                        uri: uri.to_string(),
                         language_id: "flux".to_string(),
                         version: 1,
                         text: "".to_string(),
@@ -1243,7 +1222,7 @@ speculate! {
             let expected: Response<Location> = Response {
                 id: 1,
                 result: Some(Location {
-                    uri: uri.clone(),
+                    uri: uri.to_string(),
                     range: Range {
                         start: Position {
                             line: 1,
@@ -1268,9 +1247,9 @@ speculate! {
 
     describe "Find references" {
         before {
-            flux_lsp::cache::clear().unwrap();
             let uri = flux_fixture_uri("ok");
-            open_file(uri.clone(), &mut router);
+            let uri = uri.as_str();
+            open_file(uri, &mut router);
         }
 
         after {
@@ -1284,7 +1263,7 @@ speculate! {
                 params: Some(ReferenceParams {
                     context: ReferenceContext {},
                     text_document: TextDocument {
-                        uri: uri.clone(),
+                        uri: uri.to_string(),
                         language_id: "flux".to_string(),
                         version: 1,
                         text: "".to_string(),
@@ -1311,7 +1290,7 @@ speculate! {
                 id: 1,
                 result: Some(vec![
                     Location {
-                        uri: uri.clone(),
+                        uri: uri.to_string(),
                         range: Range {
                             start: Position {
                                 line: 1,
@@ -1324,7 +1303,7 @@ speculate! {
                         },
                     },
                     Location {
-                        uri: uri.clone(),
+                        uri: uri.to_string(),
                         range: Range {
                             start: Position {
                                 line: 8,
@@ -1350,9 +1329,9 @@ speculate! {
 
     describe "Document symbols" {
         before {
-            flux_lsp::cache::clear().unwrap();
             let uri = flux_fixture_uri("simple");
-            open_file(uri.clone(), &mut router);
+            let uri = uri.as_str();
+            open_file(uri, &mut router);
         }
 
         after {
@@ -1365,7 +1344,7 @@ speculate! {
                 method: "textDocument/documentSymbol".to_string(),
                 params: Some(DocumentSymbolParams {
                     text_document: TextDocumentIdentifier {
-                        uri: uri.clone(),
+                        uri: uri.to_string(),
                     },
                 }),
             };
@@ -1387,7 +1366,7 @@ speculate! {
                    kind: SymbolKind::Function,
                    deprecated: Some(false),
                    location: Location {
-                        uri: uri.clone(),
+                        uri: uri.to_string(),
                         range: Range {
                             start: Position {
                                 line: 0,
@@ -1406,7 +1385,7 @@ speculate! {
                    kind: SymbolKind::Variable,
                    deprecated: Some(false),
                    location: Location {
-                        uri: uri.clone(),
+                        uri: uri.to_string(),
                         range: Range {
                             start: Position {
                                 line: 0,
@@ -1425,7 +1404,7 @@ speculate! {
                    kind: SymbolKind::String,
                    deprecated: Some(false),
                    location: Location {
-                        uri: uri.clone(),
+                        uri: uri.to_string(),
                         range: Range {
                             start: Position {
                                 line: 0,
@@ -1466,9 +1445,9 @@ fn flux_fixture_uri(filename: &'static str) -> String {
 }
 
 pub fn get_file_contents_from_uri(
-    uri: String,
+    uri: &'_ str,
 ) -> Result<String, String> {
-    let url = match Url::parse(uri.as_str()) {
+    let url = match Url::parse(uri) {
         Ok(s) => s,
         Err(e) => {
             return Err(format!("Failed to get file path: {}", e))
@@ -1492,14 +1471,14 @@ fn create_router() -> Router {
     Router::new(false)
 }
 
-fn open_file(uri: String, router: &mut Router) {
-    let text = get_file_contents_from_uri(uri.clone()).unwrap();
+fn open_file(uri: &'_ str, router: &mut Router) {
+    let text = get_file_contents_from_uri(uri).unwrap();
     let did_open_request = Request {
         id: 1,
         method: "textDocument/didOpen".to_string(),
         params: Some(TextDocumentParams {
             text_document: TextDocument {
-                uri,
+                uri: uri.to_string(),
                 language_id: "flux".to_string(),
                 version: 1,
                 text,
@@ -1521,14 +1500,14 @@ fn open_file(uri: String, router: &mut Router) {
         .unwrap();
 }
 
-fn close_file(uri: String, router: &mut Router) {
-    let text = get_file_contents_from_uri(uri.clone()).unwrap();
+fn close_file(uri: &'_ str, router: &mut Router) {
+    let text = get_file_contents_from_uri(uri).unwrap();
     let did_close_request = Request {
         id: 1,
         method: "textDocument/didClose".to_string(),
         params: Some(TextDocumentParams {
             text_document: TextDocument {
-                uri,
+                uri: uri.to_string(),
                 language_id: "flux".to_string(),
                 version: 1,
                 text,


### PR DESCRIPTION
This change removes the global file cache and instead injects the
dependency into every function call that needed access to the cache.
The global cache meant that the test could not be run in parallel i.e.
multiple threads otherwise they would conflict on the global cache.

This change also makes the uri parameter to function a &str instead of a
String. This was because the string was being copied for every call into
the cache for the uri. Now the uri is only copied when it actually
stored in the cache etc.

Finally one test case was remove about multiple packages as it was
asserting internal details of how the router behaves via the global
cache.

Fixes #173

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
