### PR TITLE
build(dockerfile): install openssh in wasm-build docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH="~/.cargo/bin:${PATH}"
 RUN apt-get update && \
   apt-get install --no-install-recommends -y \
   ca-certificates \
-  curl file git openssh \
+  curl file git openssh-client \
   build-essential \
   openssl libssl-dev \
   clang pkg-config llvm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH="~/.cargo/bin:${PATH}"
 RUN apt-get update && \
   apt-get install --no-install-recommends -y \
   ca-certificates \
-  curl file git \
+  curl file git openssh \
   build-essential \
   openssl libssl-dev \
   clang pkg-config llvm \


### PR DESCRIPTION
CircleCI spits out this error when running the `deploy` job:

```
Either git or ssh (required by git to clone through SSH) is not installed in the image. Falling back to CircleCI's native git client but the behavior may be different from official git. If this is an issue, please use an image that has official git and ssh installed.
Enumerating objects: 141, done.
Counting objects: 100% (141/141), done.
Compressing objects: 100% (102/102), done.
Total 1368 (delta 62), reused 73 (delta 32), pack-reused 1227

reference not found
```

This PR adds `openssh` to the list of dependencies to be installed when building the `wasm-build` image.
