### PR TITLE
build: Increment version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 serde_json = "1.0"
 serde_repr = "0.1"
 serde = { version = "1.0.106", features = ["derive"] }
-flux = { git = "https://github.com/influxdata/flux", tag = "v0.90.0" }
+flux = { git = "https://github.com/influxdata/flux", tag = "v0.91.0" }
 url = "2.1.1"
 wasm-bindgen = "0.2.62"
 combinations = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flux-lsp"
-version = "0.5.20"
+version = "0.5.21"
 authors = ["Flux Developers <flux-developers@influxdata.com>"]
 edition = "2018"
 license = "MIT"

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -37,15 +37,17 @@ version=v$(cat Cargo.toml | grep -Po -m 1 '\d+\.\d+\.\d+')
 cargo install -q cargo-bump && cargo bump $release_type
 new_version=v$(cat Cargo.toml | grep -Po -m 1 '\d+\.\d+\.\d+')
 
-git checkout -B bump-$new_version
-echo "Checking out branch \`bump-$new_version\`"
+branch_name=bump-$new_version
+
+git checkout -B $branch_name
+echo "Checking out branch \`$branch_name\`"
 
 echo "Incrementing version"
 echo "$version -> $new_version"
 
 git add .
 git commit -m "build: Release $new_version"
-git push origin master
+git push -u origin $branch_name
 
 hub pull-request -o \
 	-m "build: Increment version" \


### PR DESCRIPTION
- Imports Flux 0.91.0
- `bump-version.sh` sets upstream and pushes to new github branch, rather than trying to push to master
- Increment version to 0.5.21