### PR TITLE
feat(handlers): use a error struct for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ checksum = "728b7ab3119b5167cc60a4aad16b6086b762278f5571cc650e7eed2e89a23a15"
 [[package]]
 name = "core"
 version = "0.4.0"
-source = "git+https://github.com/influxdata/flux?tag=v0.94.0#7e1ea554877ceb5b424293508aa63c0d644aaf39"
+source = "git+https://github.com/influxdata/flux?branch=master#2e0f9dd8dbf9417d7f83010a3912ded9a61e7237"
 dependencies = [
  "bindgen",
  "cc",
@@ -190,6 +190,7 @@ dependencies = [
  "serde-aux",
  "serde_derive",
  "serde_json",
+ "tabwriter",
  "walkdir",
  "wasm-bindgen",
 ]
@@ -239,7 +240,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.5.1"
-source = "git+https://github.com/influxdata/flux?tag=v0.94.0#7e1ea554877ceb5b424293508aa63c0d644aaf39"
+source = "git+https://github.com/influxdata/flux?branch=master#2e0f9dd8dbf9417d7f83010a3912ded9a61e7237"
 dependencies = [
  "core",
  "flatbuffers",
@@ -252,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "flux-lsp"
-version = "0.5.21"
+version = "0.5.22"
 dependencies = [
  "async-trait",
  "combinations",
@@ -718,6 +719,15 @@ dependencies = [
  "proc-macro2 1.0.12",
  "quote 1.0.4",
  "unicode-xid 0.2.0",
+]
+
+[[package]]
+name = "tabwriter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36205cfc997faadcc4b0b87aaef3fbedafe20d38d4959a7ca6ff803564051111"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ checksum = "728b7ab3119b5167cc60a4aad16b6086b762278f5571cc650e7eed2e89a23a15"
 [[package]]
 name = "core"
 version = "0.4.0"
-source = "git+https://github.com/influxdata/flux?branch=master#2e0f9dd8dbf9417d7f83010a3912ded9a61e7237"
+source = "git+https://github.com/influxdata/flux?tag=v0.95.0#2e0f9dd8dbf9417d7f83010a3912ded9a61e7237"
 dependencies = [
  "bindgen",
  "cc",
@@ -240,7 +240,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.5.1"
-source = "git+https://github.com/influxdata/flux?branch=master#2e0f9dd8dbf9417d7f83010a3912ded9a61e7237"
+source = "git+https://github.com/influxdata/flux?tag=v0.95.0#2e0f9dd8dbf9417d7f83010a3912ded9a61e7237"
 dependencies = [
  "core",
  "flatbuffers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 serde_json = "1.0"
 serde_repr = "0.1"
 serde = { version = "1.0.106", features = ["derive"] }
-flux = { git = "https://github.com/influxdata/flux", tag = "v0.94.0" }
+flux = { git = "https://github.com/influxdata/flux", branch="master"}
 url = "2.1.1"
 wasm-bindgen = "0.2.62"
 combinations = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 serde_json = "1.0"
 serde_repr = "0.1"
 serde = { version = "1.0.106", features = ["derive"] }
-flux = { git = "https://github.com/influxdata/flux", branch="master"}
+flux = { git = "https://github.com/influxdata/flux", tag="v0.95.0"}
 url = "2.1.1"
 wasm-bindgen = "0.2.62"
 combinations = "0.1.0"

--- a/src/handlers/completion.rs
+++ b/src/handlers/completion.rs
@@ -4,12 +4,16 @@ use std::sync::Arc;
 use crate::cache::Cache;
 use crate::handlers::{Error, RequestHandler};
 use crate::protocol::properties::Position;
-use crate::protocol::requests::{CompletionParams, PolymorphicRequest, Request};
+use crate::protocol::requests::{
+    CompletionParams, PolymorphicRequest, Request,
+};
 use crate::protocol::responses::{
-    CompletionItem, CompletionItemKind, CompletionList, InsertTextFormat, Response,
+    CompletionItem, CompletionItemKind, CompletionList,
+    InsertTextFormat, Response,
 };
 use crate::shared::{
-    get_imports_removed, CompletionInfo, CompletionType, Function, RequestContext,
+    get_imports_removed, CompletionInfo, CompletionType, Function,
+    RequestContext,
 };
 
 use crate::stdlib::{
@@ -18,8 +22,8 @@ use crate::stdlib::{
 };
 use crate::visitors::ast;
 use crate::visitors::semantic::{
-    utils, CompletableFinderVisitor, CompletableObjectFinderVisitor, FunctionFinderVisitor,
-    ObjectFunctionFinderVisitor,
+    utils, CompletableFinderVisitor, CompletableObjectFinderVisitor,
+    FunctionFinderVisitor, ObjectFunctionFinderVisitor,
 };
 
 use flux::ast::walk::walk_rc;
@@ -64,7 +68,9 @@ async fn get_stdlib_completions(
 
     for c in completes.into_iter() {
         if c.matches(name.clone(), info.clone()) {
-            matches.push(c.completion_item(ctx.clone(), info.clone()).await);
+            matches.push(
+                c.completion_item(ctx.clone(), info.clone()).await,
+            );
         }
     }
 
@@ -77,7 +83,12 @@ fn get_user_completables(
     ctx: RequestContext,
     cache: &Cache,
 ) -> Result<Vec<Arc<dyn Completable + Send + Sync>>, Error> {
-    let pkg = utils::create_completion_package(uri, pos.clone(), ctx, cache)?;
+    let pkg = utils::create_completion_package(
+        uri,
+        pos.clone(),
+        ctx,
+        cache,
+    )?;
     let walker = Rc::new(walk::Node::Package(&pkg));
     let mut visitor = CompletableFinderVisitor::new(pos);
 
@@ -97,12 +108,17 @@ async fn get_user_matches(
     ctx: RequestContext,
     cache: &Cache,
 ) -> Result<Vec<CompletionItem>, Error> {
-    let completables =
-        get_user_completables(info.uri.as_str(), info.position.clone(), ctx.clone(), cache)?;
+    let completables = get_user_completables(
+        info.uri.as_str(),
+        info.position.clone(),
+        ctx.clone(),
+        cache,
+    )?;
 
     let mut result: Vec<CompletionItem> = vec![];
     for x in completables {
-        result.push(x.completion_item(ctx.clone(), info.clone()).await)
+        result
+            .push(x.completion_item(ctx.clone(), info.clone()).await)
     }
 
     Ok(result)
@@ -114,11 +130,17 @@ async fn get_measurement_completions(
     bucket: Option<String>,
 ) -> Result<Option<CompletionList>, Error> {
     if let Some(bucket) = bucket {
-        let measurements = ctx.callbacks.get_measurements(bucket).await?;
+        let measurements =
+            ctx.callbacks.get_measurements(bucket).await?;
 
         let items: Vec<CompletionItem> = measurements
             .into_iter()
-            .map(|value| new_string_arg_completion(value, get_trigger(params.clone())))
+            .map(|value| {
+                new_string_arg_completion(
+                    value,
+                    get_trigger(params.clone()),
+                )
+            })
             .collect();
 
         return Ok(Some(CompletionList {
@@ -172,7 +194,8 @@ async fn get_tag_values_completions(
 ) -> Result<Option<CompletionList>, Error> {
     if let Some(bucket) = bucket {
         if let Some(field) = field {
-            let tag_values = ctx.callbacks.get_tag_values(bucket, field).await?;
+            let tag_values =
+                ctx.callbacks.get_tag_values(bucket, field).await?;
 
             let items: Vec<CompletionItem> = tag_values
                 .into_iter()
@@ -210,27 +233,38 @@ async fn find_completions(
 ) -> Result<CompletionList, Error> {
     let uri = params.text_document.uri.clone();
     let uri = uri.as_str();
-    let info = CompletionInfo::create(params.clone(), ctx.clone(), cache)?;
+    let info =
+        CompletionInfo::create(params.clone(), ctx.clone(), cache)?;
 
     let mut items: Vec<CompletionItem> = vec![];
 
     if let Some(info) = info {
         match info.completion_type {
             CompletionType::Generic => {
-                let mut stdlib_matches =
-                    get_stdlib_completions(info.ident.clone(), info.clone(), ctx.clone()).await;
+                let mut stdlib_matches = get_stdlib_completions(
+                    info.ident.clone(),
+                    info.clone(),
+                    ctx.clone(),
+                )
+                .await;
                 items.append(&mut stdlib_matches);
 
-                let mut user_matches = get_user_matches(info, ctx, cache).await?;
+                let mut user_matches =
+                    get_user_matches(info, ctx, cache).await?;
 
                 items.append(&mut user_matches);
             }
             CompletionType::Logical(_operator) => {
-                let om = ObjectMember::from_string(info.ident.clone());
+                let om =
+                    ObjectMember::from_string(info.ident.clone());
                 if let Some(om) = om {
                     if om.object == "r" {
-                        let list =
-                            get_tag_values_completions(ctx, info.bucket, Some(om.member)).await?;
+                        let list = get_tag_values_completions(
+                            ctx,
+                            info.bucket,
+                            Some(om.member),
+                        )
+                        .await?;
                         if let Some(list) = list {
                             return Ok(list);
                         }
@@ -240,25 +274,42 @@ async fn find_completions(
             CompletionType::Bad => {}
             CompletionType::CallProperty(_func) => {
                 if info.ident == "bucket" {
-                    return get_bucket_completions(ctx, get_trigger(params)).await;
+                    return get_bucket_completions(
+                        ctx,
+                        get_trigger(params),
+                    )
+                    .await;
                 } else if info.ident == "measurement" {
-                    if let Some(list) =
-                        get_measurement_completions(params, ctx, info.bucket).await?
+                    if let Some(list) = get_measurement_completions(
+                        params,
+                        ctx,
+                        info.bucket,
+                    )
+                    .await?
                     {
                         return Ok(list);
                     }
                 } else {
-                    return find_param_completions(None, params, ctx, cache).await;
+                    return find_param_completions(
+                        None, params, ctx, cache,
+                    )
+                    .await;
                 }
             }
             CompletionType::Import => {
                 let infos = get_package_infos();
 
-                let imports = get_imports_removed(uri, info.position, ctx, cache)?;
+                let imports = get_imports_removed(
+                    uri,
+                    info.position,
+                    ctx,
+                    cache,
+                )?;
 
                 let mut items = vec![];
                 for info in infos {
-                    if !(&imports).iter().any(|x| x.path == info.name) {
+                    if !(&imports).iter().any(|x| x.path == info.name)
+                    {
                         items.push(new_string_arg_completion(
                             info.path,
                             get_trigger(params.clone()),
@@ -272,7 +323,8 @@ async fn find_completions(
                 });
             }
             CompletionType::ObjectMember(_obj) => {
-                return find_dot_completions(params, ctx, cache).await;
+                return find_dot_completions(params, ctx, cache)
+                    .await;
             }
         }
     }
@@ -283,7 +335,10 @@ async fn find_completions(
     })
 }
 
-fn new_string_arg_completion(value: String, trigger: Option<String>) -> CompletionItem {
+fn new_string_arg_completion(
+    value: String,
+    trigger: Option<String>,
+) -> CompletionItem {
     let trigger = trigger.unwrap_or_else(|| "".to_string());
     let insert_text = if trigger == "\"" {
         value
@@ -308,7 +363,10 @@ fn new_string_arg_completion(value: String, trigger: Option<String>) -> Completi
     }
 }
 
-fn new_param_completion(name: String, trigger: Option<String>) -> CompletionItem {
+fn new_param_completion(
+    name: String,
+    trigger: Option<String>,
+) -> CompletionItem {
     let insert_text = if let Some(trigger) = trigger {
         if trigger == "(" {
             format!("{}: ", name)
@@ -342,7 +400,12 @@ fn get_user_functions(
     ctx: RequestContext,
     cache: &Cache,
 ) -> Result<Vec<Function>, Error> {
-    let pkg = utils::create_completion_package(uri, pos.clone(), ctx, cache)?;
+    let pkg = utils::create_completion_package(
+        uri,
+        pos.clone(),
+        ctx,
+        cache,
+    )?;
     let walker = Rc::new(walk::Node::Package(&pkg));
     let mut visitor = FunctionFinderVisitor::new(pos);
 
@@ -362,8 +425,12 @@ fn get_provided_arguments(call: &CallExpr) -> Vec<String> {
     if let Some(Expression::Object(obj)) = call.arguments.first() {
         for prop in obj.properties.clone() {
             match prop.key {
-                flux::ast::PropertyKey::Identifier(ident) => provided.push(ident.name),
-                flux::ast::PropertyKey::StringLit(lit) => provided.push(lit.value),
+                flux::ast::PropertyKey::Identifier(ident) => {
+                    provided.push(ident.name)
+                }
+                flux::ast::PropertyKey::StringLit(lit) => {
+                    provided.push(lit.value)
+                }
             };
         }
     }
@@ -402,13 +469,17 @@ fn get_function_params(
     functions: Vec<Function>,
     provided: Vec<String>,
 ) -> Vec<String> {
-    functions
-        .into_iter()
-        .filter(|f| f.name == name)
-        .fold(vec![], |mut acc, f| {
-            acc.extend(f.params.into_iter().filter(|p| !provided.contains(p)));
+    functions.into_iter().filter(|f| f.name == name).fold(
+        vec![],
+        |mut acc, f| {
+            acc.extend(
+                f.params
+                    .into_iter()
+                    .filter(|p| !provided.contains(p)),
+            );
             acc
-        })
+        },
+    )
 }
 
 async fn find_param_completions(
@@ -421,7 +492,10 @@ async fn find_param_completions(
     let position = params.position;
 
     let source = cache.get(uri)?;
-    let pkg = crate::shared::conversion::create_file_node_from_text(uri, source.contents);
+    let pkg = crate::shared::conversion::create_file_node_from_text(
+        uri,
+        source.contents,
+    );
     let walker = Rc::new(AstNode::File(&pkg.files[0]));
     let visitor = ast::CallFinderVisitor::new(position.move_back(1));
 
@@ -435,16 +509,20 @@ async fn find_param_completions(
         if let AstNode::CallExpr(call) = node.as_ref() {
             let provided = get_provided_arguments(call);
 
-            if let Expression::Identifier(ident) = call.callee.clone() {
+            if let Expression::Identifier(ident) = call.callee.clone()
+            {
                 items.extend(get_function_params(
                     ident.name.clone(),
                     get_builtin_functions(),
                     provided.clone(),
                 ));
 
-                if let Ok(user_functions) =
-                    get_user_functions(uri, position.clone(), ctx.clone(), cache)
-                {
+                if let Ok(user_functions) = get_user_functions(
+                    uri,
+                    position.clone(),
+                    ctx.clone(),
+                    cache,
+                ) {
                     items.extend(get_function_params(
                         ident.name,
                         user_functions,
@@ -454,10 +532,12 @@ async fn find_param_completions(
             }
             if let Expression::Member(me) = call.callee.clone() {
                 if let Expression::Identifier(ident) = me.object {
-                    let package_functions = get_package_functions(ident.name.clone());
+                    let package_functions =
+                        get_package_functions(ident.name.clone());
 
-                    let object_functions =
-                        get_object_functions(uri, position, ctx, ident.name, cache)?;
+                    let object_functions = get_object_functions(
+                        uri, position, ctx, ident.name, cache,
+                    )?;
 
                     let key = match me.property {
                         PropertyKey::Identifier(i) => i.name,
@@ -470,7 +550,11 @@ async fn find_param_completions(
                         provided.clone(),
                     ));
 
-                    items.extend(get_function_params(key, object_functions, provided));
+                    items.extend(get_function_params(
+                        key,
+                        object_functions,
+                        provided,
+                    ));
                 }
             }
         }
@@ -501,7 +585,9 @@ async fn get_bucket_completions(
 
     let items: Vec<CompletionItem> = buckets
         .into_iter()
-        .map(|value| new_string_arg_completion(value, trigger.clone()))
+        .map(|value| {
+            new_string_arg_completion(value, trigger.clone())
+        })
         .collect();
 
     Ok(CompletionList {
@@ -515,11 +601,13 @@ async fn find_arg_completions(
     ctx: RequestContext,
     cache: &Cache,
 ) -> Result<CompletionList, Error> {
-    let info = CompletionInfo::create(params.clone(), ctx.clone(), cache)?;
+    let info =
+        CompletionInfo::create(params.clone(), ctx.clone(), cache)?;
 
     if let Some(info) = info {
         if info.ident == "bucket" {
-            return get_bucket_completions(ctx, get_trigger(params)).await;
+            return get_bucket_completions(ctx, get_trigger(params))
+                .await;
         }
     }
 
@@ -541,10 +629,17 @@ async fn find_dot_completions(
 
     if let Some(info) = info.clone() {
         let imports = info.imports.clone();
-        if let CompletionType::ObjectMember(om) = info.completion_type.clone() {
+        if let CompletionType::ObjectMember(om) =
+            info.completion_type.clone()
+        {
             if om == "r" {
                 if let Some(bucket) = info.bucket.clone() {
-                    if let Some(list) = get_tag_keys_completions(ctx.clone(), Some(bucket)).await? {
+                    if let Some(list) = get_tag_keys_completions(
+                        ctx.clone(),
+                        Some(bucket),
+                    )
+                    .await?
+                    {
                         return Ok(list);
                     }
                 }
@@ -553,17 +648,33 @@ async fn find_dot_completions(
 
         let mut list = vec![];
         let name = info.ident.clone();
-        get_specific_package_functions(&mut list, name, imports.clone());
+        get_specific_package_functions(
+            &mut list,
+            name,
+            imports.clone(),
+        );
 
         let mut items = vec![];
-        let obj_results = get_specific_object(info.ident.clone(), pos, uri, ctx.clone(), cache)?;
+        let obj_results = get_specific_object(
+            info.ident.clone(),
+            pos,
+            uri,
+            ctx.clone(),
+            cache,
+        )?;
 
         for completable in obj_results.into_iter() {
-            items.push(completable.completion_item(ctx.clone(), info.clone()).await);
+            items.push(
+                completable
+                    .completion_item(ctx.clone(), info.clone())
+                    .await,
+            );
         }
 
         for item in list.into_iter() {
-            items.push(item.completion_item(ctx.clone(), info.clone()).await);
+            items.push(
+                item.completion_item(ctx.clone(), info.clone()).await,
+            );
         }
 
         return Ok(CompletionList {
@@ -585,7 +696,9 @@ pub fn get_specific_object(
     ctx: RequestContext,
     cache: &Cache,
 ) -> Result<Vec<Arc<dyn Completable + Send + Sync>>, Error> {
-    let pkg = utils::create_completion_package_removed(uri, pos, ctx, cache)?;
+    let pkg = utils::create_completion_package_removed(
+        uri, pos, ctx, cache,
+    )?;
     let walker = Rc::new(walk::Node::Package(&pkg));
     let mut visitor = CompletableObjectFinderVisitor::new(name);
 
@@ -614,7 +727,8 @@ async fn triggered_completion(
             return find_arg_completions(params, ctx, cache).await;
         } else if ch == "(" || ch == "," {
             let trgr = trigger;
-            return find_param_completions(trgr, params, ctx, cache).await;
+            return find_param_completions(trgr, params, ctx, cache)
+                .await;
         }
     }
 
@@ -629,22 +743,35 @@ impl RequestHandler for CompletionHandler {
         ctx: RequestContext,
         cache: &Cache,
     ) -> Result<Option<String>, Error> {
-        let req: Request<CompletionParams> = Request::from_json(prequest.data.as_str())?;
+        let req: Request<CompletionParams> =
+            Request::from_json(prequest.data.as_str())?;
         if let Some(params) = req.params {
             if let Some(context) = params.clone().context {
-                let completions =
-                    triggered_completion(context.trigger_character, params, ctx, cache).await?;
+                let completions = triggered_completion(
+                    context.trigger_character,
+                    params,
+                    ctx,
+                    cache,
+                )
+                .await?;
 
-                let response = Response::new(prequest.base_request.id, Some(completions));
+                let response = Response::new(
+                    prequest.base_request.id,
+                    Some(completions),
+                );
 
                 let result = response.to_json()?;
 
                 return Ok(Some(result));
             }
 
-            let completions = find_completions(params, ctx, cache).await?;
+            let completions =
+                find_completions(params, ctx, cache).await?;
 
-            let response = Response::new(prequest.base_request.id, Some(completions));
+            let response = Response::new(
+                prequest.base_request.id,
+                Some(completions),
+            );
 
             let result = response.to_json()?;
 

--- a/src/handlers/completion_resolve.rs
+++ b/src/handlers/completion_resolve.rs
@@ -1,5 +1,5 @@
 use crate::cache::Cache;
-use crate::handlers::RequestHandler;
+use crate::handlers::{Error, RequestHandler};
 use crate::protocol::requests::{PolymorphicRequest, Request};
 use crate::protocol::responses::{CompletionItem, Response};
 
@@ -15,7 +15,7 @@ impl RequestHandler for CompletionResolveHandler {
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
         _: &Cache,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         let req: Request<CompletionItem> =
             Request::from_json(prequest.data.as_str())?;
 

--- a/src/handlers/document_change.rs
+++ b/src/handlers/document_change.rs
@@ -1,5 +1,5 @@
 use crate::cache::Cache;
-use crate::handlers::RequestHandler;
+use crate::handlers::{Error, RequestHandler};
 use crate::protocol::properties::ContentChange;
 use crate::protocol::requests::PolymorphicRequest;
 use crate::protocol::requests::{Request, TextDocumentChangeParams};
@@ -37,7 +37,7 @@ fn handle_change(
     data: String,
     ctx: RequestContext,
     cache: &Cache,
-) -> Result<Option<String>, String> {
+) -> Result<Option<String>, Error> {
     let request = parse_change_request(data)?;
     if let Some(params) = request.params {
         let uri = params.text_document.uri.as_str();
@@ -55,7 +55,7 @@ fn handle_change(
         return Ok(Some(json));
     }
 
-    Err("invalid textDocument/didChange request".to_string())
+    Err(Error{msg: "invalid textDocument/didChange request".to_string()})
 }
 
 #[async_trait]
@@ -65,7 +65,7 @@ impl RequestHandler for DocumentChangeHandler {
         prequest: PolymorphicRequest,
         ctx: crate::shared::RequestContext,
         cache: &Cache,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         handle_change(prequest.data, ctx, cache)
     }
 }

--- a/src/handlers/document_change.rs
+++ b/src/handlers/document_change.rs
@@ -55,7 +55,9 @@ fn handle_change(
         return Ok(Some(json));
     }
 
-    Err(Error{msg: "invalid textDocument/didChange request".to_string()})
+    Err(Error {
+        msg: "invalid textDocument/didChange request".to_string(),
+    })
 }
 
 #[async_trait]

--- a/src/handlers/document_close.rs
+++ b/src/handlers/document_close.rs
@@ -1,5 +1,5 @@
 use crate::cache::Cache;
-use crate::handlers::RequestHandler;
+use crate::handlers::{Error, RequestHandler};
 use crate::protocol::requests::{
     PolymorphicRequest, Request, TextDocumentParams,
 };
@@ -21,7 +21,7 @@ fn parse_close_request(
 fn handle_close(
     data: String,
     cache: &Cache,
-) -> Result<Option<String>, String> {
+) -> Result<Option<String>, Error> {
     let request = parse_close_request(data)?;
 
     if let Some(params) = request.params {
@@ -32,7 +32,7 @@ fn handle_close(
         return Ok(None);
     }
 
-    Err("invalid textDocument/didClose request".to_string())
+    Err(Error{msg: "invalid textDocument/didClose request".to_string()})
 }
 
 #[async_trait]
@@ -42,7 +42,7 @@ impl RequestHandler for DocumentCloseHandler {
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
         cache: &Cache,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         handle_close(prequest.data, cache)
     }
 }

--- a/src/handlers/document_close.rs
+++ b/src/handlers/document_close.rs
@@ -32,7 +32,9 @@ fn handle_close(
         return Ok(None);
     }
 
-    Err(Error{msg: "invalid textDocument/didClose request".to_string()})
+    Err(Error {
+        msg: "invalid textDocument/didClose request".to_string(),
+    })
 }
 
 #[async_trait]

--- a/src/handlers/document_open.rs
+++ b/src/handlers/document_open.rs
@@ -38,7 +38,9 @@ fn handle_open(
         return Ok(Some(json));
     }
 
-    Err(Error{msg: "invalid textDocument/didOpen request".to_string()})
+    Err(Error {
+        msg: "invalid textDocument/didOpen request".to_string(),
+    })
 }
 
 #[async_trait::async_trait]

--- a/src/handlers/document_open.rs
+++ b/src/handlers/document_open.rs
@@ -1,5 +1,5 @@
 use crate::cache::Cache;
-use crate::handlers::RequestHandler;
+use crate::handlers::{Error, RequestHandler};
 use crate::protocol::requests::{
     PolymorphicRequest, Request, TextDocumentParams,
 };
@@ -22,7 +22,7 @@ fn handle_open(
     data: String,
     ctx: RequestContext,
     cache: &Cache,
-) -> Result<Option<String>, String> {
+) -> Result<Option<String>, Error> {
     let request = parse_open_request(data)?;
 
     if let Some(params) = request.params {
@@ -38,7 +38,7 @@ fn handle_open(
         return Ok(Some(json));
     }
 
-    Err("invalid textDocument/didOpen request".to_string())
+    Err(Error{msg: "invalid textDocument/didOpen request".to_string()})
 }
 
 #[async_trait::async_trait]
@@ -48,7 +48,7 @@ impl RequestHandler for DocumentOpenHandler {
         prequest: PolymorphicRequest,
         ctx: crate::shared::RequestContext,
         cache: &Cache,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         handle_open(prequest.data, ctx, cache)
     }
 }

--- a/src/handlers/document_save.rs
+++ b/src/handlers/document_save.rs
@@ -1,5 +1,5 @@
 use crate::cache::Cache;
-use crate::handlers::RequestHandler;
+use crate::handlers::{Error, RequestHandler};
 use crate::protocol::requests::{
     PolymorphicRequest, Request, TextDocumentSaveParams,
 };
@@ -21,7 +21,7 @@ impl RequestHandler for DocumentSaveHandler {
         prequest: PolymorphicRequest,
         ctx: crate::shared::RequestContext,
         cache: &Cache,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         let request = parse_save_request(prequest.data)?;
         if let Some(params) = request.params {
             let uri = params.text_document.uri.as_str();
@@ -31,6 +31,6 @@ impl RequestHandler for DocumentSaveHandler {
             return Ok(Some(json));
         }
 
-        Err("invalid textDocument/didSave request".to_string())
+        Err(Error{msg: "invalid textDocument/didSave request".to_string()})
     }
 }

--- a/src/handlers/document_save.rs
+++ b/src/handlers/document_save.rs
@@ -31,6 +31,8 @@ impl RequestHandler for DocumentSaveHandler {
             return Ok(Some(json));
         }
 
-        Err(Error{msg: "invalid textDocument/didSave request".to_string()})
+        Err(Error {
+            msg: "invalid textDocument/didSave request".to_string(),
+        })
     }
 }

--- a/src/handlers/document_symbol.rs
+++ b/src/handlers/document_symbol.rs
@@ -1,7 +1,9 @@
 use crate::cache::Cache;
 use crate::handlers::{Error, RequestHandler};
 use crate::protocol::properties::SymbolInformation;
-use crate::protocol::requests::{DocumentSymbolParams, PolymorphicRequest, Request};
+use crate::protocol::requests::{
+    DocumentSymbolParams, PolymorphicRequest, Request,
+};
 use crate::protocol::responses::Response;
 use crate::shared::structs::RequestContext;
 use crate::visitors::semantic::utils;
@@ -10,7 +12,10 @@ use crate::visitors::semantic::SymbolsVisitor;
 use flux::semantic::walk::{self, Node};
 use std::rc::Rc;
 
-fn sort_symbols(a: &SymbolInformation, b: &SymbolInformation) -> std::cmp::Ordering {
+fn sort_symbols(
+    a: &SymbolInformation,
+    b: &SymbolInformation,
+) -> std::cmp::Ordering {
     let a_start = a.location.range.start.clone();
     let b_start = b.location.range.start.clone();
 
@@ -51,9 +56,14 @@ impl RequestHandler for DocumentSymbolHandler {
         ctx: crate::shared::RequestContext,
         cache: &Cache,
     ) -> Result<Option<String>, Error> {
-        let request: Request<DocumentSymbolParams> = Request::from_json(prequest.data.as_str())?;
+        let request: Request<DocumentSymbolParams> =
+            Request::from_json(prequest.data.as_str())?;
         if let Some(params) = request.params {
-            let symbols = find_symbols(params.text_document.uri.as_str(), ctx, cache)?;
+            let symbols = find_symbols(
+                params.text_document.uri.as_str(),
+                ctx,
+                cache,
+            )?;
             let response: Response<Vec<SymbolInformation>> =
                 Response::new(request.id, Some(symbols));
             let json = response.to_json()?;

--- a/src/handlers/folding.rs
+++ b/src/handlers/folding.rs
@@ -1,5 +1,5 @@
 use crate::cache::Cache;
-use crate::handlers::RequestHandler;
+use crate::handlers::{Error, RequestHandler};
 use crate::protocol::properties::FoldingRange;
 use crate::protocol::requests::{
     FoldingRangeParams, PolymorphicRequest, Request,
@@ -53,7 +53,7 @@ impl RequestHandler for FoldingHandler {
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
         cache: &Cache,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         let request: Request<FoldingRangeParams> =
             Request::from_json(prequest.data.as_str())?;
         let mut areas: Option<Vec<FoldingRange>> = None;

--- a/src/handlers/goto_definition.rs
+++ b/src/handlers/goto_definition.rs
@@ -129,6 +129,9 @@ impl RequestHandler for GotoDefinitionHandler {
             return Ok(Some(json));
         }
 
-        Err(Error{msg: "invalid textDocument/definition request".to_string()})
+        Err(Error {
+            msg: "invalid textDocument/definition request"
+                .to_string(),
+        })
     }
 }

--- a/src/handlers/goto_definition.rs
+++ b/src/handlers/goto_definition.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use crate::cache::Cache;
-use crate::handlers::RequestHandler;
+use crate::handlers::{Error, RequestHandler};
 use crate::protocol::properties::{Location, Position, Range};
 use crate::protocol::requests::{
     PolymorphicRequest, Request, TextDocumentPositionParams,
@@ -82,7 +82,7 @@ impl RequestHandler for GotoDefinitionHandler {
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
         cache: &Cache,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         let mut result: Option<Location> = None;
 
         let request: Request<TextDocumentPositionParams> =
@@ -129,6 +129,6 @@ impl RequestHandler for GotoDefinitionHandler {
             return Ok(Some(json));
         }
 
-        Err("invalid textDocument/definition request".to_string())
+        Err(Error{msg: "invalid textDocument/definition request".to_string()})
     }
 }

--- a/src/handlers/hover.rs
+++ b/src/handlers/hover.rs
@@ -1,5 +1,5 @@
 use crate::cache::Cache;
-use crate::handlers::RequestHandler;
+use crate::handlers::{Error, RequestHandler};
 use crate::protocol::requests::{
     HoverParams, PolymorphicRequest, Request,
 };
@@ -15,7 +15,7 @@ impl RequestHandler for HoverHandler {
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
         _: &Cache,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         let req: Request<HoverParams> =
             Request::from_json(prequest.data.as_str())?;
 

--- a/src/handlers/initialize.rs
+++ b/src/handlers/initialize.rs
@@ -1,5 +1,5 @@
 use crate::cache::Cache;
-use crate::handlers::RequestHandler;
+use crate::handlers::{Error, RequestHandler};
 use crate::protocol::requests::{
     InitializeParams, PolymorphicRequest, Request,
 };
@@ -22,7 +22,7 @@ impl RequestHandler for InitializeHandler {
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
         _: &Cache,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         let _: Request<InitializeParams> =
             Request::from_json(prequest.data.as_str())?;
         let result = InitializeResult::new(!self.disable_folding);

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -20,8 +20,7 @@ pub use router::Router;
 
 use crate::cache::Cache;
 use crate::protocol::notifications::{
-    create_diagnostics_notification, Notification,
-    PublishDiagnosticsParams,
+    create_diagnostics_notification, Notification, PublishDiagnosticsParams,
 };
 use crate::protocol::properties::Position;
 use crate::protocol::requests::PolymorphicRequest;
@@ -34,6 +33,16 @@ use std::rc::Rc;
 use async_trait::async_trait;
 use flux::ast::{check, walk};
 
+#[derive(Debug)]
+pub struct Error {
+    pub msg: String,
+}
+impl From<String> for Error {
+    fn from(s: String) -> Error {
+        Error { msg: s }
+    }
+}
+
 #[async_trait]
 pub trait RequestHandler {
     async fn handle(
@@ -41,7 +50,7 @@ pub trait RequestHandler {
         prequest: PolymorphicRequest,
         ctx: RequestContext,
         cache: &Cache,
-    ) -> Result<Option<String>, String>;
+    ) -> Result<Option<String>, Error>;
 }
 
 pub fn create_diagnostics(
@@ -62,10 +71,7 @@ pub struct NodeFinderResult<'a> {
     path: Vec<Rc<flux::semantic::walk::Node<'a>>>,
 }
 
-pub fn find_node(
-    node: flux::semantic::walk::Node<'_>,
-    position: Position,
-) -> NodeFinderResult<'_> {
+pub fn find_node(node: flux::semantic::walk::Node<'_>, position: Position) -> NodeFinderResult<'_> {
     let mut result = NodeFinderResult::default();
     let mut visitor = NodeFinderVisitor::new(position);
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -20,7 +20,8 @@ pub use router::Router;
 
 use crate::cache::Cache;
 use crate::protocol::notifications::{
-    create_diagnostics_notification, Notification, PublishDiagnosticsParams,
+    create_diagnostics_notification, Notification,
+    PublishDiagnosticsParams,
 };
 use crate::protocol::properties::Position;
 use crate::protocol::requests::PolymorphicRequest;
@@ -71,7 +72,10 @@ pub struct NodeFinderResult<'a> {
     path: Vec<Rc<flux::semantic::walk::Node<'a>>>,
 }
 
-pub fn find_node(node: flux::semantic::walk::Node<'_>, position: Position) -> NodeFinderResult<'_> {
+pub fn find_node(
+    node: flux::semantic::walk::Node<'_>,
+    position: Position,
+) -> NodeFinderResult<'_> {
     let mut result = NodeFinderResult::default();
     let mut visitor = NodeFinderVisitor::new(position);
 

--- a/src/handlers/references.rs
+++ b/src/handlers/references.rs
@@ -1,6 +1,6 @@
 use crate::cache::Cache;
 use crate::handlers::find_node;
-use crate::handlers::RequestHandler;
+use crate::handlers::{Error, RequestHandler};
 use crate::protocol::properties::{Location, Position};
 use crate::protocol::requests::{
     PolymorphicRequest, ReferenceParams, Request,
@@ -128,7 +128,7 @@ impl RequestHandler for FindReferencesHandler {
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
         cache: &Cache,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         let mut locations: Vec<Location> = vec![];
         let request: Request<ReferenceParams> =
             Request::from_json(prequest.data.as_str())?;

--- a/src/handlers/rename.rs
+++ b/src/handlers/rename.rs
@@ -1,6 +1,6 @@
 use crate::cache::Cache;
 use crate::handlers::references::find_references;
-use crate::handlers::RequestHandler;
+use crate::handlers::{Error, RequestHandler};
 use crate::protocol::properties::TextEdit;
 use crate::protocol::requests::{
     PolymorphicRequest, RenameParams, Request,
@@ -19,7 +19,7 @@ impl RequestHandler for RenameHandler {
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
         cache: &Cache,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         let request: Request<RenameParams> =
             Request::from_json(prequest.data.as_str())?;
 

--- a/src/handlers/router.rs
+++ b/src/handlers/router.rs
@@ -15,7 +15,7 @@ use crate::handlers::references::FindReferencesHandler;
 use crate::handlers::rename::RenameHandler;
 use crate::handlers::shutdown::ShutdownHandler;
 use crate::handlers::signature_help::SignatureHelpHandler;
-use crate::handlers::RequestHandler;
+use crate::handlers::{Error, RequestHandler};
 use crate::protocol::requests::PolymorphicRequest;
 use crate::shared::RequestContext;
 
@@ -42,7 +42,7 @@ impl RequestHandler for NoOpHandler {
         _: PolymorphicRequest,
         _: RequestContext,
         _: &Cache,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         Ok(None)
     }
 }
@@ -128,7 +128,7 @@ impl Router {
         &mut self,
         request: PolymorphicRequest,
         ctx: RequestContext,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         let method = request.method();
         let handler = match self.mapping.get(&method) {
             Some(h) => h,

--- a/src/handlers/shutdown.rs
+++ b/src/handlers/shutdown.rs
@@ -1,5 +1,5 @@
 use crate::cache::Cache;
-use crate::handlers::RequestHandler;
+use crate::handlers::{Error, RequestHandler};
 use crate::protocol::requests::PolymorphicRequest;
 use crate::protocol::responses::{Response, ShutdownResult};
 
@@ -12,7 +12,7 @@ impl RequestHandler for ShutdownHandler {
         prequest: PolymorphicRequest,
         _: crate::shared::RequestContext,
         _: &Cache,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, Error> {
         let id = prequest.base_request.id;
         let response: Response<ShutdownResult> =
             Response::new(id, None);

--- a/src/handlers/signature_help.rs
+++ b/src/handlers/signature_help.rs
@@ -1,28 +1,20 @@
 use crate::cache::Cache;
-use crate::handlers::{find_node, RequestHandler};
+use crate::handlers::{find_node, Error, RequestHandler};
 use crate::protocol::properties::Position;
-use crate::protocol::requests::{
-    PolymorphicRequest, Request, SignatureHelpParams,
-};
-use crate::protocol::responses::{
-    Response, SignatureHelp, SignatureInformation,
-};
+use crate::protocol::requests::{PolymorphicRequest, Request, SignatureHelpParams};
+use crate::protocol::responses::{Response, SignatureHelp, SignatureInformation};
 use crate::shared::signatures::FunctionSignature;
 use crate::shared::RequestContext;
 use crate::stdlib::{get_stdlib_functions, BUILTIN_PACKAGE};
 use crate::visitors::semantic::functions::FunctionFinderVisitor;
-use crate::visitors::semantic::utils::{
-    create_completion_package, create_semantic_package,
-};
+use crate::visitors::semantic::utils::{create_completion_package, create_semantic_package};
 
 use flux::semantic::nodes::Expression;
 use flux::semantic::walk::{walk, Node};
 
 use std::rc::Rc;
 
-fn create_signature_information(
-    fs: FunctionSignature,
-) -> SignatureInformation {
+fn create_signature_information(fs: FunctionSignature) -> SignatureInformation {
     SignatureInformation {
         label: fs.create_signature(),
         parameters: Some(fs.create_parameters()),
@@ -33,18 +25,11 @@ fn create_signature_information(
 #[derive(Default)]
 pub struct SignatureHelpHandler {}
 
-fn find_stdlib_signatures(
-    name: String,
-    package: String,
-) -> Vec<SignatureInformation> {
+fn find_stdlib_signatures(name: String, package: String) -> Vec<SignatureInformation> {
     get_stdlib_functions()
         .into_iter()
         .filter(|x| x.name == name && x.package_name == package)
-        .map(|x| {
-            x.signatures()
-                .into_iter()
-                .map(create_signature_information)
-        })
+        .map(|x| x.signatures().into_iter().map(create_signature_information))
         .fold(vec![], |mut acc, x| {
             acc.extend(x);
             acc
@@ -58,8 +43,7 @@ fn find_user_defined_signatures(
     ctx: RequestContext,
     cache: &Cache,
 ) -> Result<Vec<SignatureInformation>, String> {
-    let pkg =
-        create_completion_package(uri, pos.clone(), ctx, cache)?;
+    let pkg = create_completion_package(uri, pos.clone(), ctx, cache)?;
     let mut visitor = FunctionFinderVisitor::new(pos);
 
     walk(&mut visitor, Rc::new(Node::Package(&pkg)));
@@ -70,11 +54,7 @@ fn find_user_defined_signatures(
     Ok(functions
         .into_iter()
         .filter(|x| x.name == name)
-        .map(|x| {
-            x.signatures()
-                .into_iter()
-                .map(create_signature_information)
-        })
+        .map(|x| x.signatures().into_iter().map(create_signature_information))
         .fold(vec![], |mut acc, x| {
             acc.extend(x);
             acc
@@ -100,12 +80,8 @@ fn find_signatures(
 
                 if let Expression::Member(me) = callee.clone() {
                     let name = me.property.clone();
-                    if let Expression::Identifier(ident) =
-                        me.object.clone()
-                    {
-                        result.extend(find_stdlib_signatures(
-                            name, ident.name,
-                        ));
+                    if let Expression::Identifier(ident) = me.object.clone() {
+                        result.extend(find_stdlib_signatures(name, ident.name));
                     }
                 } else if let Expression::Identifier(ident) = callee {
                     result.extend(find_stdlib_signatures(
@@ -130,9 +106,8 @@ impl RequestHandler for SignatureHelpHandler {
         prequest: PolymorphicRequest,
         ctx: RequestContext,
         cache: &Cache,
-    ) -> Result<Option<String>, String> {
-        let req: Request<SignatureHelpParams> =
-            Request::from_json(prequest.data.as_str())?;
+    ) -> Result<Option<String>, Error> {
+        let req: Request<SignatureHelpParams> = Request::from_json(prequest.data.as_str())?;
 
         let sh = SignatureHelp {
             signatures: find_signatures(req.clone(), ctx, cache)?,

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -1,6 +1,8 @@
 use crate::handlers::{Error, Router};
 use crate::shared::callbacks::Callbacks;
-use crate::shared::messages::{create_polymorphic_request, wrap_message};
+use crate::shared::messages::{
+    create_polymorphic_request, wrap_message,
+};
 use crate::shared::RequestContext;
 
 use std::cell::RefCell;
@@ -73,9 +75,14 @@ impl ServerResponse {
 #[wasm_bindgen]
 impl Server {
     #[wasm_bindgen(constructor)]
-    pub fn new(disable_folding: bool, support_multiple_files: bool) -> Server {
+    pub fn new(
+        disable_folding: bool,
+        support_multiple_files: bool,
+    ) -> Server {
         Server {
-            handler: Rc::new(RefCell::new(Router::new(disable_folding))),
+            handler: Rc::new(RefCell::new(Router::new(
+                disable_folding,
+            ))),
             callbacks: Callbacks::default(),
             support_multiple_files,
         }
@@ -104,34 +111,49 @@ impl Server {
 
         future_to_promise(async move {
             let lines = msg.lines();
-            let content: String = lines.skip(2).fold(String::new(), |c, l| c.add(l));
+            let content: String =
+                lines.skip(2).fold(String::new(), |c, l| c.add(l));
 
             match create_polymorphic_request(content.clone()) {
                 Ok(req) => {
                     let id = req.base_request.id;
-                    let ctx = RequestContext::new(callbacks.clone(), support_multiple_files);
+                    let ctx = RequestContext::new(
+                        callbacks.clone(),
+                        support_multiple_files,
+                    );
                     let mut h = router.borrow_mut();
                     match (*h).route(req, ctx).await {
                         Ok(response) => {
                             if let Some(response) = response {
-                                return Ok(JsValue::from(ServerResponse {
-                                    message: Some(wrap_message(response)),
-                                    error: None,
-                                }));
+                                return Ok(JsValue::from(
+                                    ServerResponse {
+                                        message: Some(wrap_message(
+                                            response,
+                                        )),
+                                        error: None,
+                                    },
+                                ));
                             } else {
-                                return Ok(JsValue::from(ServerResponse {
-                                    message: None,
-                                    error: None,
-                                }));
+                                return Ok(JsValue::from(
+                                    ServerResponse {
+                                        message: None,
+                                        error: None,
+                                    },
+                                ));
                             }
                         }
                         Err(error) => {
-                            return Ok(JsValue::from(ServerResponse {
-                                message: Some(wrap_message(
-                                    ServerError::from_error(id, error).unwrap(),
-                                )),
-                                error: None,
-                            }))
+                            return Ok(JsValue::from(
+                                ServerResponse {
+                                    message: Some(wrap_message(
+                                        ServerError::from_error(
+                                            id, error,
+                                        )
+                                        .unwrap(),
+                                    )),
+                                    error: None,
+                                },
+                            ))
                         }
                     }
                 }

--- a/tests/handlers.rs
+++ b/tests/handlers.rs
@@ -320,7 +320,7 @@ speculate! {
 
 
                 let file_text = get_file_contents_from_uri(uri).unwrap();
-                let formatted_text = flux::formatter::format(file_text).unwrap();
+                let formatted_text = flux::formatter::format(&file_text).unwrap();
 
                 assert_eq!(text, formatted_text, "returns formatted text");
             }


### PR DESCRIPTION
This change uses an error struct instead of string for error handling,
this makes it easier to implement From traits on the error type for the
various kinds of error we might encounter.

Do NOT merge in this state, it points at Flux master in order to bring in recent changes the formatter. Its safe to merge as part of the upgrade to the next version of Flux.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
