### PR TITLE
build: Increment version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ checksum = "728b7ab3119b5167cc60a4aad16b6086b762278f5571cc650e7eed2e89a23a15"
 [[package]]
 name = "core"
 version = "0.4.0"
-source = "git+https://github.com/influxdata/flux?tag=v0.95.0#2e0f9dd8dbf9417d7f83010a3912ded9a61e7237"
+source = "git+https://github.com/influxdata/flux?tag=v0.96.0#9c3cf772426aef125c979c81d93e0dda37ab95b8"
 dependencies = [
  "bindgen",
  "cc",
@@ -240,7 +240,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.5.1"
-source = "git+https://github.com/influxdata/flux?tag=v0.95.0#2e0f9dd8dbf9417d7f83010a3912ded9a61e7237"
+source = "git+https://github.com/influxdata/flux?tag=v0.96.0#9c3cf772426aef125c979c81d93e0dda37ab95b8"
 dependencies = [
  "core",
  "flatbuffers",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "flux-lsp"
-version = "0.5.23"
+version = "0.5.24"
 dependencies = [
  "async-trait",
  "combinations",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "flux-lsp"
-version = "0.5.22"
+version = "0.5.23"
 dependencies = [
  "async-trait",
  "combinations",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 serde_json = "1.0"
 serde_repr = "0.1"
 serde = { version = "1.0.106", features = ["derive"] }
-flux = { git = "https://github.com/influxdata/flux", tag="v0.95.0"}
+flux = { git = "https://github.com/influxdata/flux", tag="v0.96.0"}
 url = "2.1.1"
 wasm-bindgen = "0.2.62"
 combinations = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flux-lsp"
-version = "0.5.23"
+version = "0.5.24"
 authors = ["Flux Developers <flux-developers@influxdata.com>"]
 edition = "2018"
 license = "MIT"

--- a/get_flux_version
+++ b/get_flux_version
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+flux_version=$(cat Cargo.toml | grep -P -m 1 'flux = *' | grep -Po 'v\d+\.\d+\.\d+')
+
+echo "Release $new_version
+- Upgrade to [Flux $flux_version](https://github.com/influxdata/flux/releases/tag/$flux_version)" -e

--- a/get_flux_version
+++ b/get_flux_version
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-flux_version=$(cat Cargo.toml | grep -P -m 1 'flux = *' | grep -Po 'v\d+\.\d+\.\d+')
-
-echo "Release $new_version
-- Upgrade to [Flux $flux_version](https://github.com/influxdata/flux/releases/tag/$flux_version)" -e

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -29,7 +29,10 @@ fi
 
 new_version=v$(cat Cargo.toml | grep -Po -m 1 '\d+\.\d+\.\d+')
 
-git tag -a -s $new_version -m "Release $new_verion"
+git tag -a -s $new_version -m "Release $new_version"
 git push origin master $new_version
 
-hub release create $new_version -m "Release $new_version" -e
+flux_version=$(cat Cargo.toml | grep -P -m 1 'flux = *' | grep -Po 'v\d+\.\d+\.\d+')
+
+hub release create $new_version -m "Release $new_version
+- Upgrade to [Flux $flux_version](https://github.com/influxdata/flux/releases/tag/$flux_version)" -e


### PR DESCRIPTION
- Change version from `v0.5.23` to `v0.5.24`
- Upgrades Flux dependency to `v0.96.0`
- Modifies `tag-release.sh` to include a link to the release notes of the imported flux version