### PR TITLE
fix(callbacks): Disable callbacks for user data

### DIFF
--- a/src/shared/callbacks.rs
+++ b/src/shared/callbacks.rs
@@ -128,8 +128,14 @@ pub struct Callbacks {
 }
 
 impl Callbacks {
+    // All of the `register_*_callback` methods have been disabled
+    // to prevent the LSP from crashing. Autocomplete for user-specific
+    // data will not be available until these methods are re-enabled
+    // See the following issue for more details:
+    // https://github.com/influxdata/flux-lsp/issues/190
     pub fn register_buckets_callback(&mut self, _f: Function) {
         self.buckets = None;
+        // self.buckets = Some(Callback::new(f)) // re-enable buckets callback
     }
 
     pub fn register_measurements_callback(&mut self, _f: Function) {

--- a/src/shared/callbacks.rs
+++ b/src/shared/callbacks.rs
@@ -128,20 +128,20 @@ pub struct Callbacks {
 }
 
 impl Callbacks {
-    pub fn register_buckets_callback(&mut self, f: Function) {
-        self.buckets = Some(Callback::new(f));
+    pub fn register_buckets_callback(&mut self, _f: Function) {
+        self.buckets = None;
     }
 
-    pub fn register_measurements_callback(&mut self, f: Function) {
-        self.measurements = Some(Callback::new(f));
+    pub fn register_measurements_callback(&mut self, _f: Function) {
+        self.measurements = None;
     }
 
-    pub fn register_tag_keys_callback(&mut self, f: Function) {
-        self.tag_keys = Some(Callback::new(f));
+    pub fn register_tag_keys_callback(&mut self, _f: Function) {
+        self.tag_keys = None;
     }
 
-    pub fn register_tag_values_callback(&mut self, f: Function) {
-        self.tag_values = Some(Callback::new(f));
+    pub fn register_tag_values_callback(&mut self, _f: Function) {
+        self.tag_values = None;
     }
 
     fn call_buckets(&self) -> Result<JsFuture, String> {


### PR DESCRIPTION
`register_blahblah_callback` methods now just set callbacks to `None`. After failing to find a proper fix for #190, @nathanielc and I determined that it was best to just disable the feature until we can settle on a better solution.
