### PR TITLE
build: Increment version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ checksum = "728b7ab3119b5167cc60a4aad16b6086b762278f5571cc650e7eed2e89a23a15"
 [[package]]
 name = "core"
 version = "0.4.0"
-source = "git+https://github.com/influxdata/flux?tag=v0.98.0#c40321a5a49949ec65906064251e419fdee4a2ef"
+source = "git+https://github.com/influxdata/flux?tag=v0.99.0#2c56fe7a54c0c9a61b24854eb6ad9e143886c56e"
 dependencies = [
  "bindgen",
  "cc",
@@ -246,7 +246,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.5.1"
-source = "git+https://github.com/influxdata/flux?tag=v0.98.0#c40321a5a49949ec65906064251e419fdee4a2ef"
+source = "git+https://github.com/influxdata/flux?tag=v0.99.0#2c56fe7a54c0c9a61b24854eb6ad9e143886c56e"
 dependencies = [
  "core",
  "flatbuffers",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "flux-lsp"
-version = "0.5.25"
+version = "0.5.26"
 dependencies = [
  "async-trait",
  "combinations",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flux-lsp"
-version = "0.5.25"
+version = "0.5.26"
 authors = ["Flux Developers <flux-developers@influxdata.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 serde_json = "1.0"
 serde_repr = "0.1"
 serde = { version = "1.0.106", features = ["derive"] }
-flux = { git = "https://github.com/influxdata/flux", tag="v0.98.0"}
+flux = { git = "https://github.com/influxdata/flux", tag="v0.99.0"}
 url = "2.1.1"
 wasm-bindgen = "0.2.69"
 combinations = "0.1.0"

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -50,5 +50,5 @@ git commit -m "build: Release $new_version"
 git push -u origin $branch_name
 
 hub pull-request -o \
-	-m "build: Increment version" \
+	-m "build: Bump to $new_version" \
 	-m "Change version from $version to $new_version" &> /dev/null &

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -35,4 +35,5 @@ git push origin master $new_version
 flux_version=$(cat Cargo.toml | grep -P -m 1 'flux = *' | grep -Po 'v\d+\.\d+\.\d+')
 
 hub release create $new_version -m "Release $new_version
+
 - Upgrade to [Flux $flux_version](https://github.com/influxdata/flux/releases/tag/$flux_version)" -e


### PR DESCRIPTION
- Change version from v0.5.25 to v0.5.26
- Upgrade to Flux v0.99.0
- Formatting changes to release notes + PR text in tag-release.sh and bump-version.sh