### PR TITLE
build: Bump to v0.5.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ checksum = "728b7ab3119b5167cc60a4aad16b6086b762278f5571cc650e7eed2e89a23a15"
 [[package]]
 name = "core"
 version = "0.4.0"
-source = "git+https://github.com/influxdata/flux?tag=v0.105.1#cfe404620069347e7e4e11424bf6b954034b2823"
+source = "git+https://github.com/influxdata/flux?tag=v0.106.0#e764a70f36b8531a6879e081f68eb4458e0f05bf"
 dependencies = [
  "chrono",
  "derivative",
@@ -116,7 +116,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.5.1"
-source = "git+https://github.com/influxdata/flux?tag=v0.105.1#cfe404620069347e7e4e11424bf6b954034b2823"
+source = "git+https://github.com/influxdata/flux?tag=v0.106.0#e764a70f36b8531a6879e081f68eb4458e0f05bf"
 dependencies = [
  "core",
  "flatbuffers",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "flux-lsp"
-version = "0.5.32"
+version = "0.5.33"
 dependencies = [
  "async-trait",
  "combinations",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ checksum = "728b7ab3119b5167cc60a4aad16b6086b762278f5571cc650e7eed2e89a23a15"
 [[package]]
 name = "core"
 version = "0.4.0"
-source = "git+https://github.com/influxdata/flux?tag=v0.104.0#09bd305621027b86dadbafa3ddf06c881d6dacbf"
+source = "git+https://github.com/influxdata/flux?tag=v0.105.1#cfe404620069347e7e4e11424bf6b954034b2823"
 dependencies = [
  "chrono",
  "derivative",
@@ -116,7 +116,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.5.1"
-source = "git+https://github.com/influxdata/flux?tag=v0.104.0#09bd305621027b86dadbafa3ddf06c881d6dacbf"
+source = "git+https://github.com/influxdata/flux?tag=v0.105.1#cfe404620069347e7e4e11424bf6b954034b2823"
 dependencies = [
  "core",
  "flatbuffers",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "flux-lsp"
-version = "0.5.31"
+version = "0.5.32"
 dependencies = [
  "async-trait",
  "combinations",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 serde_json = "1.0"
 serde_repr = "0.1"
 serde = { version = "1.0.106", features = ["derive"] }
-flux = { git = "https://github.com/influxdata/flux", tag = "v0.105.1" }
+flux = { git = "https://github.com/influxdata/flux", tag = "v0.106.0" }
 url = "2.1.1"
 wasm-bindgen = "0.2.69"
 combinations = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flux-lsp"
-version = "0.5.32"
+version = "0.5.33"
 authors = ["Flux Developers <flux-developers@influxdata.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
- Change version from v0.5.32 to v0.5.33
- Upgrade to [Flux v0.106.0](https://github.com/influxdata/flux/releases/tag/v0.106.0)