### PR TITLE
chore: modify rust toolchain to be more like flux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           command: cargo fmt --all -- --check
       - run:
           name: "run lint"
-          command: cargo clippy --all -- -D warnings
+          command: cargo clippy --all -- -Dclippy::all
 
   test:
     docker:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/influxdata/flux-lsp"
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Oz", "--enable-mutable-globals"]
 
+[features]
+default = ["strict"]
+strict = []
+
 [lib]
 name = "flux_lsp"
 crate-type = ["cdylib", "rlib"]
@@ -18,23 +22,18 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.30"
+combinations = "0.1.0"
+flux = { git = "https://github.com/influxdata/flux", tag = "v0.111.0" }
+futures = "0.3.8"
+js-sys = "0.3.46"
+serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0"
 serde_repr = "0.1"
-serde = { version = "1.0.106", features = ["derive"] }
-flux = { git = "https://github.com/influxdata/flux", tag = "v0.111.0" }
 url = "2.1.1"
 wasm-bindgen = "0.2.69"
-combinations = "0.1.0"
-js-sys = "0.3.46"
 wasm-bindgen-futures = "0.4.19"
-futures = "0.3.8"
-async-trait = "0.1.30"
-
-[dependencies.web-sys]
-version = "0.3.46"
-features = [
-  "console",
-]
+web-sys = { version = "0.3.46", features = ["console"] }
 
 [dev-dependencies]
 speculate = "0.1.2"

--- a/src/handlers/document_save.rs
+++ b/src/handlers/document_save.rs
@@ -8,7 +8,7 @@ use crate::shared::create_diagnoistics;
 fn parse_save_request(
     data: String,
 ) -> Result<Request<TextDocumentSaveParams>, String> {
-    Ok(Request::from_json(data.as_str())?)
+    Request::from_json(data.as_str())
 }
 
 #[derive(Default)]

--- a/src/handlers/goto_definition.rs
+++ b/src/handlers/goto_definition.rs
@@ -31,10 +31,10 @@ fn ident_to_location(uri: String, node: Rc<Node<'_>>) -> Location {
     Location { uri, range }
 }
 
-fn find_scoped_definition<'a>(
+fn find_scoped_definition(
     uri: String,
     ident_name: String,
-    path: Vec<Rc<Node<'a>>>,
+    path: Vec<Rc<Node>>,
 ) -> Option<Location> {
     let path_iter = path.iter().rev();
     for n in path_iter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "strict", deny(warnings))]
 pub mod cache;
 pub mod handlers;
 pub mod protocol;

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -335,21 +335,20 @@ impl CompletionInfo {
                     }
                 }
                 AstNode::CallExpr(c) => {
-                    if let Some(arg) = c.arguments.last() {
-                        if let Expression::Identifier(ident) = arg {
-                            return Ok(Some(CompletionInfo {
-                                completion_type:
-                                    CompletionType::Generic,
-                                ident: ident.name.clone(),
-                                bucket,
-                                position: position.clone(),
-                                uri: uri.to_string(),
-                                imports: get_imports(
-                                    uri, position, ctx, cache,
-                                )?,
-                                package,
-                            }));
-                        }
+                    if let Some(Expression::Identifier(ident)) =
+                        c.arguments.last()
+                    {
+                        return Ok(Some(CompletionInfo {
+                            completion_type: CompletionType::Generic,
+                            ident: ident.name.clone(),
+                            bucket,
+                            position: position.clone(),
+                            uri: uri.to_string(),
+                            imports: get_imports(
+                                uri, position, ctx, cache,
+                            )?,
+                            package,
+                        }));
                     }
                 }
                 _ => {}

--- a/src/visitors/semantic/completion/utils.rs
+++ b/src/visitors/semantic/completion/utils.rs
@@ -5,10 +5,8 @@ use flux::semantic::nodes::*;
 use flux::semantic::types::MonoType;
 
 pub fn follow_function_pipes(c: &CallExpr) -> &MonoType {
-    if let Some(p) = &c.pipe {
-        if let Expression::Call(call) = p {
-            return follow_function_pipes(&call);
-        }
+    if let Some(Expression::Call(call)) = &c.pipe {
+        return follow_function_pipes(&call);
     }
 
     &c.typ

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -125,35 +125,29 @@ impl Server {
                     match (*h).route(req, ctx).await {
                         Ok(response) => {
                             if let Some(response) = response {
-                                return Ok(JsValue::from(
-                                    ServerResponse {
-                                        message: Some(wrap_message(
-                                            response,
-                                        )),
-                                        error: None,
-                                    },
-                                ));
+                                Ok(JsValue::from(ServerResponse {
+                                    message: Some(wrap_message(
+                                        response,
+                                    )),
+                                    error: None,
+                                }))
                             } else {
-                                return Ok(JsValue::from(
-                                    ServerResponse {
-                                        message: None,
-                                        error: None,
-                                    },
-                                ));
+                                Ok(JsValue::from(ServerResponse {
+                                    message: None,
+                                    error: None,
+                                }))
                             }
                         }
                         Err(error) => {
-                            return Ok(JsValue::from(
-                                ServerResponse {
-                                    message: Some(wrap_message(
-                                        ServerError::from_error(
-                                            id, error,
-                                        )
-                                        .unwrap(),
-                                    )),
-                                    error: None,
-                                },
-                            ))
+                            Ok(JsValue::from(ServerResponse {
+                                message: Some(wrap_message(
+                                    ServerError::from_error(
+                                        id, error,
+                                    )
+                                    .unwrap(),
+                                )),
+                                error: None,
+                            }))
                         }
                     }
                 }


### PR DESCRIPTION
In flux, we have a pretty standard process that we use for building rust
code. We deny warnings, we enforce style with fmt checks, and we check
lint with clippy. This patch brings flux-lsp more in-line with flux, and
fixes outstanding issues that occurred as a result of the new stricter
checks.