### PR TITLE
feat: inherit build setup from flux-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,15 @@
-FROM ubuntu:20.04
+FROM quay.io/influxdb/flux-build:latest
 
-WORKDIR /src
+USER root
 
-ENV CC=clang
-ENV PATH="~/.cargo/bin:${PATH}"
+ENV NODE_VERSION="node_12.x"
+ENV DEBIAN_NAME="buster"
 
-# Install common packages
-RUN apt-get update && \
-  apt-get install --no-install-recommends -y \
-  ca-certificates \
-  curl file git openssh-client \
-  build-essential \
-  openssl libssl-dev \
-  clang pkg-config llvm \
-  autoconf automake autotools-dev libtool xutils-dev git \
-  && rm -rf /var/lib/{apt,dpkg,cache,log}
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    echo "deb https://deb.nodesource.com/$NODE_VERSION $DEBIAN_NAME main" \
+        > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && apt-get install --no-install-recommends -y nodejs && \
+    apt-get clean  && rm -rf /var/lib/apt/lists/*
 
-# Install Rust
-ENV RUST_VERSION 1.47.0
-RUN curl https://sh.rustup.rs -sSf | \
-  sh -s -- --default-toolchain $RUST_VERSION -y
-
-# Install wasm-pack
-RUN ~/.cargo/bin/cargo install wasm-pack
-
-# Install Node.js
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
-RUN apt-get install -y nodejs
-
-# Install linting tools
-RUN ~/.cargo/bin/rustup component add rustfmt
-RUN ~/.cargo/bin/rustup component add clippy
+USER $UNAME


### PR DESCRIPTION
The newest release of flux, 1.119.0, included changes that won't work on
the old version of rust in the current wasm-build image. That exposed
the problem that we were on an ancient rust. When upgrading, I noticed
that we were still using the `curl | sh` pattern we've been trying to
avoid. The best way to combat that was to just use the `flux-build`
image that we use in flux.

The only remaining need for the wasm-build image was nodejs, which
_also_ used the `curl | sh` pattern, so I took the time to read the
downloaded script and did the tasks (albeit less smart) that the script
did, only manually.