### PR TITLE
fix: update dependencies to most recent versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,18 +22,18 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.30"
+async-trait = "0.1.50"
 combinations = "0.1.0"
 flux = { git = "https://github.com/influxdata/flux", tag = "v0.119.0" }
-futures = "0.3.8"
-js-sys = "0.3.46"
-serde = { version = "1.0.106", features = ["derive"] }
-serde_json = "1.0"
-serde_repr = "0.1"
-url = "2.1.1"
-wasm-bindgen = "0.2.69"
-wasm-bindgen-futures = "0.4.19"
-web-sys = { version = "0.3.46", features = ["console"] }
+futures = "0.3.15"
+js-sys = "0.3.51"
+serde = { version = "1.0.126", features = ["derive"] }
+serde_json = "1.0.64"
+serde_repr = "0.1.7"
+url = "2.2.2"
+wasm-bindgen = "0.2.74"
+wasm-bindgen-futures = "0.4.24"
+web-sys = { version = "0.3.51", features = ["console"] }
 
 [dev-dependencies]
 speculate = "0.1.2"


### PR DESCRIPTION
Auditing dependencies, some of these (slightly older) dependencies
allowed for versions of their dependencies with open vulnerabilities. In
general, this didn't necessarily affect this library, because we don't
commit `Cargo.lock` and the default is to take the most up-to-date, but
this change will force updates to stale `Cargo.lock` files on dev
machines.