### PR TITLE
feat: introduce new lspower-based server prototype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,8 @@ url = "2.2.2"
 wasm-bindgen = "0.2.74"
 wasm-bindgen-futures = "0.4.24"
 web-sys = { version = "0.3.51", features = ["console"] }
+
+lspower = "1.1.0"
+
+[dev-dependencies]
+tokio-test = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,5 @@ mod visitors;
 
 pub use handlers::Router;
 pub use wasm::Server;
+
+mod server;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,105 @@
+use lspower::jsonrpc::Result;
+use lspower::lsp::{
+    InitializeParams, InitializeResult, ServerCapabilities,
+    ServerInfo,
+};
+use lspower::LanguageServer;
+
+struct LspServer {}
+
+#[lspower::async_trait]
+impl LanguageServer for LspServer {
+    async fn initialize(
+        &self,
+        _: InitializeParams,
+    ) -> Result<InitializeResult> {
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                call_hierarchy_provider: None,
+                code_action_provider: None,
+                code_lens_provider: None,
+                color_provider: None,
+                completion_provider: None,
+                declaration_provider: None,
+                definition_provider: None,
+                document_formatting_provider: None,
+                document_highlight_provider: None,
+                document_link_provider: None,
+                document_on_type_formatting_provider: None,
+                document_range_formatting_provider: None,
+                document_symbol_provider: None,
+                execute_command_provider: None,
+                experimental: None,
+                folding_range_provider: None,
+                hover_provider: None,
+                implementation_provider: None,
+                linked_editing_range_provider: None,
+                moniker_provider: None,
+                references_provider: None,
+                rename_provider: None,
+                selection_range_provider: None,
+                semantic_tokens_provider: None,
+                signature_help_provider: None,
+                text_document_sync: None,
+                type_definition_provider: None,
+                workspace: None,
+                workspace_symbol_provider: None,
+            },
+            server_info: Some(ServerInfo {
+                name: "flux-lsp".to_string(),
+                version: Some("2.0".to_string()),
+            }),
+        })
+    }
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(deprecated)]
+mod tests {
+    use lspower::lsp::{ClientCapabilities, InitializeParams};
+    use lspower::LanguageServer;
+    use tokio_test::block_on;
+
+    use super::LspServer;
+
+    #[test]
+    fn test_initialized() {
+        let server = LspServer {};
+
+        let params = InitializeParams {
+            capabilities: ClientCapabilities {
+                workspace: None,
+                text_document: None,
+                window: None,
+                general: None,
+                experimental: None,
+            },
+            client_info: None,
+            initialization_options: None,
+            locale: None,
+            process_id: None,
+            root_path: None,
+            root_uri: None,
+            trace: None,
+            workspace_folders: None,
+        };
+
+        let result = block_on(server.initialize(params)).unwrap();
+        let server_info = result.server_info.unwrap();
+
+        assert_eq!(server_info.name, "flux-lsp".to_string());
+        assert_eq!(server_info.version, Some("2.0".to_string()));
+    }
+
+    #[test]
+    fn test_shutdown() {
+        let server = LspServer {};
+
+        let result = block_on(server.shutdown()).unwrap();
+
+        assert_eq!((), result)
+    }
+}


### PR DESCRIPTION
This patch creates a new `LspServer` struct which implements the basics
of `lspower::LanguageServer`, with accompanying tests.