### PR TITLE
chore: parallelize ci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,8 @@ workflows:
   build-and-test:
     jobs:
       - lint
-      - build:
-          requires:
-            - lint
-      - test:
-          requires:
-            - build
+      - build
+      - test
 
   build-and-deploy:
     jobs:


### PR DESCRIPTION
This patch makes the ci jobs parallelized rather than serial. This is a
good idea when there is a credit limit on CircleCI, but the `influxdata`
credit budget allows for parallelizing these tasks.