### PR TITLE
chore: Revert USER to UNAME in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
     apt-get update && apt-get install --no-install-recommends -y nodejs && \
     apt-get clean  && rm -rf /var/lib/apt/lists/*
 
-USER $USER
+# UNAME comes from the flux-build docker container
+USER $UNAME


### PR DESCRIPTION
Undoing this mistake: https://github.com/influxdata/flux-lsp/commit/27ff301f62a5e0d29a9db32311b73bf1bb462e32#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L15-R15