### PR TITLE
feat: implement textDocument/didChange

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ combinations = "0.1.0"
 flux = { git = "https://github.com/influxdata/flux", tag = "v0.119.1" }
 futures = "0.3.15"
 js-sys = "0.3.51"
+line-col = "0.2.1"
 log = "0.4.14"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"


### PR DESCRIPTION
This patch implements the `textDocument/didChange` rpc call in the
`lspower` server. At this point, the absolutely critical pieces of the
lsp are supported. There is one new piece of functionality in this new
lsp server over the original, and that is the ability to update only a
range of the document, rather than sending the whole file across to the
server.

There is one specific caveat to call out here: the lsp protocol spec
specifically speaks about versioned documents, and has corresponding
data structures that the client can send the server on change events.
It's not clear from the protocol what that versioning _does_, as it
doesn't seem to be read out anywhere, only set. The current lsp server
writes those versions, but it never reads them out; it overwrites with
each `textDocument/onChange` event.

Additionally, while adding thorough test cases for this functionality,
the `textDocument/didOpen` and `textDocument/didClose` tests got a bit
of an update upon realization that, due to the structure of the tests,
`LspServer.store` was accessible in the tests, despite it being private.

Closes #244