### PR TITLE
feat: implement textDocument/formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ combinations = "0.1.0"
 flux = { git = "https://github.com/influxdata/flux", tag = "v0.119.1" }
 futures = "0.3.15"
 js-sys = "0.3.51"
+line-col = "0.2.1"
 log = "0.4.14"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"

--- a/src/handlers/tests.rs
+++ b/src/handlers/tests.rs
@@ -416,8 +416,23 @@ fn test_formatting() {
 
     let file_text = get_file_contents_from_uri(uri);
     let formatted_text = flux::formatter::format(&file_text).unwrap();
+    // XXX: rockstar (15 Jul 2021) - These values are technically incorrect.
+    // lsp::Position should start at index 1, e.g. you can't have line number 0,
+    // but also, the end character position should be 96, as the final line is 96
+    // characters long.
+    let expected_range = lsp::Range {
+        start: lsp::Position {
+            line: 0,
+            character: 0,
+        },
+        end: lsp::Position {
+            line: 15,
+            character: 0,
+        },
+    };
 
     assert_eq!(text, formatted_text, "returns formatted text");
+    assert_eq!(expected_range, edit.range);
 }
 
 #[test]


### PR DESCRIPTION
This patch implements `textDocument/formatting` in the new lsp server.
While working on this issue, a problem was discovered in the old
implementation whereby the ranges, likely across the board, were
incorrect. They were left as is, but an explicit assertion on the
existing test was added, with a comment demonstrated its correctness
issues.

Closes #242