### PR TITLE
chore: consolidate macros module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,14 @@ pub mod shared;
 pub mod stdlib;
 pub mod wasm;
 
-#[macro_use]
-mod macros;
 mod visitors;
 
 pub use handlers::Router;
 pub use wasm::Server;
+
+#[macro_export]
+macro_rules! log {
+    ( $( $t:tt )* ) => {
+        web_sys::console::log_1(&format!( $( $t )* ).into());
+    }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,0 @@
-#[macro_export]
-macro_rules! log {
-    ( $( $t:tt )* ) => {
-        web_sys::console::log_1(&format!( $( $t )* ).into());
-    }
-}


### PR DESCRIPTION
> Flat is better than nested.

This patch merges the 4 lines from the `macros` module into the core
`lib.rs` file and removes the `macros.rs` file.