### PR TITLE
chore: reduce the public interface

### DIFF
--- a/integration/lsp.test.ts
+++ b/integration/lsp.test.ts
@@ -82,7 +82,7 @@ describe('LSP Server integration tests', () => {
             params: {
                 textDocument: {
                     uri: "file:///path/to/file.flux",
-                    languague: "flux",
+                    language: "flux",
                     version: 1,
                     text: `from(bucket:"my-bucket")|>group()|>last()`
                 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -50,16 +50,6 @@ impl Cache {
         Ok(())
     }
 
-    pub fn clear(&self) -> Result<(), String> {
-        let keys = self.keys()?;
-
-        for key in keys {
-            self.remove(key.as_str())?;
-        }
-
-        Ok(())
-    }
-
     pub fn keys(&self) -> Result<Vec<String>, String> {
         let store = match self.store.lock() {
             Ok(s) => s,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -22,20 +22,14 @@ mod tests;
 pub use router::Router;
 
 use crate::cache::Cache;
-use crate::protocol::notifications::{
-    create_diagnostics_notification, Notification,
-    PublishDiagnosticsParams,
-};
 use crate::protocol::properties::Position;
 use crate::protocol::requests::PolymorphicRequest;
-use crate::shared::conversion::map_errors_to_diagnostics;
 use crate::shared::RequestContext;
 use crate::visitors::semantic::NodeFinderVisitor;
 
 use std::rc::Rc;
 
 use async_trait::async_trait;
-use flux::ast::{check, walk};
 
 #[derive(Debug)]
 pub struct Error {
@@ -55,18 +49,6 @@ pub trait RequestHandler {
         ctx: RequestContext,
         cache: &Cache,
     ) -> Result<Option<String>, Error>;
-}
-
-pub fn create_diagnostics(
-    uri: String,
-    file: flux::ast::File,
-) -> Result<Notification<PublishDiagnosticsParams>, String> {
-    let walker = walk::Node::File(&file);
-
-    let errors = check::check(walker);
-    let diagnostics = map_errors_to_diagnostics(errors);
-
-    Ok(create_diagnostics_notification(uri, diagnostics))
 }
 
 #[derive(Default, Clone)]

--- a/src/handlers/tests.rs
+++ b/src/handlers/tests.rs
@@ -5,6 +5,7 @@ use futures::executor::block_on;
 use serde_json::from_str;
 use url::Url;
 
+use super::Router;
 use crate::protocol::notifications;
 use crate::protocol::properties;
 use crate::protocol::requests;
@@ -12,7 +13,6 @@ use crate::protocol::responses;
 use crate::shared::callbacks::Callbacks;
 use crate::shared::{CompletionInfo, CompletionType, RequestContext};
 use crate::stdlib::{get_builtins, Completable, PackageResult};
-use crate::Router;
 
 const FLUX: &'static str = "flux";
 const JSONRPCVERSION: &'static str = "2.0";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,12 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
-pub mod cache;
-pub mod handlers;
-pub mod protocol;
-pub mod shared;
-pub mod stdlib;
-pub mod wasm;
+mod cache;
+mod handlers;
+mod protocol;
+mod shared;
+mod stdlib;
+mod wasm;
 
 mod visitors;
-
-pub use handlers::Router;
-pub use wasm::Server;
 
 #[macro_export]
 macro_rules! log {

--- a/src/protocol/properties.rs
+++ b/src/protocol/properties.rs
@@ -59,26 +59,6 @@ pub struct DocumentSymbol {
     pub children: Option<Vec<DocumentSymbol>>,
 }
 
-impl DocumentSymbol {
-    pub fn new(
-        kind: SymbolKind,
-        name: String,
-        detail: String,
-        loc: &SourceLocation,
-    ) -> DocumentSymbol {
-        let range = loc_to_range(loc);
-        DocumentSymbol {
-            children: None,
-            deprecated: None,
-            kind,
-            selection_range: range.clone(),
-            range,
-            name,
-            detail: Some(detail),
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Clone)]
 pub struct SymbolInformation {
     pub name: String,

--- a/src/protocol/responses.rs
+++ b/src/protocol/responses.rs
@@ -137,26 +137,6 @@ pub struct CompletionItem {
     pub additional_text_edits: Option<Vec<TextEdit>>,
 }
 
-impl CompletionItem {
-    pub fn new(name: String, package: String) -> Self {
-        CompletionItem {
-            label: format!("{} ({})", name, package),
-            additional_text_edits: None,
-            commit_characters: None,
-            deprecated: false,
-            detail: Some(format!("package: {}", package)),
-            documentation: Some(format!("package: {}", package)),
-            filter_text: Some(name.clone()),
-            insert_text: Some(name.clone()),
-            insert_text_format: InsertTextFormat::PlainText,
-            kind: Some(CompletionItemKind::Function),
-            preselect: None,
-            sort_text: Some(format!("{} {}", name, package)),
-            text_edit: None,
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Clone)]
 pub struct SignatureHelp {
     pub signatures: Vec<SignatureInformation>,
@@ -188,13 +168,4 @@ pub struct HoverResult {
 pub struct MarkupContent {
     pub kind: String,
     pub value: String,
-}
-
-impl MarkupContent {
-    pub fn new(content: String) -> Self {
-        MarkupContent {
-            kind: "markdown".to_string(),
-            value: content,
-        }
-    }
 }

--- a/src/shared/messages.rs
+++ b/src/shared/messages.rs
@@ -8,16 +8,6 @@ pub fn wrap_message(s: String) -> String {
     format!("Content-Length: {}\r\n\r\n{}", size, s)
 }
 
-pub fn get_content_size(s: String) -> Result<usize, String> {
-    let tmp = String::from(s.trim_end());
-    let stmp: Vec<&str> = tmp.split(": ").collect();
-
-    match String::from(stmp[1]).parse::<usize>() {
-        Ok(size) => Ok(size),
-        Err(_) => Err("Failed to parse content size".to_string()),
-    }
-}
-
 pub fn create_polymorphic_request(
     content: String,
 ) -> Result<PolymorphicRequest, String> {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,3 +1,10 @@
+/* There are many `allow(dead_code)` pragmas in this file. The reason
+ * these are necessary is because they are used solely by the wasm build
+ * process, and aren't used when building the lib itself. We want still want
+ * the "X is never used" messages in this file, so we mark only the things we
+ * know are being used with the pragma. There is an integration test that
+ * we can use to assert what is actually being used here.
+ */
 use crate::handlers::{Error, Router};
 use crate::shared::callbacks::Callbacks;
 use crate::shared::messages::{
@@ -23,20 +30,22 @@ pub struct Server {
 
 #[wasm_bindgen]
 #[derive(Deserialize)]
-pub struct ServerResponse {
+struct ServerResponse {
+    #[allow(dead_code)]
     message: Option<String>,
+    #[allow(dead_code)]
     error: Option<String>,
 }
 
 #[derive(Serialize)]
-pub struct ServerError {
-    pub id: u32,
-    pub error: ResponseError,
-    pub jsonrpc: String,
+struct ServerError {
+    id: u32,
+    error: ResponseError,
+    jsonrpc: String,
 }
 
 impl ServerError {
-    pub fn from_error(id: u32, err: Error) -> Result<String, Error> {
+    fn from_error(id: u32, err: Error) -> Result<String, Error> {
         let se = ServerError {
             id,
             error: ResponseError {
@@ -56,17 +65,19 @@ impl ServerError {
 }
 
 #[derive(Serialize)]
-pub struct ResponseError {
+struct ResponseError {
     code: u32,
     message: String,
 }
 
 #[wasm_bindgen]
 impl ServerResponse {
+    #[allow(dead_code)]
     pub fn get_message(&self) -> Option<String> {
         self.message.clone()
     }
 
+    #[allow(dead_code)]
     pub fn get_error(&self) -> Option<String> {
         self.error.clone()
     }


### PR DESCRIPTION
Building on the knowledge and assertions made by the existence of the
integration tests added in #274, this patch reduces the public interface
provided by the `flux-lsp` lib.

This means that _nothing_ is exposed in the `flux-lsp` lib, but there
are still things exported via `wasm_bindgen`, and they are denoted in
the source properly and enforced with the integration tests.