### PR TITLE
feat: hide the new LspServer behind a feature flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,15 +20,21 @@ jobs:
       - checkout
       - run:
           name: "run tests"
-          command: cargo test
+          command: |
+            cargo test
+            cargo test --features lsp2
 
   build:
     docker:
       - image: quay.io/influxdb/wasm-build
     steps:
       - checkout
-      - run: cargo build --verbose
-      - run: make wasm
+      - run: |
+          cargo build --verbose
+          cargo build --features lsp2 --verbose
+      - run: |
+          make wasm
+          LSP2=1 make wasm
 
   test-integration:
     docker:
@@ -41,6 +47,10 @@ jobs:
             cd integration
             npm install -f  # Force, because fsevents
             npm test
+            # XXX: rockstar (22 Jul 2021) - Enabling the `lsp2` feature flag
+            # does not enable a wasm binary, currently. That will have to be
+            # followed up.
+            # LSP2=1 npm test
 
   deploy:
     docker:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ wasm-opt = ["-Oz", "--enable-mutable-globals"]
 [features]
 default = ["strict"]
 strict = []
+lsp2 = ["lspower"]
 
 [lib]
 name = "flux_lsp"
@@ -23,6 +24,7 @@ path = "src/lib.rs"
 name = "flux-lsp"
 test = false
 bench = false
+required-features = ["lsp2"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -35,6 +37,8 @@ futures = "0.3.15"
 js-sys = "0.3.51"
 line-col = "0.2.1"
 log = "0.4.14"
+lsp-types = "0.89.2"
+lspower = { version = "1.1.0", optional = true }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 serde_repr = "0.1.7"
@@ -44,8 +48,6 @@ url = "2.2.2"
 wasm-bindgen = "0.2.74"
 wasm-bindgen-futures = "0.4.24"
 web-sys = { version = "0.3.51", features = ["console"] }
-
-lspower = "1.1.0"
 
 [dev-dependencies]
 futures = "0.3.15"

--- a/src/bin/flux-lsp.rs
+++ b/src/bin/flux-lsp.rs
@@ -88,6 +88,16 @@ async fn main() {
     let (service, messages) = LspService::new(|_client| {
         LspServer::new(!disable_folding, influxdb_url, token, org)
     });
+    // service(LspService).server is an instance of the LspServer
+    // service.call sends request to LspServer
+    // crate::generated_impl::handle_request
+    //   - takes the LspServer instance as first argument
+    //   - state
+    //   - pending server messages
+    //   - req
+    //  handle_request does the following:
+    //   - get the method by checking the ServerRequest.kind
+    //   - if the method is not known, return the request_else result
     Server::new(stdin, stdout)
         .interleave(messages)
         .serve(service)

--- a/src/handlers/completion.rs
+++ b/src/handlers/completion.rs
@@ -27,7 +27,7 @@ use flux::semantic::walk;
 
 use async_trait::async_trait;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 fn move_back(position: lsp::Position, count: u32) -> lsp::Position {
     lsp::Position {

--- a/src/handlers/completion_resolve.rs
+++ b/src/handlers/completion_resolve.rs
@@ -4,7 +4,7 @@ use crate::protocol::{PolymorphicRequest, Request, Response};
 
 use async_trait::async_trait;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 #[derive(Default)]
 pub struct CompletionResolveHandler {}

--- a/src/handlers/document_change.rs
+++ b/src/handlers/document_change.rs
@@ -6,7 +6,7 @@ use crate::shared::structs::RequestContext;
 
 use async_trait::async_trait;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 #[derive(Default)]
 pub struct DocumentChangeHandler {}

--- a/src/handlers/document_close.rs
+++ b/src/handlers/document_close.rs
@@ -4,7 +4,7 @@ use crate::protocol::{PolymorphicRequest, Request};
 
 use async_trait::async_trait;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 #[derive(Default)]
 pub struct DocumentCloseHandler {}

--- a/src/handlers/document_formatting.rs
+++ b/src/handlers/document_formatting.rs
@@ -6,7 +6,7 @@ use std::convert::TryFrom;
 
 use flux::formatter;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 fn create_range(contents: String) -> lsp::Range {
     let lines = contents.split('\n').collect::<Vec<&str>>();

--- a/src/handlers/document_open.rs
+++ b/src/handlers/document_open.rs
@@ -4,7 +4,7 @@ use crate::protocol::{PolymorphicRequest, Request};
 use crate::shared::create_diagnoistics;
 use crate::shared::structs::RequestContext;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 #[derive(Default)]
 pub struct DocumentOpenHandler {}

--- a/src/handlers/document_save.rs
+++ b/src/handlers/document_save.rs
@@ -3,7 +3,7 @@ use crate::handlers::{Error, RequestHandler};
 use crate::protocol::{PolymorphicRequest, Request};
 use crate::shared::create_diagnoistics;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 fn parse_save_request(
     data: String,

--- a/src/handlers/document_symbol.rs
+++ b/src/handlers/document_symbol.rs
@@ -8,7 +8,7 @@ use crate::visitors::semantic::SymbolsVisitor;
 use flux::semantic::walk::{self, Node};
 use std::rc::Rc;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 pub fn sort_symbols(
     a: &lsp::SymbolInformation,

--- a/src/handlers/folding.rs
+++ b/src/handlers/folding.rs
@@ -7,7 +7,7 @@ use flux::semantic::walk::{self, Node};
 
 use std::rc::Rc;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 fn node_to_folding_range(node: Rc<Node>) -> lsp::FoldingRange {
     lsp::FoldingRange {

--- a/src/handlers/goto_definition.rs
+++ b/src/handlers/goto_definition.rs
@@ -11,7 +11,7 @@ use crate::visitors::semantic::{
 
 use flux::semantic::walk::{self, Node};
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 fn ident_to_location(
     uri: lsp::Url,

--- a/src/handlers/initialize.rs
+++ b/src/handlers/initialize.rs
@@ -2,7 +2,7 @@ use crate::cache::Cache;
 use crate::handlers::{Error, RequestHandler};
 use crate::protocol::{PolymorphicRequest, Request, Response};
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 pub struct InitializeHandler {
     disable_folding: bool,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -29,7 +29,7 @@ use std::rc::Rc;
 
 use async_trait::async_trait;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 #[derive(Debug)]
 pub struct Error {

--- a/src/handlers/references.rs
+++ b/src/handlers/references.rs
@@ -11,7 +11,7 @@ use crate::visitors::semantic::{
 use flux::semantic::nodes::FunctionExpr;
 use flux::semantic::walk::{self, Node};
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 use std::rc::Rc;
 

--- a/src/handlers/rename.rs
+++ b/src/handlers/rename.rs
@@ -5,7 +5,7 @@ use crate::protocol::{PolymorphicRequest, Request, Response};
 
 use std::collections::HashMap;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 #[derive(Default)]
 pub struct RenameHandler {}

--- a/src/handlers/signature_help.rs
+++ b/src/handlers/signature_help.rs
@@ -14,7 +14,7 @@ use flux::semantic::walk::{walk, Node};
 
 use std::rc::Rc;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 fn create_signature_information(
     fs: FunctionSignature,

--- a/src/handlers/tests.rs
+++ b/src/handlers/tests.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::fs;
 
 use futures::executor::block_on;
-use lspower::lsp;
+use lsp_types as lsp;
 use serde_json::from_str;
 use url::Url;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,16 @@ extern crate clap;
 mod cache;
 mod handlers;
 mod protocol;
+#[cfg(feature = "lsp2")]
 mod server;
 mod shared;
 mod stdlib;
+#[cfg(not(feature = "lsp2"))]
 mod wasm;
+#[cfg(feature = "lsp2")]
+mod wasm2;
 
 mod visitors;
 
+#[cfg(feature = "lsp2")]
 pub use server::LspServer;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,7 +1,7 @@
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 fn default_id() -> u32 {
     0

--- a/src/shared/ast.rs
+++ b/src/shared/ast.rs
@@ -2,7 +2,7 @@ use crate::cache;
 use crate::cache::Cache;
 use crate::shared::structs::RequestContext;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 pub fn is_in_node(
     pos: lsp::Position,

--- a/src/shared/conversion.rs
+++ b/src/shared/conversion.rs
@@ -5,7 +5,7 @@ use flux::semantic::walk::Node;
 
 use std::rc::Rc;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 pub fn map_node_to_location(
     uri: lsp::Url,

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -20,11 +20,12 @@ use std::rc::Rc;
 
 use flux::semantic::walk;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 pub mod ast;
 pub mod callbacks;
 pub mod conversion;
+#[cfg(not(feature = "lsp2"))]
 pub mod messages;
 pub mod signatures;
 pub mod structs;

--- a/src/shared/signatures.rs
+++ b/src/shared/signatures.rs
@@ -4,7 +4,7 @@ use flux::semantic::types::{Function, MonoType};
 
 use crate::shared::all_combos;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 #[allow(clippy::implicit_hasher)]
 pub fn get_argument_names(

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -14,7 +14,7 @@ use std::iter::Iterator;
 
 use async_trait::async_trait;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 pub const BUILTIN_PACKAGE: &str = "builtin";
 

--- a/src/visitors/ast/mod.rs
+++ b/src/visitors/ast/mod.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 use flux::ast::walk::{self, Visitor};
 pub mod package_finder;

--- a/src/visitors/ast/package_finder.rs
+++ b/src/visitors/ast/package_finder.rs
@@ -9,7 +9,7 @@ use crate::shared::ast::create_ast_package;
 use crate::shared::conversion::flux_position_to_position;
 use crate::shared::RequestContext;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 #[derive(Clone)]
 pub struct PackageInfo {

--- a/src/visitors/semantic/completion/mod.rs
+++ b/src/visitors/semantic/completion/mod.rs
@@ -15,7 +15,7 @@ use flux::semantic::nodes::*;
 use flux::semantic::types::MonoType;
 use flux::semantic::walk::{Node, Visitor};
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 pub struct FunctionFinderState {
     pub functions: Vec<Function>,

--- a/src/visitors/semantic/completion/results.rs
+++ b/src/visitors/semantic/completion/results.rs
@@ -6,7 +6,7 @@ use crate::visitors::semantic::completion::utils::follow_function_pipes;
 use flux::semantic::nodes::*;
 use flux::semantic::types::MonoType;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 #[derive(Clone)]
 pub struct ImportAliasResult {

--- a/src/visitors/semantic/completion/utils.rs
+++ b/src/visitors/semantic/completion/utils.rs
@@ -2,7 +2,7 @@ use flux::ast::SourceLocation;
 use flux::semantic::nodes::*;
 use flux::semantic::types::MonoType;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 pub fn follow_function_pipes(c: &CallExpr) -> &MonoType {
     if let Some(Expression::Call(call)) = &c.pipe {

--- a/src/visitors/semantic/functions.rs
+++ b/src/visitors/semantic/functions.rs
@@ -8,7 +8,7 @@ use flux::semantic::walk::{Node, Visitor};
 
 use crate::shared::signatures::FunctionInfo;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 #[derive(Default)]
 pub struct FunctionFinderState {

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -7,7 +7,7 @@ use crate::shared::get_package_name;
 use flux::semantic::nodes::*;
 use flux::semantic::walk::{self, Node, Visitor};
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 mod completion;
 mod symbols;

--- a/src/visitors/semantic/symbols/mod.rs
+++ b/src/visitors/semantic/symbols/mod.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use flux::semantic::nodes::{self, Expression};
 use flux::semantic::walk::{Node, Visitor};
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 fn parse_variable_assignment(
     uri: lsp::Url,

--- a/src/visitors/semantic/utils.rs
+++ b/src/visitors/semantic/utils.rs
@@ -11,7 +11,7 @@ use flux::semantic::nodes::Package;
 
 use flux::analyze;
 
-use lspower::lsp;
+use lsp_types as lsp;
 
 fn local_analyze(
     pkg: flux::ast::Package,

--- a/src/wasm2.rs
+++ b/src/wasm2.rs
@@ -1,0 +1,73 @@
+use std::str;
+
+use js_sys::{Function, Promise};
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::future_to_promise;
+
+#[derive(Serialize)]
+struct ResponseError {
+    code: u32,
+    message: String,
+}
+
+#[wasm_bindgen]
+#[derive(Deserialize)]
+struct ServerResponse {
+    #[allow(dead_code)]
+    message: Option<String>,
+    #[allow(dead_code)]
+    error: Option<String>,
+}
+
+#[wasm_bindgen]
+impl ServerResponse {
+    #[allow(dead_code)]
+    pub fn get_message(&self) -> Option<String> {
+        self.message.clone()
+    }
+
+    #[allow(dead_code)]
+    pub fn get_error(&self) -> Option<String> {
+        self.error.clone()
+    }
+}
+
+#[derive(Serialize)]
+struct ServerError {
+    id: u32,
+    error: ResponseError,
+    jsonrpc: String,
+}
+
+#[wasm_bindgen]
+pub struct Server {}
+
+#[wasm_bindgen]
+impl Server {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        _disable_folding: bool,
+        _support_multiple_files: bool,
+    ) -> Self {
+        Server {}
+    }
+
+    pub fn process(&mut self, msg: String) -> Promise {
+        future_to_promise(async move {
+            Ok(JsValue::from(ServerResponse {
+                message: Some(
+                    str::from_utf8(msg.as_bytes())
+                        .unwrap()
+                        .to_string(),
+                ),
+                error: None,
+            }))
+        })
+    }
+
+    pub fn register_buckets_callback(&mut self, _f: Function) {}
+    pub fn register_measurements_callback(&mut self, _f: Function) {}
+    pub fn register_tag_keys_callback(&mut self, _f: Function) {}
+    pub fn register_tag_values_callback(&mut self, _f: Function) {}
+}

--- a/wasm-build.sh
+++ b/wasm-build.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-wasm-pack build -t nodejs -d pkg-node --out-name flux-lsp-node --scope influxdata --release
-wasm-pack build -t browser -d pkg-browser --out-name flux-lsp-browser --scope influxdata --release
+EXTRA_ARGS="--"
+if [[ ! -z "${LSP2}" ]]; then
+    echo "Building with --featurs lsp2"
+    EXTRA_ARGS="${EXTRA_ARGS} --features lsp2"
+fi
+
+wasm-pack build -t nodejs -d pkg-node --out-name flux-lsp-node --scope influxdata --release $EXTRA_ARGS
+wasm-pack build -t browser -d pkg-browser --out-name flux-lsp-browser --scope influxdata --release $EXTRA_ARGS
 
 cat pkg-node/package.json | sed s/@influxdata\\/flux-lsp\"/@influxdata\\/flux-lsp-node\"/g > pkg-node/package-new.json
 mv pkg-node/package-new.json pkg-node/package.json


### PR DESCRIPTION
This patch adds a feature flag which allows us to hide the LspServer
work behind a feature flag. This enables the ability to merge the
feature branch into the mainline branch.