### PR TITLE
feat: use the builder pattern for LspServer

### DIFF
--- a/src/bin/flux-lsp.rs
+++ b/src/bin/flux-lsp.rs
@@ -86,7 +86,20 @@ async fn main() {
     let stdout = tokio::io::stdout();
 
     let (service, messages) = LspService::new(|_client| {
-        LspServer::new(!disable_folding, influxdb_url, token, org)
+        let mut server = LspServer::default();
+        if disable_folding {
+            server = server.disable_folding();
+        }
+        if let Some(value) = influxdb_url {
+            server = server.with_influxdb_url(value);
+        }
+        if let Some(value) = token {
+            server = server.with_token(value);
+        }
+        if let Some(value) = org {
+            server = server.with_org(value);
+        }
+        server
     });
     // service(LspService).server is an instance of the LspServer
     // service.call sends request to LspServer

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,19 +84,61 @@ pub struct LspServer {
 }
 
 impl LspServer {
-    pub fn new(
-        folding: bool,
-        influxdb_url: Option<String>,
-        token: Option<String>,
-        org: Option<String>,
-    ) -> Self {
+    pub fn disable_folding(self) -> Self {
+        Self {
+            store: self.store,
+            options: LspServerOptions {
+                folding: false,
+                influxdb_url: self.options.influxdb_url,
+                token: self.options.token,
+                org: self.options.org,
+            },
+        }
+    }
+    pub fn with_influxdb_url(self, influxdb_url: String) -> Self {
+        Self {
+            store: self.store,
+            options: LspServerOptions {
+                folding: self.options.folding,
+                influxdb_url: Some(influxdb_url),
+                token: self.options.token,
+                org: self.options.org,
+            },
+        }
+    }
+    pub fn with_token(self, token: String) -> Self {
+        Self {
+            store: self.store,
+            options: LspServerOptions {
+                folding: self.options.folding,
+                influxdb_url: self.options.influxdb_url,
+                token: Some(token),
+                org: self.options.org,
+            },
+        }
+    }
+    pub fn with_org(self, org: String) -> Self {
+        Self {
+            store: self.store,
+            options: LspServerOptions {
+                folding: self.options.folding,
+                influxdb_url: self.options.influxdb_url,
+                token: self.options.token,
+                org: Some(org),
+            },
+        }
+    }
+}
+
+impl Default for LspServer {
+    fn default() -> Self {
         Self {
             store: Arc::new(Mutex::new(HashMap::new())),
             options: LspServerOptions {
-                folding,
-                influxdb_url,
-                token,
-                org,
+                folding: true,
+                influxdb_url: None,
+                token: None,
+                org: None,
             },
         }
     }
@@ -575,7 +617,7 @@ mod tests {
         include_str!("../tests/fixtures/signatures.flux");
 
     fn create_server() -> LspServer {
-        LspServer::new(true, None, None, None)
+        LspServer::default()
     }
 
     fn open_file(server: &LspServer, text: String) {


### PR DESCRIPTION
This patch introduces the builder pattern to the `LspServer`. This work
was a spike in building out a couple of different ways to create an
`LspServer` instance. In the default main case, an `LspServer::new()` is
all that's needed, and doing `LspServer::new(true, None, None, None)` is
less clear about what the random `bool` and `Option` args are.