### PR TITLE
feat(lspower): Implement rename handler for lspower server

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -94,8 +94,8 @@ fn find_references(
 
     if let Some(node) = result.node {
         let name = match node.as_ref() {
-            walk::Node::Identifier(ident) => &ident.name[..],
-            walk::Node::IdentifierExpr(ident) => &ident.name[..],
+            walk::Node::Identifier(ident) => ident.name.as_str(),
+            walk::Node::IdentifierExpr(ident) => ident.name.as_str(),
             _ => return locations,
         };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -73,7 +73,7 @@ fn replace_string_in_range(
 
 fn function_defines(
     name: String,
-    params: Vec<FunctionParameter>,
+    params: &Vec<FunctionParameter>,
 ) -> bool {
     for param in params {
         if param.key.name == name {
@@ -95,7 +95,6 @@ fn is_scope(name: String, n: Rc<walk::Node<'_>>) -> bool {
 fn find_references(
     uri: lsp::Url,
     result: NodeFinderResult,
-    position: lsp::Position,
 ) -> Vec<lsp::Location> {
     let mut locations: Vec<lsp::Location> = vec![];
 
@@ -115,7 +114,7 @@ fn find_references(
                     walk::Node::FunctionExpr(f)
                         if function_defines(
                             name.clone(),
-                            f.params,
+                            &f.params,
                         ) =>
                     {
                         Some(n.clone())
@@ -711,7 +710,7 @@ impl LanguageServer for LspServer {
         let pkg = parse_and_analyze(contents);
         let node = find_node(walk::Node::Package(&pkg), pos);
 
-        let locations = find_references(key.clone(), node, pos);
+        let locations = find_references(key.clone(), node);
 
         let mut changes = HashMap::new();
         changes.insert(key.clone(), Vec::new());


### PR DESCRIPTION
Closes #251

The main chunk of logic I had to work on was the `find_references` function. It seems to make the test pass, but I think I could use an extra set of eyes on it. [This](https://github.com/rockstar/flux-lsp/blob/40f7edd5c651888542e608a096c0ae09cb3c1753/src/server.rs#L66-L128) was the original implementation when I started working on it, and it looks like it was mostly copied from [here](https://github.com/influxdata/flux-lsp/blob/69e9fd48f0c56695dcd568d57726ba6bfab9a5a2/src/handlers/references.rs#L81-L117). I just tried to clean it up a bit.