### PR TITLE
feat: make the lsp server platform agnostic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ wasm-opt = ["-Oz", "--enable-mutable-globals"]
 [features]
 default = ["strict"]
 strict = []
-lsp2 = ["lspower"]
+lsp2 = ["lspower/runtime-agnostic"]
 
 [lib]
 name = "flux_lsp"
@@ -29,6 +29,7 @@ required-features = ["lsp2"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-std = { version = "1.9.0", features = ["attributes"] }
 async-trait = "0.1.50"
 clap = "2.33.3"
 combinations = "0.1.0"
@@ -38,12 +39,11 @@ js-sys = "0.3.51"
 line-col = "0.2.1"
 log = "0.4.14"
 lsp-types = "0.89.2"
-lspower = { version = "1.1.0", optional = true }
+lspower = { version = "1.1.0", default-features = false, optional = true }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 serde_repr = "0.1.7"
 simplelog = "0.10.0"
-tokio = { version = "1.7.1", features = ["io-std", "macros", "rt", "rt-multi-thread"] }
 url = "2.2.2"
 wasm-bindgen = "0.2.74"
 wasm-bindgen-futures = "0.4.24"
@@ -51,4 +51,3 @@ web-sys = { version = "0.3.51", features = ["console"] }
 
 [dev-dependencies]
 futures = "0.3.15"
-tokio-test = "*"

--- a/src/bin/flux-lsp.rs
+++ b/src/bin/flux-lsp.rs
@@ -7,7 +7,7 @@ use simplelog::{CombinedLogger, Config, LevelFilter, WriteLogger};
 
 use flux_lsp::LspServer;
 
-#[tokio::main]
+#[async_std::main]
 async fn main() {
     let matches = App::new("flux-lsp")
         .version("2.0")
@@ -82,8 +82,8 @@ async fn main() {
     };
 
     debug!("Starting lsp client");
-    let stdin = tokio::io::stdin();
-    let stdout = tokio::io::stdout();
+    let stdin = async_std::io::stdin();
+    let stdout = async_std::io::stdout();
 
     let (service, messages) = LspService::new(|_client| {
         let mut server = LspServer::default();

--- a/src/server.rs
+++ b/src/server.rs
@@ -606,9 +606,9 @@ impl LanguageServer for LspServer {
 mod tests {
     use std::collections::HashMap;
 
+    use async_std::task::block_on;
     use lspower::lsp;
     use lspower::LanguageServer;
-    use tokio_test::block_on;
 
     use super::LspServer;
 


### PR DESCRIPTION
This patch removes tokio from the equation, and moves to using
`async_std` instead. It's _possible_ that there may one day be a case
for using `tokio` again, and at that point, we'll enable it using
feature flag.