### PR TITLE
feat: build the wasm interface for lsp2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,7 @@ jobs:
             cd integration
             npm install -f  # Force, because fsevents
             npm test
-            # XXX: rockstar (22 Jul 2021) - Enabling the `lsp2` feature flag
-            # does not enable a wasm binary, currently. That will have to be
-            # followed up.
-            # LSP2=1 npm test
+            LSP2=1 npm test
 
   deploy:
     docker:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ wasm-opt = ["-Oz", "--enable-mutable-globals"]
 [features]
 default = ["strict"]
 strict = []
-lsp2 = ["lspower/runtime-agnostic"]
+lsp2 = ["lspower/runtime-agnostic", "tower-service"]
 
 [lib]
 name = "flux_lsp"
@@ -44,9 +44,13 @@ serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 serde_repr = "0.1.7"
 simplelog = "0.10.0"
+tower-service = { version = "0.3.1", optional = true }
 url = "2.2.2"
 wasm-bindgen = "0.2.74"
 wasm-bindgen-futures = "0.4.24"
+# wasm-bindgen-test isn't a dev dependency because the tests are
+# built externally.
+wasm-bindgen-test = "0.3.0"
 web-sys = { version = "0.3.51", features = ["console"] }
 
 [dev-dependencies]

--- a/integration/lsp.test.ts
+++ b/integration/lsp.test.ts
@@ -54,17 +54,18 @@ describe('LSP Server integration tests', () => {
             }
         };
 
-        const request = {method: "initialize"};
+        const request = {method: "initialize", params: { capabilities: {}}};
 
         const response = await server.process(buildRequest(request));
         const error = response.get_error();
         expect(error).toBe(undefined);
         const message = parseResponse(response.get_message());
-        expect(message).toStrictEqual(expected);
+        // XXX: rockstar (27 Jul 2021) - The serverInfo between the two servers
+        // is different, which would cause this to fail.
+        expect(message.result["capabilities"]).toStrictEqual(expected.result["capabilities"]);
     });
 
     it('formats', async () => {
-
         const expected = {
             result: [{
                 newText: "from(bucket: \"my-bucket\") |> group() |> last()",

--- a/src/bin/flux-lsp.rs
+++ b/src/bin/flux-lsp.rs
@@ -101,16 +101,6 @@ async fn main() {
         }
         server
     });
-    // service(LspService).server is an instance of the LspServer
-    // service.call sends request to LspServer
-    // crate::generated_impl::handle_request
-    //   - takes the LspServer instance as first argument
-    //   - state
-    //   - pending server messages
-    //   - req
-    //  handle_request does the following:
-    //   - get the method by checking the ServerRequest.kind
-    //   - if the method is not known, return the request_else result
     Server::new(stdin, stdout)
         .interleave(messages)
         .serve(service)

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -15,7 +15,9 @@ pub mod router;
 pub mod shutdown;
 pub mod signature_help;
 
-#[cfg(test)]
+// Url::to_file_path doesn't exist in wasm-unknown-unknown, for kinda
+// obvious reasons. Ignore these tests when executing against that target.
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests;
 
 pub use router::Router;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,9 @@ mod visitors;
 #[cfg(feature = "lsp2")]
 pub use server::LspServer;
 
+#[cfg(target_arch = "wasm32")]
 #[macro_export]
-macro_rules! log {
+macro_rules! console_log {
     ( $( $t:tt )* ) => {
         web_sys::console::log_1(&format!( $( $t )* ).into());
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -234,13 +234,17 @@ impl LanguageServer for LspServer {
                         },
                 }),
                 declaration_provider: None,
-                definition_provider: None,
-                document_formatting_provider: None,
+                definition_provider: Some(lsp::OneOf::Left(true)),
+                document_formatting_provider: Some(lsp::OneOf::Left(
+                    true,
+                )),
                 document_highlight_provider: None,
                 document_link_provider: None,
                 document_on_type_formatting_provider: None,
                 document_range_formatting_provider: None,
-                document_symbol_provider: None,
+                document_symbol_provider: Some(lsp::OneOf::Left(
+                    true,
+                )),
                 execute_command_provider: None,
                 experimental: None,
                 folding_range_provider: Some(
@@ -252,8 +256,8 @@ impl LanguageServer for LspServer {
                 implementation_provider: None,
                 linked_editing_range_provider: None,
                 moniker_provider: None,
-                references_provider: None,
-                rename_provider: None,
+                references_provider: Some(lsp::OneOf::Left(true)),
+                rename_provider: Some(lsp::OneOf::Left(true)),
                 selection_range_provider: None,
                 semantic_tokens_provider: None,
                 signature_help_provider: Some(
@@ -270,7 +274,11 @@ impl LanguageServer for LspServer {
                             },
                     },
                 ),
-                text_document_sync: None,
+                text_document_sync: Some(
+                    lsp::TextDocumentSyncCapability::Kind(
+                        lsp::TextDocumentSyncKind::Full,
+                    ),
+                ),
                 type_definition_provider: None,
                 workspace: None,
                 workspace_symbol_provider: None,
@@ -701,7 +709,9 @@ impl LanguageServer for LspServer {
     }
 }
 
-#[cfg(test)]
+// Url::to_file_path doesn't exist in wasm-unknown-unknown, for kinda
+// obvious reasons. Ignore these tests when executing against that target.
+#[cfg(all(test, not(target_arch = "wasm32")))]
 #[allow(deprecated)]
 mod tests {
     use std::collections::HashMap;

--- a/src/server.rs
+++ b/src/server.rs
@@ -460,8 +460,11 @@ impl LanguageServer for LspServer {
                 info!("textDocument/formatting requested trimming final newlines, but the flux formatter will always trim trailing whitespace");
             }
         }
-        let lookup = line_col::LineColLookup::new(formatted.as_str());
-        let end = lookup.get(formatted.len() - 1);
+
+        // The new text shows the range of the previously replaced section,
+        // not the range of the new section.
+        let lookup = line_col::LineColLookup::new(contents.as_str());
+        let end = lookup.get(contents.len());
 
         let edit = lsp::TextEdit::new(
             lsp::Range {
@@ -1125,8 +1128,8 @@ errorCounts
                     character: 0,
                 },
                 end: lsp::Position {
-                    line: 14,
-                    character: 95,
+                    line: 15,
+                    character: 96,
                 },
             },
             flux::formatter::format(&fluxscript).unwrap(),
@@ -1187,13 +1190,9 @@ errorCounts
                     line: 0,
                     character: 0,
                 },
-                // This reads funny, because line 15 is only 96 characters long.
-                // Character number 97 is a newline, but it doesn't show as line
-                // 16 because there aren't any characters on the line, and we
-                // can't use character 0 there.
                 end: lsp::Position {
-                    line: 14,
-                    character: 96,
+                    line: 17,
+                    character: 0,
                 },
             },
             formatted_text,

--- a/wasm-build.sh
+++ b/wasm-build.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+set -e
+
 EXTRA_ARGS="--"
 if [[ ! -z "${LSP2}" ]]; then
-    echo "Building with --featurs lsp2"
+    echo "Building with --features lsp2"
     EXTRA_ARGS="${EXTRA_ARGS} --features lsp2"
 fi
 


### PR DESCRIPTION
This patch adds the lsp server for the new lspower-based lsp server.

Closes #283