### PR TITLE
fix: attempt to fix many off-by-one errors

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,103 @@
+use flux::ast;
+use flux::semantic::walk::Node;
+
+/// Convert a flux::ast::Position to a lsp_types::Position
+/// https://microsoft.github.io/language-server-protocol/specification#position
+// XXX: rockstar (28 Jul 2021) - This can't be implemented in a From trait
+// without some clownshoes type aliasing, so this conversion function will work.
+fn ast_to_lsp_position(
+    position: ast::Position,
+) -> lsp_types::Position {
+    lsp_types::Position {
+        line: position.line - 1,
+        character: position.column - 1,
+    }
+}
+
+/// Convert a flux::semantic::walk::Node to a lsp_types::Location
+/// https://microsoft.github.io/language-server-protocol/specification#location
+// XXX: rockstar (28 Jul 2021) - This can't be implemented in a From trait
+// without some clownshoes type aliasing, so this conversion function will work.
+pub fn node_to_location(
+    node: &Node,
+    uri: lsp_types::Url,
+) -> lsp_types::Location {
+    let node_location = node.loc().clone();
+    lsp_types::Location {
+        uri,
+        range: lsp_types::Range {
+            start: ast_to_lsp_position(node_location.start),
+            end: ast_to_lsp_position(node_location.end),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flux::ast;
+    use flux::semantic::nodes::IdentifierExpr;
+    use flux::semantic::types::MonoType;
+    use flux::semantic::walk::Node;
+
+    use super::*;
+
+    #[test]
+    fn test_ast_to_lsp_position() {
+        let expected = lsp_types::Position {
+            line: 22,
+            character: 7,
+        };
+
+        let ast_position = ast::Position {
+            line: 23,
+            column: 8,
+        };
+        let result = ast_to_lsp_position(ast_position);
+
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_node_to_location() {
+        let expected = lsp_types::Location {
+            uri: lsp_types::Url::parse("file:///path/to/file.flux")
+                .unwrap(),
+            range: lsp_types::Range {
+                start: lsp_types::Position {
+                    line: 22,
+                    character: 7,
+                },
+                end: lsp_types::Position {
+                    line: 22,
+                    character: 8,
+                },
+            },
+        };
+
+        let expr = IdentifierExpr {
+            loc: ast::SourceLocation {
+                file: None,
+                start: ast::Position {
+                    line: 23,
+                    column: 8,
+                },
+                end: ast::Position {
+                    line: 23,
+                    column: 9,
+                },
+                source: None,
+            },
+            typ: MonoType::String,
+            name: "a".to_string(),
+        };
+        let node = Node::IdentifierExpr(&expr);
+
+        let result = node_to_location(
+            &node,
+            lsp_types::Url::parse("file:///path/to/file.flux")
+                .unwrap(),
+        );
+
+        assert_eq!(expected, result);
+    }
+}

--- a/src/handlers/goto_definition.rs
+++ b/src/handlers/goto_definition.rs
@@ -1,9 +1,9 @@
 use std::rc::Rc;
 
 use crate::cache::Cache;
+use crate::convert;
 use crate::handlers::{Error, RequestHandler};
 use crate::protocol::{PolymorphicRequest, Request, Response};
-use crate::shared::conversion::map_node_to_location;
 use crate::visitors::semantic::utils;
 use crate::visitors::semantic::{
     DefinitionFinderVisitor, NodeFinderVisitor,
@@ -63,8 +63,9 @@ fn find_scoped_definition(
                 let state = dvisitor.state.borrow();
 
                 if let Some(node) = state.node.clone() {
-                    let loc = map_node_to_location(uri, node);
-                    return Some(loc);
+                    return Some(convert::node_to_location(
+                        &node, uri,
+                    ));
                 }
             }
             _ => (),

--- a/src/handlers/references.rs
+++ b/src/handlers/references.rs
@@ -1,8 +1,8 @@
 use crate::cache::Cache;
+use crate::convert;
 use crate::handlers::find_node;
 use crate::handlers::{Error, RequestHandler};
 use crate::protocol::{PolymorphicRequest, Request, Response};
-use crate::shared::conversion::map_node_to_location;
 use crate::visitors::semantic::utils::create_semantic_package;
 use crate::visitors::semantic::{
     DefinitionFinderVisitor, IdentFinderVisitor,
@@ -103,11 +103,10 @@ pub fn find_references(
                 let identifiers = (*state).identifiers.clone();
 
                 for node in identifiers {
-                    let loc = map_node_to_location(
+                    locations.push(convert::node_to_location(
+                        &node,
                         uri.clone(),
-                        node.clone(),
-                    );
-                    locations.push(loc);
+                    ));
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate clap;
 
 mod cache;
+mod convert;
 mod handlers;
 mod protocol;
 #[cfg(feature = "lsp2")]

--- a/src/shared/conversion.rs
+++ b/src/shared/conversion.rs
@@ -1,35 +1,8 @@
 use flux::ast::check;
 use flux::ast::Package;
 use flux::parser::parse_string;
-use flux::semantic::walk::Node;
-
-use std::rc::Rc;
 
 use lsp_types as lsp;
-
-pub fn map_node_to_location(
-    uri: lsp::Url,
-    node: Rc<Node>,
-) -> lsp::Location {
-    let start_line = node.loc().start.line - 1;
-    let start_col = node.loc().start.column - 1;
-    let end_line = node.loc().end.line - 1;
-    let end_col = node.loc().end.column - 1;
-
-    lsp::Location {
-        uri,
-        range: lsp::Range {
-            start: lsp::Position {
-                line: start_line,
-                character: start_col,
-            },
-            end: lsp::Position {
-                line: end_line,
-                character: end_col,
-            },
-        },
-    }
-}
 
 pub fn create_file_node_from_text(
     uri: lsp::Url,


### PR DESCRIPTION
> Position in a text document expressed as zero-based line and zero-based character offset.

I genuinely feel kinda gaslit, because I thought for sure I read that it
was the opposite of what the spec says, but the spec says positions are
zero-based. This patch attempts to fix those issues, though I suspect
that it's actually going to be an ongoing process.