### PR TITLE
feat(lspower): Implement completion handler

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -2666,16 +2666,12 @@ fn find_dot_completions(
     let pos = params.text_document_position.position;
     let info = CompletionInfo::create(params, contents.clone())?;
 
-    if let Some(info) = info.clone() {
+    if let Some(info) = info {
         let imports = info.imports.clone();
 
         let mut list = vec![];
         let name = info.ident.clone();
-        get_specific_package_functions(
-            &mut list,
-            name,
-            imports.clone(),
-        );
+        get_specific_package_functions(&mut list, name, imports);
 
         let mut items = vec![];
         let obj_results = get_specific_object(
@@ -3194,13 +3190,12 @@ impl Completable for PackageResult {
         let mut additional_text_edits = vec![];
         let mut insert_text = self.name.clone();
 
-        let current_imports = imports
+        if imports
             .clone()
             .into_iter()
             .map(|x| x.path)
-            .collect::<Vec<String>>();
-
-        if !current_imports.contains(&self.full_name) {
+            .any(|x| x == self.full_name)
+        {
             let alias =
                 find_alias_name(imports, self.name.clone(), 1);
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,22 +1,50 @@
+#![allow(deprecated)]
 use std::collections::HashMap;
+use std::fmt;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-use flux::semantic::nodes::FunctionParameter;
+use flux::analyze;
+use flux::ast::walk::walk_rc;
+use flux::ast::walk::Node as AstNode;
+use flux::ast::{Expression, Package, PropertyKey, SourceLocation};
+use flux::parser::parse_string;
+use flux::semantic::nodes::Expression as SemanticExpression;
+use flux::semantic::nodes::{CallExpr, FunctionParameter};
+use flux::semantic::types::{MonoType, Record};
 use flux::semantic::walk;
-use log::{debug, error, info, warn};
-use lspower::jsonrpc::Result;
-use lspower::lsp;
-use lspower::LanguageServer;
+use flux::semantic::walk::Node as SemanticNode;
+use flux::semantic::walk::Visitor as SemanticVisitor;
+use flux::{imports, prelude};
 
-use crate::convert;
+use crate::convert::node_to_location;
 use crate::handlers::document_symbol::sort_symbols;
 use crate::handlers::signature_help::find_stdlib_signatures;
-use crate::handlers::{find_node, NodeFinderResult};
-use crate::visitors::semantic::{
-    DefinitionFinderVisitor, FoldFinderVisitor, IdentFinderVisitor,
-    NodeFinderVisitor, SymbolsVisitor,
+use crate::shared::ast::is_in_node;
+use crate::shared::get_package_name;
+use crate::shared::signatures::get_argument_names;
+use crate::shared::structs::Function;
+use crate::stdlib::{
+    create_function_signature, get_builtin_functions,
+    get_package_functions, get_package_infos,
 };
+use crate::visitors::ast::package_finder::{
+    PackageFinderVisitor, PackageInfo,
+};
+use crate::visitors::ast::{CallFinderVisitor, NodeFinderVisitor};
+use crate::visitors::semantic::NodeFinderVisitor as SemanticNodeFinderVisitor;
+use crate::visitors::semantic::{
+    DefinitionFinderVisitor, FoldFinderVisitor,
+    FunctionFinderVisitor, IdentFinderVisitor, Import,
+    ImportFinderVisitor, ObjectFunctionFinderVisitor, SymbolsVisitor,
+};
+
+use log::{debug, error, info, warn};
+
+use lspower::jsonrpc::Result as RpcResult;
+use lspower::{lsp, LanguageServer};
+
+const BUILTIN_PACKAGE: &str = "builtin";
 
 // The spec talks specifically about setting versions for files, but isn't
 // clear on how those versions are surfaced to the client, if ever. This
@@ -77,7 +105,7 @@ fn function_defines(
     params.iter().any(|param| param.key.name == name)
 }
 
-fn is_scope(name: &str, n: Rc<walk::Node<'_>>) -> bool {
+fn is_scope(name: &str, n: Rc<SemanticNode<'_>>) -> bool {
     let mut dvisitor = DefinitionFinderVisitor::new(name.to_string());
     walk::walk(&mut dvisitor, n.clone());
     let state = dvisitor.state.borrow();
@@ -91,20 +119,22 @@ fn find_references(
 ) -> Vec<lsp::Location> {
     if let Some(node) = result.node {
         let name = match node.as_ref() {
-            walk::Node::Identifier(ident) => ident.name.as_str(),
-            walk::Node::IdentifierExpr(ident) => ident.name.as_str(),
+            SemanticNode::Identifier(ident) => ident.name.as_str(),
+            SemanticNode::IdentifierExpr(ident) => {
+                ident.name.as_str()
+            }
             _ => return Vec::new(),
         };
 
         let mut path_iter = result.path.iter().rev();
-        let scope: Rc<walk::Node> =
+        let scope: Rc<SemanticNode> =
             match path_iter.find_map(|n| match n.as_ref() {
-                walk::Node::FunctionExpr(f)
+                SemanticNode::FunctionExpr(f)
                     if function_defines(name, &f.params) =>
                 {
                     Some(n)
                 }
-                walk::Node::Package(_) | walk::Node::File(_)
+                SemanticNode::Package(_) | walk::Node::File(_)
                     if is_scope(name, n.clone()) =>
                 {
                     Some(n)
@@ -211,7 +241,7 @@ impl LanguageServer for LspServer {
     async fn initialize(
         &self,
         _: lsp::InitializeParams,
-    ) -> Result<lsp::InitializeResult> {
+    ) -> RpcResult<lsp::InitializeResult> {
         Ok(lsp::InitializeResult {
             capabilities: lsp::ServerCapabilities {
                 call_hierarchy_provider: None,
@@ -291,7 +321,7 @@ impl LanguageServer for LspServer {
             }),
         })
     }
-    async fn shutdown(&self) -> Result<()> {
+    async fn shutdown(&self) -> RpcResult<()> {
         Ok(())
     }
     async fn did_open(
@@ -376,7 +406,7 @@ impl LanguageServer for LspServer {
     async fn signature_help(
         &self,
         params: lsp::SignatureHelpParams,
-    ) -> Result<Option<lsp::SignatureHelp>> {
+    ) -> RpcResult<Option<lsp::SignatureHelp>> {
         let key =
             params.text_document_position_params.text_document.uri;
         let store = self.store.lock().unwrap();
@@ -396,12 +426,12 @@ impl LanguageServer for LspServer {
 
         let pkg = parse_and_analyze(data);
         let node_finder_result = find_node(
-            walk::Node::Package(&pkg),
+            SemanticNode::Package(&pkg),
             params.text_document_position_params.position,
         );
 
         if let Some(node) = node_finder_result.node {
-            if let walk::Node::CallExpr(call) = node.as_ref() {
+            if let SemanticNode::CallExpr(call) = node.as_ref() {
                 let callee = call.callee.clone();
 
                 if let flux::semantic::nodes::Expression::Member(member) = callee.clone() {
@@ -437,7 +467,7 @@ impl LanguageServer for LspServer {
     async fn formatting(
         &self,
         params: lsp::DocumentFormattingParams,
-    ) -> Result<Option<Vec<lsp::TextEdit>>> {
+    ) -> RpcResult<Option<Vec<lsp::TextEdit>>> {
         let key = params.text_document.uri;
         let store = self.store.lock().unwrap();
         if !store.contains_key(&key) {
@@ -504,7 +534,7 @@ impl LanguageServer for LspServer {
     async fn folding_range(
         &self,
         params: lsp::FoldingRangeParams,
-    ) -> Result<Option<Vec<lsp::FoldingRange>>> {
+    ) -> RpcResult<Option<Vec<lsp::FoldingRange>>> {
         let key = params.text_document.uri;
         let store = self.store.lock().unwrap();
         if !store.contains_key(&key) {
@@ -519,7 +549,7 @@ impl LanguageServer for LspServer {
         let contents = store.get(&key).unwrap();
         let pkg = parse_and_analyze(contents.as_str());
         let mut visitor = FoldFinderVisitor::default();
-        let pkg_node = walk::Node::Package(&pkg);
+        let pkg_node = SemanticNode::Package(&pkg);
 
         walk::walk(&mut visitor, Rc::new(pkg_node));
 
@@ -542,7 +572,7 @@ impl LanguageServer for LspServer {
     async fn document_symbol(
         &self,
         params: lsp::DocumentSymbolParams,
-    ) -> Result<Option<lsp::DocumentSymbolResponse>> {
+    ) -> RpcResult<Option<lsp::DocumentSymbolResponse>> {
         let key = params.text_document.uri;
         let store = self.store.lock().unwrap();
         if !store.contains_key(&key) {
@@ -557,7 +587,7 @@ impl LanguageServer for LspServer {
 
         let contents = store.get(&key).unwrap();
         let pkg = parse_and_analyze(contents);
-        let pkg_node = walk::Node::Package(&pkg);
+        let pkg_node = SemanticNode::Package(&pkg);
         let mut visitor = SymbolsVisitor::new(key);
         walk::walk(&mut visitor, Rc::new(pkg_node));
 
@@ -573,7 +603,7 @@ impl LanguageServer for LspServer {
     async fn goto_definition(
         &self,
         params: lsp::GotoDefinitionParams,
-    ) -> Result<Option<lsp::GotoDefinitionResponse>> {
+    ) -> RpcResult<Option<lsp::GotoDefinitionResponse>> {
         let key =
             params.text_document_position_params.text_document.uri;
         let store = self.store.lock().unwrap();
@@ -588,8 +618,8 @@ impl LanguageServer for LspServer {
         }
         let contents = store.get(&key).unwrap();
         let pkg = parse_and_analyze(contents);
-        let pkg_node = walk::Node::Package(&pkg);
-        let mut visitor = NodeFinderVisitor::new(
+        let pkg_node = SemanticNode::Package(&pkg);
+        let mut visitor = SemanticNodeFinderVisitor::new(
             params.text_document_position_params.position,
         );
 
@@ -601,10 +631,10 @@ impl LanguageServer for LspServer {
 
         if let Some(node) = node {
             let name = match node.as_ref() {
-                walk::Node::Identifier(ident) => {
+                SemanticNode::Identifier(ident) => {
                     Some(ident.name.clone())
                 }
-                walk::Node::IdentifierExpr(ident) => {
+                SemanticNode::IdentifierExpr(ident) => {
                     Some(ident.name.clone())
                 }
                 _ => return Ok(None),
@@ -614,10 +644,10 @@ impl LanguageServer for LspServer {
                 let path_iter = path.iter().rev();
                 for n in path_iter {
                     match n.as_ref() {
-                        walk::Node::FunctionExpr(_)
-                        | walk::Node::Package(_)
-                        | walk::Node::File(_) => {
-                            if let walk::Node::FunctionExpr(f) =
+                        SemanticNode::FunctionExpr(_)
+                        | SemanticNode::Package(_)
+                        | SemanticNode::File(_) => {
+                            if let SemanticNode::FunctionExpr(f) =
                                 n.as_ref()
                             {
                                 for param in f.params.clone() {
@@ -665,7 +695,7 @@ impl LanguageServer for LspServer {
     async fn rename(
         &self,
         params: lsp::RenameParams,
-    ) -> Result<Option<lsp::WorkspaceEdit>> {
+    ) -> RpcResult<Option<lsp::WorkspaceEdit>> {
         let key =
             params.text_document_position.text_document.uri.clone();
         let store = self.store.lock().unwrap();
@@ -683,7 +713,7 @@ impl LanguageServer for LspServer {
         };
         let pkg = parse_and_analyze(contents);
         let node = find_node(
-            walk::Node::Package(&pkg),
+            SemanticNode::Package(&pkg),
             params.text_document_position.position,
         );
 
@@ -709,7 +739,7 @@ impl LanguageServer for LspServer {
     async fn references(
         &self,
         params: lsp::ReferenceParams,
-    ) -> Result<Option<Vec<lsp::Location>>> {
+    ) -> RpcResult<Option<Vec<lsp::Location>>> {
         let key =
             params.text_document_position.text_document.uri.clone();
         let store = self.store.lock().unwrap();
@@ -727,13 +757,12 @@ impl LanguageServer for LspServer {
         };
         let pkg = parse_and_analyze(contents);
         let node = find_node(
-            walk::Node::Package(&pkg),
+            SemanticNode::Package(&pkg),
             params.text_document_position.position,
         );
 
         Ok(Some(find_references(key, node)))
     }
-
     // XXX: rockstar (9 Aug 2021) - This implementation exists here *solely* for
     // compatibility with the previous server. This behavior is identical to it,
     // although very clearly kinda useless.
@@ -752,6 +781,73 @@ impl LanguageServer for LspServer {
         params: lsp::CompletionItem,
     ) -> Result<lsp::CompletionItem> {
         Ok(params)
+    }
+
+    async fn completion(
+        &self,
+        params: lsp::CompletionParams,
+    ) -> RpcResult<Option<lsp::CompletionResponse>> {
+        let key =
+            params.text_document_position.text_document.uri.clone();
+
+        // We need to clone here becase `params` is used later.
+        let store = self.store.lock().unwrap().clone();
+        let contents = match store.get(&key) {
+            Some(v) => v.to_string(),
+            None => {
+                error!(
+										"textDocument/completion called on unknown file {}",
+										key
+								);
+                return Err(lspower::jsonrpc::Error::invalid_params(
+                    format!("file not opened: {}", key),
+                ));
+            }
+        };
+
+        let items = if let Some(ctx) = params.context.clone() {
+            match (ctx.trigger_kind, ctx.trigger_character) {
+                (
+                    lsp::CompletionTriggerKind::TriggerCharacter,
+                    Some(c),
+                ) => match c.as_str() {
+                    "." => find_dot_completions(params, contents),
+                    // XXX(sean): All `find_arg_completions` does is look for bucket names
+                    // if the parameter name is "bucket". Since we don't currently
+                    // support bucket completions, this match arm is unnecessary.
+                    //
+                    // ":" => {
+                    //     find_arg_completions(params, contents)
+                    //         .await
+                    // }
+                    "(" | "," => find_param_completions(
+                        Some(c),
+                        params,
+                        contents,
+                    ),
+                    _ => find_completions(params, contents),
+                },
+                _ => find_completions(params, contents),
+            }
+        } else {
+            find_completions(params, contents)
+        };
+
+        let items = match items {
+            Ok(items) => items,
+            Err(e) => {
+                error!("error getting completion items: {}", e.msg);
+                return Err(lspower::jsonrpc::Error::invalid_params(
+                    format!(
+                        "error getting completion items: {}",
+                        e.msg
+                    ),
+                ));
+            }
+        };
+
+        let response = lsp::CompletionResponse::List(items);
+        Ok(Some(response))
     }
 }
 
@@ -1718,5 +1814,2422 @@ errorCounts
                 .unwrap();
 
         assert_eq!(params, result);
+    }
+    #[test]
+    fn test_package_completion() {
+        let fluxscript = r#"import "sql"
+
+sql."#;
+        let server = create_server();
+        open_file(&server, fluxscript.to_string());
+
+        let params = lsp::CompletionParams {
+            text_document_position: lsp::TextDocumentPositionParams {
+                text_document: lsp::TextDocumentIdentifier {
+                    uri: lsp::Url::parse(
+                        "file:///home/user/file.flux",
+                    )
+                    .unwrap(),
+                },
+                position: lsp::Position {
+                    line: 2,
+                    character: 3,
+                },
+            },
+            work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_token: None,
+            },
+            partial_result_params: lsp::PartialResultParams {
+                partial_result_token: None,
+            },
+            context: Some(lsp::CompletionContext {
+                trigger_kind:
+                    lsp::CompletionTriggerKind::TriggerCharacter,
+                trigger_character: Some(".".to_string()),
+            }),
+        };
+
+        let result = block_on(server.completion(params.clone()))
+            .unwrap()
+            .unwrap();
+
+        let len = match result.clone() {
+            lsp::CompletionResponse::List(l) => l.items.len(),
+            _ => unreachable!(),
+        };
+
+        assert_eq!(2, len);
+    }
+
+    #[test]
+    fn test_variable_completion() {
+        let fluxscript = r#" import "strings"
+import "csv"
+
+cal = 10
+env = "prod01-us-west-2"
+
+cool = (a) => a + 1
+
+c
+
+errorCounts = from(bucket:"kube-infra/monthly")
+    |> range(start: -3d)
+    |> filter(fn: (r) => r._measurement == "query_log" and
+                         r.error != "" and
+                         r._field == "responseSize" and
+                         r.env == env)
+    |> group(columns:["env", "error"])
+    |> count()
+    |> group(columns:["env", "_stop", "_start"])
+
+errorCounts
+    |> filter(fn: (r) => strings.containsStr(v: r.error, substr: "AppendMappedRecordWithNulls"))
+"#;
+        let server = create_server();
+        open_file(&server, fluxscript.to_string());
+
+        let params = lsp::CompletionParams {
+            text_document_position: lsp::TextDocumentPositionParams {
+                text_document: lsp::TextDocumentIdentifier {
+                    uri: lsp::Url::parse(
+                        "file:///home/user/file.flux",
+                    )
+                    .unwrap(),
+                },
+                position: lsp::Position {
+                    line: 8,
+                    character: 1,
+                },
+            },
+            work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_token: None,
+            },
+            partial_result_params: lsp::PartialResultParams {
+                partial_result_token: None,
+            },
+            context: Some(lsp::CompletionContext {
+                trigger_kind: lsp::CompletionTriggerKind::Invoked,
+                trigger_character: None,
+            }),
+        };
+
+        let result = block_on(server.completion(params.clone()))
+            .unwrap()
+            .unwrap();
+
+        let items = match result.clone() {
+            lsp::CompletionResponse::List(l) => l.items,
+            _ => unreachable!(),
+        };
+
+        assert_eq!(117, items.len());
+        assert_eq!(items.first().unwrap().label, "csv");
+        assert_eq!(items.last().unwrap().label, "cool (self)");
+    }
+
+    // TODO(sean): This test fails unless the line reading `ab = 10`
+    // in the flux script is commented out. The error is valid, but
+    // the lsp should be able to turn it into a diagnostic notification
+    // and continue to provide completion suggestions.
+    #[test]
+    fn test_option_object_members_completion() {
+        let fluxscript = r#"import "strings"
+import "csv"
+
+cal = 10
+env = "prod01-us-west-2"
+
+cool = (a) => a + 1
+
+option task = {
+  name: "foo",        // Name is required.
+  every: 1h,          // Task should be run at this interval.
+  delay: 10m,         // Delay scheduling this task by this duration.
+  cron: "0 2 * * *",  // Cron is a more sophisticated way to schedule. 'every' and 'cron' are mutually exclusive.
+  retry: 5,           // Number of times to retry a failed query.
+}
+
+task.
+
+ab = 10
+"#;
+        let server = create_server();
+        open_file(&server, fluxscript.to_string());
+
+        let params = lsp::CompletionParams {
+            text_document_position: lsp::TextDocumentPositionParams {
+                text_document: lsp::TextDocumentIdentifier {
+                    uri: lsp::Url::parse(
+                        "file:///home/user/file.flux",
+                    )
+                    .unwrap(),
+                },
+                position: lsp::Position {
+                    line: 16,
+                    character: 5,
+                },
+            },
+            work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_token: None,
+            },
+            partial_result_params: lsp::PartialResultParams {
+                partial_result_token: None,
+            },
+            context: Some(lsp::CompletionContext {
+                trigger_kind:
+                    lsp::CompletionTriggerKind::TriggerCharacter,
+                trigger_character: Some(".".to_string()),
+            }),
+        };
+
+        let result = block_on(server.completion(params.clone()))
+            .unwrap()
+            .unwrap();
+
+        let items = match result.clone() {
+            lsp::CompletionResponse::List(l) => l.items,
+            _ => unreachable!(),
+        };
+
+        let labels: Vec<&str> =
+            items.iter().map(|item| item.label.as_str()).collect();
+
+        let expected = vec![
+            "name (self)",
+            "every (self)",
+            "delay (self)",
+            "cron (self)",
+            "retry (self)",
+        ];
+
+        assert_eq!(expected, labels);
+    }
+
+    #[test]
+    fn test_option_function_completion() {
+        let fluxscript = r#"import "strings"
+import "csv"
+
+cal = 10
+env = "prod01-us-west-2"
+
+cool = (a) => a + 1
+
+option now = () => 2020-02-20T23:00:00Z
+
+n
+
+ab = 10
+"#;
+        let server = create_server();
+        open_file(&server, fluxscript.to_string());
+
+        let params = lsp::CompletionParams {
+            text_document_position: lsp::TextDocumentPositionParams {
+                text_document: lsp::TextDocumentIdentifier {
+                    uri: lsp::Url::parse(
+                        "file:///home/user/file.flux",
+                    )
+                    .unwrap(),
+                },
+                position: lsp::Position {
+                    line: 10,
+                    character: 1,
+                },
+            },
+            work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_token: None,
+            },
+            partial_result_params: lsp::PartialResultParams {
+                partial_result_token: None,
+            },
+            context: Some(lsp::CompletionContext {
+                trigger_kind: lsp::CompletionTriggerKind::Invoked,
+                trigger_character: None,
+            }),
+        };
+
+        let result = block_on(server.completion(params.clone()))
+            .unwrap()
+            .unwrap();
+
+        let items = match result.clone() {
+            lsp::CompletionResponse::List(l) => l.items,
+            _ => unreachable!(),
+        };
+
+        assert_eq!(117, items.len());
+        assert_eq!(
+            items.first().unwrap().label,
+            "contrib/RohanSreerama5/naiveBayesClassifier"
+        );
+        assert_eq!(items.last().unwrap().label, "now (self)");
+    }
+
+    #[test]
+    fn test_object_param_completion() {
+        let fluxscript = r#"obj = {
+	func: (name, age) => name + age
+}
+
+obj.func(
+		"#;
+        let server = create_server();
+        open_file(&server, fluxscript.to_string());
+
+        let params = lsp::CompletionParams {
+            text_document_position: lsp::TextDocumentPositionParams {
+                text_document: lsp::TextDocumentIdentifier {
+                    uri: lsp::Url::parse(
+                        "file:///home/user/file.flux",
+                    )
+                    .unwrap(),
+                },
+                position: lsp::Position {
+                    line: 4,
+                    character: 8,
+                },
+            },
+            work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_token: None,
+            },
+            partial_result_params: lsp::PartialResultParams {
+                partial_result_token: None,
+            },
+            context: Some(lsp::CompletionContext {
+                trigger_kind:
+                    lsp::CompletionTriggerKind::TriggerCharacter,
+                trigger_character: Some("(".to_string()),
+            }),
+        };
+
+        let result = block_on(server.completion(params.clone()))
+            .unwrap()
+            .unwrap();
+
+        let items = match result.clone() {
+            lsp::CompletionResponse::List(l) => l.items,
+            _ => unreachable!(),
+        };
+
+        let labels: Vec<&str> =
+            items.iter().map(|item| item.label.as_str()).collect();
+
+        let expected = vec!["name", "age"];
+
+        assert_eq!(expected, labels);
+    }
+
+    #[test]
+    fn test_param_completion() {
+        let fluxscript = r#"import "csv"
+
+csv.from(
+		"#;
+        let server = create_server();
+        open_file(&server, fluxscript.to_string());
+
+        let params = lsp::CompletionParams {
+            text_document_position: lsp::TextDocumentPositionParams {
+                text_document: lsp::TextDocumentIdentifier {
+                    uri: lsp::Url::parse(
+                        "file:///home/user/file.flux",
+                    )
+                    .unwrap(),
+                },
+                position: lsp::Position {
+                    line: 2,
+                    character: 8,
+                },
+            },
+            work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_token: None,
+            },
+            partial_result_params: lsp::PartialResultParams {
+                partial_result_token: None,
+            },
+            context: Some(lsp::CompletionContext {
+                trigger_kind:
+                    lsp::CompletionTriggerKind::TriggerCharacter,
+                trigger_character: Some("(".to_string()),
+            }),
+        };
+
+        let result = block_on(server.completion(params.clone()))
+            .unwrap()
+            .unwrap();
+
+        let items = match result.clone() {
+            lsp::CompletionResponse::List(l) => l.items,
+            _ => unreachable!(),
+        };
+
+        let labels: Vec<&str> =
+            items.iter().map(|item| item.label.as_str()).collect();
+
+        let expected = vec!["csv", "file", "mode", "url"];
+
+        assert_eq!(expected, labels);
+    }
+
+    #[test]
+    fn test_options_completion() {
+        let fluxscript = r#"import "strings"
+import "csv"
+
+cal = 10
+env = "prod01-us-west-2"
+
+cool = (a) => a + 1
+
+option task = {
+  name: "foo",        // Name is required.
+  every: 1h,          // Task should be run at this interval.
+  delay: 10m,         // Delay scheduling this task by this duration.
+  cron: "0 2 * * *",  // Cron is a more sophisticated way to schedule. 'every' and 'cron' are mutually exclusive.
+  retry: 5,           // Number of times to retry a failed query.
+}
+
+newNow = t
+
+errorCounts = from(bucket:"kube-infra/monthly")
+    |> range(start: -3d )
+    |> filter(fn: (r) => r._measurement == "query_log" and
+                         r.error != "" and
+                         r._field == "responseSize" and
+                         r.env == env)
+    |> group(columns:["env", "error"])
+    |> count()
+    |> group(columns:["env", "_stop", "_start"])
+
+errorCounts
+    |> filter(fn: (r) => strings.containsStr(v: r.error, substr: "AppendMappedRecordWithNulls"))
+
+"#;
+        let server = create_server();
+        open_file(&server, fluxscript.to_string());
+
+        let params = lsp::CompletionParams {
+            text_document_position: lsp::TextDocumentPositionParams {
+                text_document: lsp::TextDocumentIdentifier {
+                    uri: lsp::Url::parse(
+                        "file:///home/user/file.flux",
+                    )
+                    .unwrap(),
+                },
+                position: lsp::Position {
+                    line: 16,
+                    character: 10,
+                },
+            },
+            work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_token: None,
+            },
+            partial_result_params: lsp::PartialResultParams {
+                partial_result_token: None,
+            },
+            context: Some(lsp::CompletionContext {
+                trigger_kind: lsp::CompletionTriggerKind::Invoked,
+                trigger_character: None,
+            }),
+        };
+
+        let result = block_on(server.completion(params.clone()))
+            .unwrap()
+            .unwrap();
+
+        let items = match result.clone() {
+            lsp::CompletionResponse::List(l) => l.items,
+            _ => unreachable!(),
+        };
+
+        assert_eq!(123, items.len());
+        assert_eq!("task (self)", items.last().unwrap().label);
+    }
+}
+
+#[derive(Debug)]
+struct Error {
+    msg: String,
+}
+impl From<String> for Error {
+    fn from(s: String) -> Error {
+        Error { msg: s }
+    }
+}
+
+fn find_completions(
+    params: lsp::CompletionParams,
+    contents: String,
+) -> Result<lsp::CompletionList, Error> {
+    let uri = params.text_document_position.text_document.uri.clone();
+    let info =
+        CompletionInfo::create(params.clone(), contents.clone())?;
+
+    let mut items: Vec<lsp::CompletionItem> = vec![];
+
+    if let Some(info) = info {
+        match info.completion_type {
+            CompletionType::Generic => {
+                let mut stdlib_matches = get_stdlib_completions(
+                    info.ident.clone(),
+                    info.clone(),
+                );
+                items.append(&mut stdlib_matches);
+
+                let mut user_matches =
+                    get_user_matches(info, contents)?;
+
+                items.append(&mut user_matches);
+            }
+            CompletionType::Bad => {}
+            CompletionType::CallProperty(_func) => {
+                return find_param_completions(None, params, contents)
+            }
+            CompletionType::Import => {
+                let infos = get_package_infos();
+
+                let imports = get_imports_removed(
+                    uri,
+                    info.position,
+                    contents,
+                )?;
+
+                let mut items = vec![];
+                for info in infos {
+                    if !(&imports).iter().any(|x| x.path == info.name)
+                    {
+                        items.push(new_string_arg_completion(
+                            info.path,
+                            get_trigger(params.clone()),
+                        ));
+                    }
+                }
+
+                return Ok(lsp::CompletionList {
+                    is_incomplete: false,
+                    items,
+                });
+            }
+            CompletionType::ObjectMember(_obj) => {
+                return find_dot_completions(params, contents);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(lsp::CompletionList {
+        is_incomplete: false,
+        items,
+    })
+}
+
+#[derive(Clone)]
+enum CompletionType {
+    Generic,
+    Logical(flux::ast::Operator),
+    CallProperty(String),
+    ObjectMember(String),
+    Import,
+    Bad,
+}
+
+#[derive(Clone)]
+struct CompletionInfo {
+    completion_type: CompletionType,
+    ident: String,
+    position: lsp::Position,
+    uri: lsp::Url,
+    imports: Vec<Import>,
+    package: Option<PackageInfo>,
+}
+
+impl CompletionInfo {
+    fn create(
+        params: lsp::CompletionParams,
+        source: String,
+    ) -> Result<Option<CompletionInfo>, String> {
+        let uri =
+            params.text_document_position.text_document.uri.clone();
+        let position = params.text_document_position.position;
+
+        let pkg: Package =
+            parse_string(uri.as_str(), source.as_str()).into();
+        let walker = Rc::new(AstNode::File(&pkg.files[0]));
+        let visitor = NodeFinderVisitor::new(move_back(position, 1));
+
+        walk_rc(&visitor, walker);
+
+        let package = PackageFinderVisitor::find_package(
+            uri.clone(),
+            source.clone(),
+        )?;
+
+        let state = visitor.state.borrow();
+        let finder_node = (*state).node.clone();
+
+        if let Some(finder_node) = finder_node {
+            if let Some(parent) = finder_node.parent {
+                match parent.node.as_ref() {
+                    AstNode::MemberExpr(me) => {
+                        if let Expression::Identifier(obj) =
+                            me.object.clone()
+                        {
+                            return Ok(Some(CompletionInfo {
+                                completion_type:
+                                    CompletionType::ObjectMember(
+                                        obj.name.clone(),
+                                    ),
+                                ident: obj.name,
+                                position,
+                                uri: uri.clone(),
+                                imports: get_imports_removed(
+                                    uri, position, source,
+                                )?,
+                                package,
+                            }));
+                        }
+                    }
+                    AstNode::ImportDeclaration(_id) => {
+                        return Ok(Some(CompletionInfo {
+                            completion_type: CompletionType::Import,
+                            ident: "".to_string(),
+                            position,
+                            uri: uri.clone(),
+                            imports: get_imports_removed(
+                                uri, position, source,
+                            )?,
+                            package,
+                        }));
+                    }
+                    AstNode::BinaryExpr(be) => {
+                        match be.left.clone() {
+                            Expression::Identifier(left) => {
+                                let name = left.name;
+
+                                return Ok(Some(CompletionInfo {
+                                    completion_type:
+                                        CompletionType::Logical(
+                                            be.operator.clone(),
+                                        ),
+                                    ident: name,
+                                    position,
+                                    uri: uri.clone(),
+                                    imports: get_imports(
+                                        uri, position, source,
+                                    )?,
+                                    package,
+                                }));
+                            }
+                            Expression::Member(left) => {
+                                if let Expression::Identifier(ident) =
+                                    left.object
+                                {
+                                    let key = match left.property {
+                                        PropertyKey::Identifier(
+                                            ident,
+                                        ) => ident.name,
+                                        PropertyKey::StringLit(
+                                            lit,
+                                        ) => lit.value,
+                                    };
+
+                                    let name = format!(
+                                        "{}.{}",
+                                        ident.name, key
+                                    );
+
+                                    return Ok(Some(CompletionInfo {
+															completion_type:
+																CompletionType::Logical(
+																	be.operator.clone(),
+																),
+																ident: name,
+																position,
+																uri: uri.clone(),
+																imports: get_imports(
+																	uri, position, source,
+																)?,
+																package,
+														}));
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    _ => {}
+                }
+
+                if let Some(grandparent) = parent.parent {
+                    if let Some(greatgrandparent) = grandparent.parent
+                    {
+                        if let (
+                            AstNode::Property(prop),
+                            AstNode::ObjectExpr(_),
+                            AstNode::CallExpr(call),
+                        ) = (
+                            parent.node.as_ref(),
+                            grandparent.node.as_ref(),
+                            greatgrandparent.node.as_ref(),
+                        ) {
+                            let name = match prop.key.clone() {
+                                PropertyKey::Identifier(ident) => {
+                                    ident.name
+                                }
+                                PropertyKey::StringLit(lit) => {
+                                    lit.value
+                                }
+                            };
+
+                            if let Expression::Identifier(func) =
+                                call.callee.clone()
+                            {
+                                return Ok(Some(CompletionInfo {
+                                    completion_type:
+                                        CompletionType::CallProperty(
+                                            func.name,
+                                        ),
+                                    ident: name,
+                                    position,
+                                    uri: uri.clone(),
+                                    imports: get_imports(
+                                        uri, position, source,
+                                    )?,
+                                    package,
+                                }));
+                            }
+                        }
+                    }
+                }
+
+                match finder_node.node.as_ref() {
+                    AstNode::BinaryExpr(be) => {
+                        if let Expression::Identifier(left) =
+                            be.left.clone()
+                        {
+                            let name = left.name;
+
+                            return Ok(Some(CompletionInfo {
+                                completion_type:
+                                    CompletionType::Logical(
+                                        be.operator.clone(),
+                                    ),
+                                ident: name,
+                                position,
+                                uri: uri.clone(),
+                                imports: get_imports(
+                                    uri, position, source,
+                                )?,
+                                package,
+                            }));
+                        }
+                    }
+                    AstNode::Identifier(ident) => {
+                        let name = ident.name.clone();
+                        return Ok(Some(CompletionInfo {
+                            completion_type: CompletionType::Generic,
+                            ident: name,
+                            position,
+                            uri: uri.clone(),
+                            imports: get_imports(
+                                uri, position, source,
+                            )?,
+                            package,
+                        }));
+                    }
+                    AstNode::BadExpr(expr) => {
+                        let name = expr.text.clone();
+                        return Ok(Some(CompletionInfo {
+                            completion_type: CompletionType::Bad,
+                            ident: name,
+                            position,
+                            uri: uri.clone(),
+                            imports: get_imports(
+                                uri, position, source,
+                            )?,
+                            package,
+                        }));
+                    }
+                    AstNode::MemberExpr(mbr) => {
+                        if let Expression::Identifier(ident) =
+                            &mbr.object
+                        {
+                            return Ok(Some(CompletionInfo {
+                                completion_type:
+                                    CompletionType::Generic,
+                                ident: ident.name.clone(),
+                                position,
+                                uri: uri.clone(),
+                                imports: get_imports(
+                                    uri, position, source,
+                                )?,
+                                package,
+                            }));
+                        }
+                    }
+                    AstNode::CallExpr(c) => {
+                        if let Some(Expression::Identifier(ident)) =
+                            c.arguments.last()
+                        {
+                            return Ok(Some(CompletionInfo {
+                                completion_type:
+                                    CompletionType::Generic,
+                                ident: ident.name.clone(),
+                                position,
+                                uri: uri.clone(),
+                                imports: get_imports(
+                                    uri, position, source,
+                                )?,
+                                package,
+                            }));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+fn get_imports(
+    uri: lsp::Url,
+    pos: lsp::Position,
+    contents: String,
+) -> Result<Vec<Import>, String> {
+    let pkg = create_completion_package(uri, pos, contents)?;
+    let walker = Rc::new(SemanticNode::Package(&pkg));
+    let mut visitor = ImportFinderVisitor::default();
+
+    walk::walk(&mut visitor, walker);
+
+    let state = visitor.state.borrow();
+
+    Ok((*state).imports.clone())
+}
+
+fn get_imports_removed(
+    uri: lsp::Url,
+    pos: lsp::Position,
+    contents: String,
+) -> Result<Vec<Import>, String> {
+    let pkg = create_completion_package_removed(uri, pos, contents)?;
+    let walker = Rc::new(SemanticNode::Package(&pkg));
+    let mut visitor = ImportFinderVisitor::default();
+
+    walk::walk(&mut visitor, walker);
+
+    let state = visitor.state.borrow();
+
+    Ok((*state).imports.clone())
+}
+
+fn move_back(position: lsp::Position, count: u32) -> lsp::Position {
+    lsp::Position {
+        line: position.line,
+        character: position.character - count,
+    }
+}
+
+fn get_user_matches(
+    info: CompletionInfo,
+    contents: String,
+) -> Result<Vec<lsp::CompletionItem>, Error> {
+    let completables = get_user_completables(
+        info.uri.clone(),
+        info.position,
+        contents,
+    )?;
+
+    let mut result: Vec<lsp::CompletionItem> = vec![];
+    for x in completables {
+        result.push(x.completion_item(info.clone()))
+    }
+
+    Ok(result)
+}
+
+fn get_trigger(params: lsp::CompletionParams) -> Option<String> {
+    if let Some(context) = params.context {
+        context.trigger_character
+    } else {
+        None
+    }
+}
+
+fn find_dot_completions(
+    params: lsp::CompletionParams,
+    contents: String,
+) -> Result<lsp::CompletionList, Error> {
+    let uri = params.text_document_position.text_document.uri.clone();
+    let pos = params.text_document_position.position;
+    let info = CompletionInfo::create(params, contents.clone())?;
+
+    if let Some(info) = info.clone() {
+        let imports = info.imports.clone();
+
+        let mut list = vec![];
+        let name = info.ident.clone();
+        get_specific_package_functions(
+            &mut list,
+            name,
+            imports.clone(),
+        );
+
+        let mut items = vec![];
+        let obj_results = get_specific_object(
+            info.ident.clone(),
+            pos,
+            uri,
+            contents,
+        )?;
+
+        for completable in obj_results.into_iter() {
+            items.push(completable.completion_item(info.clone()));
+        }
+
+        for item in list.into_iter() {
+            items.push(item.completion_item(info.clone()));
+        }
+
+        return Ok(lsp::CompletionList {
+            is_incomplete: false,
+            items,
+        });
+    }
+
+    Ok(lsp::CompletionList {
+        is_incomplete: false,
+        items: vec![],
+    })
+}
+
+fn new_string_arg_completion(
+    value: String,
+    trigger: Option<String>,
+) -> lsp::CompletionItem {
+    let trigger = trigger.unwrap_or_else(|| "".to_string());
+    let insert_text = if trigger == "\"" {
+        value
+    } else {
+        format!("\"{}\"", value)
+    };
+
+    lsp::CompletionItem {
+        deprecated: None,
+        commit_characters: None,
+        detail: None,
+        label: insert_text.clone(),
+        additional_text_edits: None,
+        filter_text: None,
+        insert_text: Some(insert_text),
+        documentation: None,
+        sort_text: None,
+        preselect: None,
+        insert_text_format: Some(lsp::InsertTextFormat::Snippet),
+        text_edit: None,
+        kind: Some(lsp::CompletionItemKind::Value),
+        command: None,
+        data: None,
+        insert_text_mode: None,
+        tags: None,
+    }
+}
+
+fn get_user_completables(
+    uri: lsp::Url,
+    pos: lsp::Position,
+    contents: String,
+) -> Result<Vec<Arc<dyn Completable>>, Error> {
+    println!("getting user completables");
+    let pkg = create_completion_package(uri, pos, contents)?;
+    let walker = Rc::new(SemanticNode::Package(&pkg));
+    let mut visitor = CompletableFinderVisitor::new(pos);
+
+    walk::walk(&mut visitor, walker);
+
+    if let Ok(state) = visitor.state.lock() {
+        return Ok((*state).completables.clone());
+    }
+
+    Err(Error {
+        msg: "failed to get completables".to_string(),
+    })
+}
+
+fn get_stdlib_completions(
+    name: String,
+    info: CompletionInfo,
+) -> Vec<lsp::CompletionItem> {
+    let mut matches = vec![];
+    let completes = get_stdlib();
+
+    for c in completes.into_iter() {
+        if c.matches(name.clone(), info.clone()) {
+            matches.push(c.completion_item(info.clone()));
+        }
+    }
+
+    matches
+}
+
+fn find_param_completions(
+    trigger: Option<String>,
+    params: lsp::CompletionParams,
+    source: String,
+) -> Result<lsp::CompletionList, Error> {
+    let uri = params.text_document_position.text_document.uri;
+    let position = params.text_document_position.position;
+
+    let pkg: Package =
+        parse_string(uri.as_str(), source.as_str()).into();
+    let walker = Rc::new(AstNode::File(&pkg.files[0]));
+    let visitor = CallFinderVisitor::new(move_back(position, 1));
+
+    walk_rc(&visitor, walker);
+
+    let state = visitor.state.borrow();
+    let node = (*state).node.clone();
+    let mut items: Vec<String> = vec![];
+
+    if let Some(node) = node {
+        if let AstNode::CallExpr(call) = node.as_ref() {
+            let provided = get_provided_arguments(call);
+
+            if let Expression::Identifier(ident) = call.callee.clone()
+            {
+                items.extend(get_function_params(
+                    ident.name.clone(),
+                    get_builtin_functions(),
+                    provided.clone(),
+                ));
+
+                if let Ok(user_functions) = get_user_functions(
+                    uri.clone(),
+                    position,
+                    source.clone(),
+                ) {
+                    items.extend(get_function_params(
+                        ident.name,
+                        user_functions,
+                        provided.clone(),
+                    ));
+                }
+            }
+            if let Expression::Member(me) = call.callee.clone() {
+                if let Expression::Identifier(ident) = me.object {
+                    let package_functions =
+                        get_package_functions(ident.name.clone());
+
+                    let object_functions = get_object_functions(
+                        uri, position, ident.name, source,
+                    )?;
+
+                    let key = match me.property {
+                        PropertyKey::Identifier(i) => i.name,
+                        PropertyKey::StringLit(l) => l.value,
+                    };
+
+                    items.extend(get_function_params(
+                        key.clone(),
+                        package_functions,
+                        provided.clone(),
+                    ));
+
+                    items.extend(get_function_params(
+                        key,
+                        object_functions,
+                        provided,
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(lsp::CompletionList {
+        is_incomplete: false,
+        items: items
+            .into_iter()
+            .map(|x| new_param_completion(x, trigger.clone()))
+            .collect(),
+    })
+}
+
+fn get_specific_package_functions(
+    list: &mut Vec<Box<dyn Completable>>,
+    name: String,
+    current_imports: Vec<Import>,
+) {
+    let env = imports().unwrap();
+
+    if let Some(import) =
+        current_imports.into_iter().find(|x| x.alias == name)
+    {
+        for (key, val) in env.values {
+            if key == import.path {
+                walk_package(key, list, val.expr);
+            }
+        }
+    } else {
+        for (key, val) in env.values {
+            if let Some(package_name) = get_package_name(key.clone())
+            {
+                if package_name == name {
+                    walk_package(key, list, val.expr);
+                }
+            }
+        }
+    }
+}
+
+fn get_specific_object(
+    name: String,
+    pos: lsp::Position,
+    uri: lsp::Url,
+    contents: String,
+) -> Result<Vec<Arc<dyn Completable>>, Error> {
+    let pkg = create_completion_package_removed(uri, pos, contents)?;
+    let walker = Rc::new(SemanticNode::Package(&pkg));
+    let mut visitor = CompletableObjectFinderVisitor::new(name);
+
+    walk::walk(&mut visitor, walker);
+
+    if let Ok(state) = visitor.state.lock() {
+        return Ok(state.completables.clone());
+    }
+
+    Ok(vec![])
+}
+
+fn get_provided_arguments(call: &flux::ast::CallExpr) -> Vec<String> {
+    let mut provided = vec![];
+    if let Some(Expression::Object(obj)) = call.arguments.first() {
+        for prop in obj.properties.clone() {
+            match prop.key {
+                flux::ast::PropertyKey::Identifier(ident) => {
+                    provided.push(ident.name)
+                }
+                flux::ast::PropertyKey::StringLit(lit) => {
+                    provided.push(lit.value)
+                }
+            };
+        }
+    }
+
+    provided
+}
+
+fn get_function_params(
+    name: String,
+    functions: Vec<Function>,
+    provided: Vec<String>,
+) -> Vec<String> {
+    functions.into_iter().filter(|f| f.name == name).fold(
+        vec![],
+        |mut acc, f| {
+            acc.extend(
+                f.params
+                    .into_iter()
+                    .filter(|p| !provided.contains(p)),
+            );
+            acc
+        },
+    )
+}
+
+fn get_user_functions(
+    uri: lsp::Url,
+    pos: lsp::Position,
+    source: String,
+) -> Result<Vec<Function>, Error> {
+    let pkg = create_completion_package(uri, pos, source)?;
+    let walker = Rc::new(SemanticNode::Package(&pkg));
+    let mut visitor = FunctionFinderVisitor::new(pos);
+
+    walk::walk(&mut visitor, walker);
+
+    if let Ok(state) = visitor.state.lock() {
+        return Ok((*state).functions.clone());
+    }
+
+    Err(Error {
+        msg: "failed to get completables".to_string(),
+    })
+}
+
+fn get_object_functions(
+    uri: lsp::Url,
+    pos: lsp::Position,
+    object: String,
+    contents: String,
+) -> Result<Vec<Function>, Error> {
+    let pkg = create_completion_package(uri, pos, contents)?;
+    let walker = Rc::new(SemanticNode::Package(&pkg));
+    let mut visitor = ObjectFunctionFinderVisitor::default();
+
+    walk::walk(&mut visitor, walker);
+
+    if let Ok(state) = visitor.state.lock() {
+        return Ok(state
+            .results
+            .clone()
+            .into_iter()
+            .filter(|obj| obj.object == object)
+            .map(|obj| obj.function)
+            .collect());
+    }
+
+    Ok(vec![])
+}
+
+fn new_param_completion(
+    name: String,
+    trigger: Option<String>,
+) -> lsp::CompletionItem {
+    let insert_text = if let Some(trigger) = trigger {
+        if trigger == "(" {
+            format!("{}: ", name)
+        } else {
+            format!(" {}: ", name)
+        }
+    } else {
+        format!("{}: ", name)
+    };
+
+    lsp::CompletionItem {
+        deprecated: None,
+        commit_characters: None,
+        detail: None,
+        label: name,
+        additional_text_edits: None,
+        filter_text: None,
+        insert_text: Some(insert_text),
+        documentation: None,
+        sort_text: None,
+        preselect: None,
+        insert_text_format: Some(lsp::InsertTextFormat::Snippet),
+        text_edit: None,
+        kind: Some(lsp::CompletionItemKind::Field),
+        command: None,
+        data: None,
+        insert_text_mode: None,
+        tags: None,
+    }
+}
+
+fn walk_package(
+    package: String,
+    list: &mut Vec<Box<dyn Completable>>,
+    t: MonoType,
+) {
+    if let MonoType::Record(record) = t {
+        if let Record::Extension { head, tail } = *record {
+            match head.v {
+                MonoType::Fun(f) => {
+                    list.push(Box::new(FunctionResult {
+                        name: head.k,
+                        package: package.clone(),
+                        signature: create_function_signature(
+                            (*f).clone(),
+                        ),
+                        required_args: get_argument_names(f.req),
+                        optional_args: get_argument_names(f.opt),
+                        package_name: get_package_name(
+                            package.clone(),
+                        ),
+                    }));
+                }
+                MonoType::Int => {
+                    list.push(Box::new(VarResult {
+                        name: head.k,
+                        var_type: VarType::Int,
+                        package: package.clone(),
+                        package_name: get_package_name(
+                            package.clone(),
+                        ),
+                    }));
+                }
+                MonoType::Float => {
+                    list.push(Box::new(VarResult {
+                        name: head.k,
+                        var_type: VarType::Float,
+                        package: package.clone(),
+                        package_name: get_package_name(
+                            package.clone(),
+                        ),
+                    }));
+                }
+                MonoType::Bool => {
+                    list.push(Box::new(VarResult {
+                        name: head.k,
+                        var_type: VarType::Bool,
+                        package: package.clone(),
+                        package_name: get_package_name(
+                            package.clone(),
+                        ),
+                    }));
+                }
+                MonoType::Arr(_) => {
+                    list.push(Box::new(VarResult {
+                        name: head.k,
+                        var_type: VarType::Array,
+                        package: package.clone(),
+                        package_name: get_package_name(
+                            package.clone(),
+                        ),
+                    }));
+                }
+                MonoType::Bytes => {
+                    list.push(Box::new(VarResult {
+                        name: head.k,
+                        var_type: VarType::Bytes,
+                        package: package.clone(),
+                        package_name: get_package_name(
+                            package.clone(),
+                        ),
+                    }));
+                }
+                MonoType::Duration => {
+                    list.push(Box::new(VarResult {
+                        name: head.k,
+                        var_type: VarType::Duration,
+                        package: package.clone(),
+                        package_name: get_package_name(
+                            package.clone(),
+                        ),
+                    }));
+                }
+                MonoType::Regexp => {
+                    list.push(Box::new(VarResult {
+                        name: head.k,
+                        var_type: VarType::Regexp,
+                        package: package.clone(),
+                        package_name: get_package_name(
+                            package.clone(),
+                        ),
+                    }));
+                }
+                MonoType::String => {
+                    list.push(Box::new(VarResult {
+                        name: head.k,
+                        var_type: VarType::String,
+                        package: package.clone(),
+                        package_name: get_package_name(
+                            package.clone(),
+                        ),
+                    }));
+                }
+                _ => {}
+            }
+
+            walk_package(package, list, tail);
+        }
+    }
+}
+
+trait Completable {
+    fn completion_item(
+        &self,
+        info: CompletionInfo,
+    ) -> lsp::CompletionItem;
+    fn matches(&self, text: String, info: CompletionInfo) -> bool;
+}
+
+impl Completable for PackageResult {
+    fn completion_item(
+        &self,
+        info: CompletionInfo,
+    ) -> lsp::CompletionItem {
+        let imports = info.imports;
+        let mut additional_text_edits = vec![];
+        let mut insert_text = self.name.clone();
+
+        let current_imports = imports
+            .clone()
+            .into_iter()
+            .map(|x| x.path)
+            .collect::<Vec<String>>();
+
+        if !current_imports.contains(&self.full_name) {
+            let alias =
+                find_alias_name(imports, self.name.clone(), 1);
+
+            let new_text = if let Some(alias) = alias {
+                insert_text = alias.clone();
+                format!("import {} \"{}\"\n", alias, self.full_name)
+            } else {
+                format!("import \"{}\"\n", self.full_name)
+            };
+
+            let line = match info.package {
+                Some(pi) => pi.position.line + 1,
+                None => 0,
+            };
+
+            additional_text_edits.push(lsp::TextEdit {
+                new_text,
+                range: lsp::Range {
+                    start: lsp::Position { character: 0, line },
+                    end: lsp::Position { character: 0, line },
+                },
+            })
+        } else {
+            for import in imports {
+                if self.full_name == import.path {
+                    insert_text = import.alias;
+                }
+            }
+        }
+
+        println!(
+            "Calling completion_item on PackageResult with name {}",
+            self.full_name
+        );
+        lsp::CompletionItem {
+            label: self.full_name.clone(),
+            additional_text_edits: Some(additional_text_edits),
+            commit_characters: None,
+            deprecated: None,
+            detail: Some("Package".to_string()),
+            documentation: Some(lsp::Documentation::String(
+                self.full_name.clone(),
+            )),
+            filter_text: Some(self.name.clone()),
+            insert_text: Some(insert_text),
+            insert_text_format: Some(
+                lsp::InsertTextFormat::PlainText,
+            ),
+            kind: Some(lsp::CompletionItemKind::Module),
+            preselect: None,
+            sort_text: Some(self.name.clone()),
+            text_edit: None,
+            command: None,
+            data: None,
+            insert_text_mode: None,
+            tags: None,
+        }
+    }
+
+    fn matches(&self, text: String, _info: CompletionInfo) -> bool {
+        if !text.ends_with('.') {
+            let name = self.name.to_lowercase();
+            let mtext = text.to_lowercase();
+            return name.starts_with(mtext.as_str());
+        }
+
+        false
+    }
+}
+
+impl Completable for FunctionResult {
+    fn completion_item(
+        &self,
+        info: CompletionInfo,
+    ) -> lsp::CompletionItem {
+        let imports = info.imports;
+        let mut additional_text_edits = vec![];
+
+        let contains_pkg =
+            imports.into_iter().any(|x| self.package == x.path);
+
+        if !contains_pkg && self.package != BUILTIN_PACKAGE {
+            additional_text_edits.push(lsp::TextEdit {
+                new_text: format!("import \"{}\"\n", self.package),
+                range: lsp::Range {
+                    start: lsp::Position {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: lsp::Position {
+                        line: 0,
+                        character: 0,
+                    },
+                },
+            })
+        }
+
+        lsp::CompletionItem {
+            label: self.name.clone(),
+            additional_text_edits: Some(additional_text_edits),
+            commit_characters: None,
+            deprecated: None,
+            detail: Some(self.signature.clone()),
+            documentation: None,
+            filter_text: Some(self.name.clone()),
+            insert_text: None,
+            insert_text_format: Some(lsp::InsertTextFormat::Snippet),
+            kind: Some(lsp::CompletionItemKind::Function),
+            preselect: None,
+            sort_text: Some(self.name.clone()),
+            text_edit: None,
+            command: None,
+            data: None,
+            insert_text_mode: None,
+            tags: None,
+        }
+    }
+
+    fn matches(&self, text: String, info: CompletionInfo) -> bool {
+        let imports = info.imports;
+        if self.package == BUILTIN_PACKAGE && !text.ends_with('.') {
+            return true;
+        }
+
+        if !imports
+            .clone()
+            .into_iter()
+            .any(|x| self.package == x.path)
+        {
+            return false;
+        }
+
+        if text.ends_with('.') {
+            let mtext = text[..text.len() - 1].to_string();
+            return imports
+                .into_iter()
+                .any(|import| import.alias == mtext);
+        }
+
+        false
+    }
+}
+
+impl Completable for CompletionVarResult {
+    fn completion_item(
+        &self,
+        _info: CompletionInfo,
+    ) -> lsp::CompletionItem {
+        println!("Calling completion_item on CompletionVarResult with name `{}`", self.name);
+        lsp::CompletionItem {
+            label: format!("{} ({})", self.name, "self".to_string()),
+            additional_text_edits: None,
+            commit_characters: None,
+            deprecated: None,
+            detail: Some(self.detail()),
+            documentation: Some(lsp::Documentation::String(
+                "from self".to_string(),
+            )),
+            filter_text: Some(self.name.clone()),
+            insert_text: Some(self.name.clone()),
+            insert_text_format: Some(
+                lsp::InsertTextFormat::PlainText,
+            ),
+            kind: Some(lsp::CompletionItemKind::Variable),
+            preselect: None,
+            sort_text: Some(self.name.clone()),
+            text_edit: None,
+            command: None,
+            data: None,
+            insert_text_mode: None,
+            tags: None,
+        }
+    }
+
+    fn matches(&self, _text: String, _info: CompletionInfo) -> bool {
+        true
+    }
+}
+
+fn get_stdlib() -> Vec<Box<dyn Completable>> {
+    let mut list = vec![];
+
+    get_packages(&mut list);
+    get_builtins(&mut list);
+
+    list
+}
+
+fn get_packages(list: &mut Vec<Box<dyn Completable>>) {
+    let env = imports().unwrap();
+
+    for (key, _val) in env.values {
+        add_package_result(key, list);
+    }
+}
+
+fn get_builtins(list: &mut Vec<Box<dyn Completable>>) {
+    let env = prelude().unwrap();
+
+    for (key, val) in env.values {
+        match val.expr {
+            MonoType::Fun(f) => list.push(Box::new(FunctionResult {
+                package: BUILTIN_PACKAGE.to_string(),
+                package_name: None,
+                name: key.clone(),
+                signature: create_function_signature((*f).clone()),
+                required_args: get_argument_names(f.req),
+                optional_args: get_argument_names(f.opt),
+            })),
+            MonoType::String => list.push(Box::new(VarResult {
+                name: key.clone(),
+                package: BUILTIN_PACKAGE.to_string(),
+                package_name: None,
+                var_type: VarType::String,
+            })),
+            MonoType::Int => list.push(Box::new(VarResult {
+                name: key.clone(),
+                package: BUILTIN_PACKAGE.to_string(),
+                package_name: None,
+                var_type: VarType::Int,
+            })),
+            MonoType::Float => list.push(Box::new(VarResult {
+                name: key.clone(),
+                package: BUILTIN_PACKAGE.to_string(),
+                package_name: None,
+                var_type: VarType::Float,
+            })),
+            MonoType::Arr(_) => list.push(Box::new(VarResult {
+                name: key.clone(),
+                package: BUILTIN_PACKAGE.to_string(),
+                package_name: None,
+                var_type: VarType::Array,
+            })),
+            MonoType::Bool => list.push(Box::new(VarResult {
+                name: key.clone(),
+                package: BUILTIN_PACKAGE.to_string(),
+                package_name: None,
+                var_type: VarType::Bool,
+            })),
+            MonoType::Bytes => list.push(Box::new(VarResult {
+                name: key.clone(),
+                package: BUILTIN_PACKAGE.to_string(),
+                package_name: None,
+                var_type: VarType::Bytes,
+            })),
+            MonoType::Duration => list.push(Box::new(VarResult {
+                name: key.clone(),
+                package: BUILTIN_PACKAGE.to_string(),
+                package_name: None,
+                var_type: VarType::Duration,
+            })),
+            MonoType::Uint => list.push(Box::new(VarResult {
+                name: key.clone(),
+                package: BUILTIN_PACKAGE.to_string(),
+                package_name: None,
+                var_type: VarType::Uint,
+            })),
+            MonoType::Regexp => list.push(Box::new(VarResult {
+                name: key.clone(),
+                package: BUILTIN_PACKAGE.to_string(),
+                package_name: None,
+                var_type: VarType::Regexp,
+            })),
+            MonoType::Time => list.push(Box::new(VarResult {
+                name: key.clone(),
+                package: BUILTIN_PACKAGE.to_string(),
+                package_name: None,
+                var_type: VarType::Time,
+            })),
+            _ => {}
+        }
+    }
+}
+
+fn find_alias_name(
+    imports: Vec<Import>,
+    name: String,
+    iteration: i32,
+) -> Option<String> {
+    let first_iteration = iteration == 1;
+    let pkg_name = if first_iteration {
+        name.clone()
+    } else {
+        format!("{}{}", name, iteration)
+    };
+
+    for import in imports.clone() {
+        if import.alias == pkg_name {
+            return find_alias_name(imports, name, iteration + 1);
+        }
+
+        if let Some(initial_name) = import.initial_name {
+            if initial_name == pkg_name && first_iteration {
+                return find_alias_name(imports, name, iteration + 1);
+            }
+        }
+    }
+
+    if first_iteration {
+        return None;
+    }
+
+    Some(format!("{}{}", name, iteration))
+}
+
+fn add_package_result(
+    name: String,
+    list: &mut Vec<Box<dyn Completable>>,
+) {
+    let package_name = get_package_name(name.clone());
+    if let Some(package_name) = package_name {
+        list.push(Box::new(PackageResult {
+            name: package_name,
+            full_name: name,
+        }));
+    }
+}
+
+impl PackageFinderVisitor {
+    fn find_package(
+        uri: lsp::Url,
+        contents: String,
+    ) -> Result<Option<PackageInfo>, String> {
+        let package = create_ast_package(uri, contents)?;
+        for file in package.files {
+            let walker = Rc::new(AstNode::File(&file));
+            let visitor = PackageFinderVisitor::default();
+
+            walk_rc(&visitor, walker);
+
+            let state = visitor.state.borrow();
+            if let Some(info) = state.info.clone() {
+                return Ok(Some(info));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+fn create_ast_package(
+    uri: lsp::Url,
+    source: String,
+) -> Result<flux::ast::Package, String> {
+    let mut pkg: Package =
+        parse_string(uri.as_str(), source.as_str()).into();
+    pkg.files.sort_by(|a, _b| {
+        if a.name == uri.as_str() {
+            std::cmp::Ordering::Greater
+        } else {
+            std::cmp::Ordering::Less
+        }
+    });
+
+    Ok(pkg)
+}
+
+#[derive(Default)]
+struct CompletableFinderState {
+    completables: Vec<Arc<dyn Completable>>,
+}
+
+struct CompletableFinderVisitor {
+    pos: lsp::Position,
+    state: Arc<Mutex<CompletableFinderState>>,
+}
+
+impl<'a> SemanticVisitor<'a> for CompletableFinderVisitor {
+    fn visit(&mut self, node: Rc<SemanticNode<'a>>) -> bool {
+        if let Ok(mut state) = self.state.lock() {
+            let loc = node.loc();
+
+            if defined_after(loc, self.pos) {
+                return true;
+            }
+
+            if let SemanticNode::ImportDeclaration(id) = node.as_ref()
+            {
+                if let Some(alias) = id.alias.clone() {
+                    (*state).completables.push(Arc::new(
+                        ImportAliasResult::new(
+                            id.path.value.clone(),
+                            alias.name,
+                        ),
+                    ));
+                }
+            }
+
+            if let SemanticNode::VariableAssgn(assgn) = node.as_ref()
+            {
+                let name = assgn.id.name.clone();
+                println!("VARIABLE ASSIGNMENT {}", name);
+                if let Some(var_type) = get_var_type(&assgn.init) {
+                    (*state).completables.push(Arc::new(
+                        CompletionVarResult {
+                            var_type,
+                            name: name.clone(),
+                        },
+                    ));
+                }
+
+                if let Some(fun) =
+                    create_function_result(name, &assgn.init)
+                {
+                    (*state).completables.push(Arc::new(fun));
+                }
+            }
+
+            if let SemanticNode::OptionStmt(opt) = node.as_ref() {
+                if let flux::semantic::nodes::Assignment::Variable(
+                    var_assign,
+                ) = &opt.assignment
+                {
+                    let name = var_assign.id.name.clone();
+                    if let Some(var_type) =
+                        get_var_type(&var_assign.init)
+                    {
+                        (*state).completables.push(Arc::new(
+                            CompletionVarResult { name, var_type },
+                        ));
+
+                        return false;
+                    }
+
+                    if let Some(fun) =
+                        create_function_result(name, &var_assign.init)
+                    {
+                        (*state).completables.push(Arc::new(fun));
+                        return false;
+                    }
+                }
+            }
+        }
+
+        true
+    }
+}
+
+impl CompletableFinderVisitor {
+    fn new(pos: lsp::Position) -> Self {
+        CompletableFinderVisitor {
+            state: Arc::new(Mutex::new(
+                CompletableFinderState::default(),
+            )),
+            pos,
+        }
+    }
+}
+
+fn defined_after(loc: &SourceLocation, pos: lsp::Position) -> bool {
+    if loc.start.line > pos.line + 1
+        || (loc.start.line == pos.line + 1
+            && loc.start.column > pos.character + 1)
+    {
+        return true;
+    }
+
+    false
+}
+
+#[derive(Clone)]
+struct ImportAliasResult {
+    path: String,
+    alias: String,
+}
+
+impl ImportAliasResult {
+    fn new(path: String, alias: String) -> Self {
+        ImportAliasResult { path, alias }
+    }
+}
+
+impl Completable for ImportAliasResult {
+    fn completion_item(
+        &self,
+        _info: CompletionInfo,
+    ) -> lsp::CompletionItem {
+        lsp::CompletionItem {
+            label: format!("{} ({})", self.alias, "self".to_string()),
+            additional_text_edits: None,
+            commit_characters: None,
+            deprecated: None,
+            detail: Some("Package".to_string()),
+            documentation: Some(lsp::Documentation::String(format!(
+                "from {}",
+                self.path
+            ))),
+            filter_text: Some(self.alias.clone()),
+            insert_text: Some(self.alias.clone()),
+            insert_text_format: Some(lsp::InsertTextFormat::Snippet),
+            kind: Some(lsp::CompletionItemKind::Module),
+            preselect: None,
+            sort_text: Some(self.alias.clone()),
+            text_edit: None,
+
+            command: None,
+            data: None,
+            insert_text_mode: None,
+            tags: None,
+        }
+    }
+
+    fn matches(&self, _text: String, _info: CompletionInfo) -> bool {
+        true
+    }
+}
+
+fn get_var_type(
+    expr: &SemanticExpression,
+) -> Option<CompletionVarType> {
+    match expr.type_of() {
+        MonoType::Duration => {
+            return Some(CompletionVarType::Duration)
+        }
+        MonoType::Int => return Some(CompletionVarType::Int),
+        MonoType::Bool => return Some(CompletionVarType::Bool),
+        MonoType::Float => return Some(CompletionVarType::Float),
+        MonoType::String => return Some(CompletionVarType::String),
+        MonoType::Arr(_) => return Some(CompletionVarType::Array),
+        MonoType::Regexp => return Some(CompletionVarType::Regexp),
+        _ => {}
+    }
+
+    match expr {
+        SemanticExpression::Object(_) => {
+            Some(CompletionVarType::Object)
+        }
+        SemanticExpression::Call(c) => {
+            let result_type = follow_function_pipes(c);
+
+            match result_type {
+                MonoType::Int => Some(CompletionVarType::Int),
+                MonoType::Float => Some(CompletionVarType::Float),
+                MonoType::Bool => Some(CompletionVarType::Bool),
+                MonoType::Arr(_) => Some(CompletionVarType::Array),
+                MonoType::Duration => {
+                    Some(CompletionVarType::Duration)
+                }
+                MonoType::Record(_) => {
+                    Some(CompletionVarType::Record)
+                }
+                MonoType::String => Some(CompletionVarType::String),
+                MonoType::Uint => Some(CompletionVarType::Uint),
+                MonoType::Time => Some(CompletionVarType::Time),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn create_function_result(
+    name: String,
+    expr: &SemanticExpression,
+) -> Option<UserFunctionResult> {
+    if let SemanticExpression::Function(f) = expr {
+        if let MonoType::Fun(fun) = f.typ.clone() {
+            return Some(UserFunctionResult {
+                name,
+                package: "self".to_string(),
+                package_name: Some("self".to_string()),
+                optional_args: get_argument_names(fun.clone().opt),
+                required_args: get_argument_names(fun.clone().req),
+                signature: create_function_signature((*fun).clone()),
+            });
+        }
+    }
+
+    None
+}
+
+fn follow_function_pipes(c: &CallExpr) -> &MonoType {
+    if let Some(SemanticExpression::Call(call)) = &c.pipe {
+        return follow_function_pipes(&call);
+    }
+
+    &c.typ
+}
+
+#[derive(Default)]
+struct CompletableObjectFinderState {
+    completables: Vec<Arc<dyn Completable>>,
+}
+
+struct CompletableObjectFinderVisitor {
+    name: String,
+    state: Arc<Mutex<CompletableObjectFinderState>>,
+}
+
+impl CompletableObjectFinderVisitor {
+    fn new(name: String) -> Self {
+        CompletableObjectFinderVisitor {
+            state: Arc::new(Mutex::new(
+                CompletableObjectFinderState::default(),
+            )),
+            name,
+        }
+    }
+}
+
+impl<'a> SemanticVisitor<'a> for CompletableObjectFinderVisitor {
+    fn visit(&mut self, node: Rc<SemanticNode<'a>>) -> bool {
+        if let Ok(mut state) = self.state.lock() {
+            let name = self.name.clone();
+
+            if let SemanticNode::ObjectExpr(obj) = node.as_ref() {
+                if let Some(ident) = &obj.with {
+                    if name == ident.name {
+                        for prop in obj.properties.clone() {
+                            let name = prop.key.name;
+                            if let Some(var_type) =
+                                get_var_type(&prop.value)
+                            {
+                                (*state).completables.push(Arc::new(
+                                    CompletionVarResult {
+                                        var_type,
+                                        name: name.clone(),
+                                    },
+                                ));
+                            }
+                            if let Some(fun) = create_function_result(
+                                name,
+                                &prop.value,
+                            ) {
+                                (*state)
+                                    .completables
+                                    .push(Arc::new(fun));
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let SemanticNode::VariableAssgn(assign) = node.as_ref()
+            {
+                if assign.id.name == name {
+                    if let SemanticExpression::Object(obj) =
+                        &assign.init
+                    {
+                        for prop in obj.properties.clone() {
+                            let name = prop.key.name;
+
+                            if let Some(var_type) =
+                                get_var_type(&prop.value)
+                            {
+                                (*state).completables.push(Arc::new(
+                                    CompletionVarResult {
+                                        var_type,
+                                        name: name.clone(),
+                                    },
+                                ));
+                            }
+
+                            if let Some(fun) = create_function_result(
+                                name,
+                                &prop.value,
+                            ) {
+                                (*state)
+                                    .completables
+                                    .push(Arc::new(fun));
+                            }
+                        }
+
+                        return false;
+                    }
+                }
+            }
+
+            if let SemanticNode::OptionStmt(opt) = node.as_ref() {
+                if let flux::semantic::nodes::Assignment::Variable(
+                    assign,
+                ) = opt.assignment.clone()
+                {
+                    if assign.id.name == name {
+                        if let SemanticExpression::Object(obj) =
+                            assign.init
+                        {
+                            for prop in obj.properties.clone() {
+                                let name = prop.key.name;
+                                if let Some(var_type) =
+                                    get_var_type(&prop.value)
+                                {
+                                    (*state).completables.push(
+                                        Arc::new(
+                                            CompletionVarResult {
+                                                var_type,
+                                                name: name.clone(),
+                                            },
+                                        ),
+                                    );
+                                }
+                                if let Some(fun) =
+                                    create_function_result(
+                                        name,
+                                        &prop.value,
+                                    )
+                                {
+                                    (*state)
+                                        .completables
+                                        .push(Arc::new(fun));
+                                }
+                            }
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+
+        true
+    }
+}
+
+#[derive(Clone)]
+struct CompletionVarResult {
+    name: String,
+    var_type: CompletionVarType,
+}
+
+#[derive(Clone)]
+enum CompletionVarType {
+    Int,
+    String,
+    Array,
+    Float,
+    Bool,
+    Duration,
+    Object,
+    Regexp,
+    Record,
+    Uint,
+    Time,
+}
+
+#[derive(Clone)]
+struct VarResult {
+    name: String,
+    var_type: VarType,
+    package: String,
+    package_name: Option<String>,
+}
+
+impl VarResult {
+    fn detail(&self) -> String {
+        match self.var_type {
+            VarType::Array => "Array".to_string(),
+            VarType::Bool => "Boolean".to_string(),
+            VarType::Bytes => "Bytes".to_string(),
+            VarType::Duration => "Duration".to_string(),
+            VarType::Float => "Float".to_string(),
+            VarType::Int => "Integer".to_string(),
+            VarType::Regexp => "Regular Expression".to_string(),
+            VarType::String => "String".to_string(),
+            VarType::Uint => "Uint".to_string(),
+            VarType::Time => "Time".to_string(),
+        }
+    }
+}
+
+impl Completable for VarResult {
+    fn completion_item(
+        &self,
+        _info: CompletionInfo,
+    ) -> lsp::CompletionItem {
+        lsp::CompletionItem {
+            label: format!("{} ({})", self.name, self.package),
+            additional_text_edits: None,
+            commit_characters: None,
+            deprecated: None,
+            detail: Some(self.detail()),
+            documentation: Some(lsp::Documentation::String(format!(
+                "from {}",
+                self.package
+            ))),
+            filter_text: Some(self.name.clone()),
+            insert_text: Some(self.name.clone()),
+            insert_text_format: Some(
+                lsp::InsertTextFormat::PlainText,
+            ),
+            kind: Some(lsp::CompletionItemKind::Variable),
+            preselect: None,
+            sort_text: Some(format!(
+                "{} {}",
+                self.name, self.package
+            )),
+            text_edit: None,
+            command: None,
+            data: None,
+            insert_text_mode: None,
+            tags: None,
+        }
+    }
+
+    fn matches(&self, text: String, info: CompletionInfo) -> bool {
+        let imports = info.imports;
+        if self.package == BUILTIN_PACKAGE && !text.ends_with('.') {
+            return true;
+        }
+
+        if !imports.into_iter().any(|x| self.package == x.path) {
+            return false;
+        }
+
+        if text.ends_with('.') {
+            let mtext = text[..text.len() - 1].to_string();
+            return Some(mtext) == self.package_name;
+        }
+
+        false
+    }
+}
+
+impl CompletionVarResult {
+    fn detail(&self) -> String {
+        match self.var_type {
+            CompletionVarType::Array => "Array".to_string(),
+            CompletionVarType::Bool => "Boolean".to_string(),
+            CompletionVarType::Duration => "Duration".to_string(),
+            CompletionVarType::Float => "Float".to_string(),
+            CompletionVarType::Int => "Integer".to_string(),
+            CompletionVarType::Object => "Object".to_string(),
+            CompletionVarType::Regexp => {
+                "Regular Expression".to_string()
+            }
+            CompletionVarType::String => "String".to_string(),
+            CompletionVarType::Record => "Record".to_string(),
+            CompletionVarType::Time => "Time".to_string(),
+            CompletionVarType::Uint => "Unsigned Integer".to_string(),
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+struct NodeFinderResult<'a> {
+    node: Option<Rc<flux::semantic::walk::Node<'a>>>,
+    path: Vec<Rc<flux::semantic::walk::Node<'a>>>,
+}
+
+fn find_node(
+    node: flux::semantic::walk::Node<'_>,
+    position: lsp::Position,
+) -> NodeFinderResult<'_> {
+    let mut result = NodeFinderResult::default();
+    let mut visitor = SemanticNodeFinderVisitor::new(position);
+
+    flux::semantic::walk::walk(&mut visitor, Rc::new(node));
+
+    let state = visitor.state.borrow();
+
+    result.node = (*state).node.clone();
+    result.path = (*state).path.clone();
+
+    result
+}
+// fn create_diagnostics_notification(
+//     uri: lsp::Url,
+//     diagnostics: Vec<lsp::Diagnostic>,
+// ) -> Notification<lsp::PublishDiagnosticsParams> {
+//     let method = String::from("textDocument/publishDiagnostics");
+//     let params = lsp::PublishDiagnosticsParams {
+//         uri,
+//         diagnostics,
+//         version: None,
+//     };
+//     Notification { method, params }
+// }
+// #[derive(Serialize, Deserialize)]
+// struct Notification<T> {
+//     method: String,
+//     params: T,
+// }
+//
+// impl<T> Notification<T>
+// where
+//     T: Serialize,
+// {
+//     fn to_json(&self) -> Result<String, String> {
+//         match serde_json::to_string(self) {
+//             Ok(s) => Ok(s),
+//             Err(_) => Err(String::from(
+//                 "Failed to serialize initialize response",
+//             )),
+//         }
+//     }
+// }
+#[derive(Clone)]
+struct FunctionResult {
+    name: String,
+    package: String,
+    package_name: Option<String>,
+    required_args: Vec<String>,
+    optional_args: Vec<String>,
+    signature: String,
+}
+#[derive(Clone)]
+struct PackageResult {
+    name: String,
+    full_name: String,
+}
+#[derive(Clone)]
+enum VarType {
+    Int,
+    String,
+    Array,
+    Float,
+    Bool,
+    Bytes,
+    Duration,
+    Regexp,
+    Uint,
+    Time,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct Property {
+    k: String,
+    v: String,
+}
+
+impl fmt::Display for Property {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}:{}", self.k, self.v)
+    }
+}
+
+fn create_completion_package_removed(
+    uri: lsp::Url,
+    pos: lsp::Position,
+    contents: String,
+) -> Result<flux::semantic::nodes::Package, String> {
+    let mut file = parse_string("", contents.as_str());
+
+    file.imports = file
+        .imports
+        .into_iter()
+        .filter(|x| valid_node(&x.base, pos))
+        .collect();
+
+    file.body = file
+        .body
+        .into_iter()
+        .filter(|x| valid_node(x.base(), pos))
+        .collect();
+
+    let mut pkg = create_ast_package(uri.clone(), contents)?;
+
+    pkg.files = pkg
+        .files
+        .into_iter()
+        .map(|curr| {
+            if curr.name == uri.as_str() {
+                file.clone()
+            } else {
+                curr
+            }
+        })
+        .collect();
+
+    match analyze(pkg) {
+        Ok(p) => Ok(p),
+        Err(e) => Err(format!("ERROR IS HERE {}", e)),
+    }
+}
+
+fn create_completion_package(
+    uri: lsp::Url,
+    pos: lsp::Position,
+    contents: String,
+) -> Result<flux::semantic::nodes::Package, String> {
+    create_filtered_package(uri, contents, |x| {
+        valid_node(x.base(), pos)
+    })
+}
+
+fn valid_node(
+    node: &flux::ast::BaseNode,
+    position: lsp::Position,
+) -> bool {
+    !is_in_node(position, node)
+}
+
+fn create_filtered_package<F>(
+    uri: lsp::Url,
+    contents: String,
+    mut filter: F,
+) -> Result<flux::semantic::nodes::Package, String>
+where
+    F: FnMut(&flux::ast::Statement) -> bool,
+{
+    let mut ast_pkg = create_ast_package(uri.clone(), contents)?;
+
+    ast_pkg.files = ast_pkg
+        .files
+        .into_iter()
+        .map(|mut file| {
+            if file.name == uri.as_str() {
+                file.body = file
+                    .body
+                    .into_iter()
+                    .filter(|x| filter(x))
+                    .collect();
+            }
+
+            file
+        })
+        .collect();
+
+    match analyze(ast_pkg) {
+        Ok(p) => Ok(p),
+        Err(e) => Err(format!("{}", e)),
+    }
+}
+
+#[derive(Clone)]
+pub struct UserFunctionResult {
+    pub name: String,
+    pub package: String,
+    pub package_name: Option<String>,
+    pub required_args: Vec<String>,
+    pub optional_args: Vec<String>,
+    pub signature: String,
+}
+
+impl UserFunctionResult {
+    fn insert_text(&self) -> String {
+        let mut insert_text = format!("{}(", self.name);
+
+        for (index, arg) in self.required_args.iter().enumerate() {
+            insert_text +=
+                (format!("{}: ${}", arg, index + 1)).as_str();
+
+            if index != self.required_args.len() - 1 {
+                insert_text += ", ";
+            }
+        }
+
+        if self.required_args.is_empty()
+            && !self.optional_args.is_empty()
+        {
+            insert_text += "$1";
+        }
+
+        insert_text += ")$0";
+
+        insert_text
+    }
+}
+
+impl Completable for UserFunctionResult {
+    fn completion_item(
+        &self,
+        _info: CompletionInfo,
+    ) -> lsp::CompletionItem {
+        lsp::CompletionItem {
+            label: format!("{} ({})", self.name, "self".to_string()),
+            additional_text_edits: None,
+            commit_characters: None,
+            deprecated: None,
+            detail: Some(self.signature.clone()),
+            documentation: Some(lsp::Documentation::String(
+                "from self".to_string(),
+            )),
+            filter_text: Some(self.name.clone()),
+            insert_text: Some(self.insert_text()),
+            insert_text_format: Some(lsp::InsertTextFormat::Snippet),
+            kind: Some(lsp::CompletionItemKind::Function),
+            preselect: None,
+            sort_text: Some(self.name.clone()),
+            text_edit: None,
+            command: None,
+            data: None,
+            insert_text_mode: None,
+            tags: None,
+        }
+    }
+
+    fn matches(&self, _text: String, _info: CompletionInfo) -> bool {
+        true
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,6 +15,10 @@ use flux::semantic::walk;
 use flux::semantic::walk::Node as SemanticNode;
 use flux::semantic::walk::Visitor as SemanticVisitor;
 use flux::{imports, prelude};
+use log::{debug, error, info, warn};
+use lspower::jsonrpc::Result;
+use lspower::lsp;
+use lspower::LanguageServer;
 
 use crate::convert;
 use crate::handlers::document_symbol::sort_symbols;
@@ -37,11 +41,6 @@ use crate::visitors::semantic::{
     FunctionFinderVisitor, IdentFinderVisitor, Import,
     ImportFinderVisitor, ObjectFunctionFinderVisitor, SymbolsVisitor,
 };
-
-use log::{debug, error, info, warn};
-
-use lspower::jsonrpc::Result;
-use lspower::{lsp, LanguageServer};
 
 const BUILTIN_PACKAGE: &str = "builtin";
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -796,9 +796,9 @@ impl LanguageServer for LspServer {
             Some(v) => v.to_string(),
             None => {
                 error!(
-										"textDocument/completion called on unknown file {}",
-										key
-								);
+                    "textDocument/completion called on unknown file {}",
+                    key
+                );
                 return Err(lspower::jsonrpc::Error::invalid_params(
                     format!("file not opened: {}", key),
                 ));
@@ -1863,7 +1863,7 @@ sql."#;
 
     #[test]
     fn test_variable_completion() {
-        let fluxscript = r#" import "strings"
+        let fluxscript = r#"import "strings"
 import "csv"
 
 cal = 10

--- a/src/server.rs
+++ b/src/server.rs
@@ -1930,7 +1930,7 @@ errorCounts
     // and continue to provide completion suggestions.
     //
     // An issue has been created for this:
-    // https://github.com/influxdata/flux-lsp/issues/289
+    // https://github.com/influxdata/flux-lsp/issues/290
     #[test]
     fn test_option_object_members_completion() {
         let fluxscript = r#"import "strings"

--- a/src/server.rs
+++ b/src/server.rs
@@ -2718,7 +2718,9 @@ fn find_arg_completions(
 
     if let Some(info) = info {
         if info.ident == "bucket" {
-            return get_bucket_completions(ctx, get_trigger(params));
+            return async_std::task::block_on(
+                get_bucket_completions(ctx, get_trigger(params)),
+            );
         }
     }
 
@@ -2728,15 +2730,15 @@ fn find_arg_completions(
     })
 }
 
-fn get_bucket_completions(
+async fn get_bucket_completions(
     ctx: crate::shared::structs::RequestContext,
     trigger: Option<String>,
 ) -> std::result::Result<lsp::CompletionList, Error> {
-    let buckets =
-        async_std::task::block_on(ctx.callbacks.get_buckets())
-            .unwrap();
+    // let buckets = ctx.callbacks.get_buckets();
+    let buckets = ctx.callbacks.get_buckets().await;
 
     let items: Vec<lsp::CompletionItem> = buckets
+        .unwrap()
         .into_iter()
         .map(|value| {
             new_string_arg_completion(value, trigger.clone())

--- a/src/server.rs
+++ b/src/server.rs
@@ -814,7 +814,9 @@ impl LanguageServer for LspServer {
                     // look for bucket names if the parameter name is "bucket". Since
                     // we don't currently support bucket completions, this match arm
                     // is a no-op.
-                    ":" => find_arg_completions(params, contents),
+                    ":" => {
+                        find_arg_completions(params, contents).await
+                    }
                     "(" | "," => find_param_completions(
                         Some(c),
                         params,
@@ -2701,7 +2703,7 @@ fn find_dot_completions(
 }
 // XXX: sean (10 Aug 2021) - This function is a no-op, since the new server
 // does not yet support completion callbacks
-fn find_arg_completions(
+async fn find_arg_completions(
     params: lsp::CompletionParams,
     source: String,
 ) -> std::result::Result<lsp::CompletionList, Error> {
@@ -2718,9 +2720,8 @@ fn find_arg_completions(
 
     if let Some(info) = info {
         if info.ident == "bucket" {
-            return async_std::task::block_on(
-                get_bucket_completions(ctx, get_trigger(params)),
-            );
+            return get_bucket_completions(ctx, get_trigger(params))
+                .await;
         }
     }
 


### PR DESCRIPTION
Closes #239 

This patch does a few things:

1. Adds an implementation of the `completion()` method to the lspower server
2. Ports the completion-related tests from `src/handlers/tests.rs` into the test module for the lspower server
3. Copies any functions, data structures, or traits that are necessary to support autocompletion into `server.rs` and refactors them so that they no longer require a `RequestContext` or a `Cache` to function. Anything that was private or that required signature/definition changes got copied into `server.rs`. Everything else was left as-is and imported.

There's one outstanding test failure involving how the new LSP handles parse errors. The old LSP could convert parse errors into diagnostic notifications and still respond to completion requests. It appears this new implementation can't handle that quite yet. We will need to find a way to adapt the [`map_errors_to_diagnostics()`](https://github.com/influxdata/flux-lsp/blob/22bab60686212d8d5ca797d39bc6cf18d3bb36ca/src/shared/conversion.rs#L23) logic to the new server in order to fix that.