### PR TITLE
fix: address issues found in testing lsp2

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -6,7 +6,7 @@ use flux::semantic::walk::Node;
 // XXX: rockstar (28 Jul 2021) - This can't be implemented in a From trait
 // without some clownshoes type aliasing, so this conversion function will work.
 fn ast_to_lsp_position(
-    position: ast::Position,
+    position: &ast::Position,
 ) -> lsp_types::Position {
     lsp_types::Position {
         line: position.line - 1,
@@ -22,12 +22,12 @@ pub fn node_to_location(
     node: &Node,
     uri: lsp_types::Url,
 ) -> lsp_types::Location {
-    let node_location = node.loc().clone();
+    let node_location = node.loc();
     lsp_types::Location {
         uri,
         range: lsp_types::Range {
-            start: ast_to_lsp_position(node_location.start),
-            end: ast_to_lsp_position(node_location.end),
+            start: ast_to_lsp_position(&node_location.start),
+            end: ast_to_lsp_position(&node_location.end),
         },
     }
 }
@@ -52,7 +52,7 @@ mod tests {
             line: 23,
             column: 8,
         };
-        let result = ast_to_lsp_position(ast_position);
+        let result = ast_to_lsp_position(&ast_position);
 
         assert_eq!(expected, result);
     }

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -487,7 +487,7 @@ pub fn create_function_signature(
         .collect::<BTreeMap<_, _>>()
         .iter()
         .map(|(&k, &v)| Property {
-            k: String::from("?") + &k,
+            k: String::from("?") + k,
             v: get_type_string(v.clone(), &mut mapping),
         })
         .collect::<Vec<_>>();

--- a/src/visitors/semantic/completion/utils.rs
+++ b/src/visitors/semantic/completion/utils.rs
@@ -6,7 +6,7 @@ use lsp_types as lsp;
 
 pub fn follow_function_pipes(c: &CallExpr) -> &MonoType {
     if let Some(Expression::Call(call)) = &c.pipe {
-        return follow_function_pipes(&call);
+        return follow_function_pipes(call);
     }
 
     &c.typ


### PR DESCRIPTION
The `textDocument/completionResolve` and `textDocument/hover` were
essentially no-ops in the previous server. They are implemented in a
not-very-useful way, but implemented nonetheless. This patch implements
both of those.

Additionally, it addresses some clippy lints.