### PR TITLE
chore: hide non-lsp2 code behind cfg pragmas

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,12 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
 extern crate clap;
 
+#[cfg(not(feature = "lsp2"))]
 mod cache;
 mod convert;
+#[cfg(not(feature = "lsp2"))]
 mod handlers;
+#[cfg(not(feature = "lsp2"))]
 mod protocol;
 #[cfg(feature = "lsp2")]
 mod server;

--- a/src/shared/ast.rs
+++ b/src/shared/ast.rs
@@ -1,5 +1,8 @@
+#[cfg(not(feature = "lsp2"))]
 use crate::cache;
+#[cfg(not(feature = "lsp2"))]
 use crate::cache::Cache;
+#[cfg(not(feature = "lsp2"))]
 use crate::shared::structs::RequestContext;
 
 use lsp_types as lsp;
@@ -32,6 +35,7 @@ pub fn is_in_node(
     true
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub fn create_ast_package(
     uri: lsp::Url,
     ctx: RequestContext,

--- a/src/shared/callbacks.rs
+++ b/src/shared/callbacks.rs
@@ -85,6 +85,7 @@ pub struct Callback {
     f: Function,
 }
 
+#[allow(dead_code)]
 impl Callback {
     pub fn new(f: Function) -> Self {
         Callback { f }
@@ -127,6 +128,7 @@ pub struct Callbacks {
     pub tag_values: Option<Callback>,
 }
 
+#[allow(dead_code)]
 impl Callbacks {
     // All of the `register_*_callback` methods have been disabled
     // to prevent the LSP from crashing. Autocomplete for user-specific

--- a/src/shared/conversion.rs
+++ b/src/shared/conversion.rs
@@ -1,9 +1,13 @@
+#[cfg(not(feature = "lsp2"))]
 use flux::ast::check;
+#[cfg(not(feature = "lsp2"))]
 use flux::ast::Package;
+#[cfg(not(feature = "lsp2"))]
 use flux::parser::parse_string;
 
 use lsp_types as lsp;
 
+#[cfg(not(feature = "lsp2"))]
 pub fn create_file_node_from_text(
     uri: lsp::Url,
     text: String,
@@ -20,6 +24,7 @@ pub fn flux_position_to_position(
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub fn map_errors_to_diagnostics(
     errors: Vec<check::Error>,
 ) -> Vec<lsp::Diagnostic> {
@@ -32,6 +37,7 @@ pub fn map_errors_to_diagnostics(
     result
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub fn location_to_range(
     location: flux::ast::SourceLocation,
 ) -> lsp::Range {
@@ -41,6 +47,7 @@ pub fn location_to_range(
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 fn map_error_to_diagnostic(error: check::Error) -> lsp::Diagnostic {
     lsp::Diagnostic {
         severity: Some(lsp::DiagnosticSeverity::Error),

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,25 +1,38 @@
+#[cfg(not(feature = "lsp2"))]
 use crate::cache::Cache;
+#[cfg(not(feature = "lsp2"))]
 use crate::protocol::{
     create_diagnostics_notification, Notification,
 };
+#[cfg(not(feature = "lsp2"))]
 use crate::shared::conversion::map_errors_to_diagnostics;
+#[cfg(not(feature = "lsp2"))]
 use crate::visitors::ast::package_finder::{
     PackageFinderVisitor, PackageInfo,
 };
+#[cfg(not(feature = "lsp2"))]
 use crate::visitors::ast::NodeFinderVisitor;
+#[cfg(not(feature = "lsp2"))]
 use crate::visitors::semantic::{
     utils, CallFinderVisitor, Import, ImportFinderVisitor,
 };
 
+#[cfg(not(feature = "lsp2"))]
 use flux::ast::walk::walk_rc;
+#[cfg(not(feature = "lsp2"))]
 use flux::ast::walk::Node as AstNode;
+#[cfg(not(feature = "lsp2"))]
 use flux::ast::{Expression, PropertyKey};
+#[cfg(not(feature = "lsp2"))]
 use flux::semantic::nodes::CallExpr;
 
+#[cfg(not(feature = "lsp2"))]
 use std::rc::Rc;
 
+#[cfg(not(feature = "lsp2"))]
 use flux::semantic::walk;
 
+#[cfg(not(feature = "lsp2"))]
 use lsp_types as lsp;
 
 pub mod ast;
@@ -32,9 +45,13 @@ pub mod structs;
 
 use combinations::Combinations;
 
+#[cfg(not(feature = "lsp2"))]
 pub use ast::create_ast_package;
-pub use structs::{Function, RequestContext};
+pub use structs::Function;
+#[cfg(not(feature = "lsp2"))]
+pub use structs::RequestContext;
 
+#[cfg(not(feature = "lsp2"))]
 fn move_back(position: lsp::Position, count: u32) -> lsp::Position {
     lsp::Position {
         line: position.line,
@@ -60,6 +77,7 @@ where
     result
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub fn create_diagnoistics(
     uri: lsp::Url,
     ctx: RequestContext,
@@ -77,6 +95,7 @@ pub fn get_package_name(name: String) -> Option<String> {
     let items = name.split('/');
     items.last().map(|n| n.to_string())
 }
+#[cfg(not(feature = "lsp2"))]
 #[derive(Clone)]
 pub enum CompletionType {
     Generic,
@@ -87,6 +106,7 @@ pub enum CompletionType {
     Bad,
 }
 
+#[cfg(not(feature = "lsp2"))]
 #[derive(Clone)]
 pub struct CompletionInfo {
     pub completion_type: CompletionType,
@@ -98,6 +118,7 @@ pub struct CompletionInfo {
     pub package: Option<PackageInfo>,
 }
 
+#[cfg(not(feature = "lsp2"))]
 impl CompletionInfo {
     pub fn create(
         params: lsp::CompletionParams,
@@ -361,6 +382,7 @@ impl CompletionInfo {
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 fn find_bucket(
     params: lsp::CompletionParams,
     ctx: RequestContext,
@@ -389,6 +411,7 @@ fn find_bucket(
     Ok(None)
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub fn get_imports(
     uri: lsp::Url,
     pos: lsp::Position,
@@ -406,6 +429,7 @@ pub fn get_imports(
     Ok((*state).imports.clone())
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub fn get_imports_removed(
     uri: lsp::Url,
     pos: lsp::Position,
@@ -425,6 +449,7 @@ pub fn get_imports_removed(
     Ok((*state).imports.clone())
 }
 
+#[cfg(not(feature = "lsp2"))]
 fn follow_pipes_for_bucket(call: Box<CallExpr>) -> Option<String> {
     for arg in call.arguments {
         if arg.key.name == "bucket" {

--- a/src/shared/structs.rs
+++ b/src/shared/structs.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "lsp2"))]
 use crate::shared::callbacks;
 
 #[derive(Clone)]
@@ -6,12 +7,14 @@ pub struct Function {
     pub params: Vec<String>,
 }
 
+#[cfg(not(feature = "lsp2"))]
 #[derive(Clone)]
 pub struct RequestContext {
     pub support_multiple_files: bool,
     pub callbacks: callbacks::Callbacks,
 }
 
+#[cfg(not(feature = "lsp2"))]
 impl RequestContext {
     pub fn new(
         callbacks: callbacks::Callbacks,

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -1,7 +1,12 @@
 use crate::shared::get_package_name;
-use crate::shared::signatures::{get_argument_names, FunctionInfo};
+use crate::shared::signatures::get_argument_names;
+use crate::shared::signatures::FunctionInfo;
+#[cfg(not(feature = "lsp2"))]
 use crate::shared::CompletionInfo;
-use crate::shared::{Function, RequestContext};
+use crate::shared::Function;
+#[cfg(not(feature = "lsp2"))]
+use crate::shared::RequestContext;
+#[cfg(not(feature = "lsp2"))]
 use crate::visitors::semantic::Import;
 
 use flux::imports;
@@ -12,12 +17,15 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::iter::Iterator;
 
+#[cfg(not(feature = "lsp2"))]
 use async_trait::async_trait;
 
+#[cfg(not(feature = "lsp2"))]
 use lsp_types as lsp;
 
 pub const BUILTIN_PACKAGE: &str = "builtin";
 
+#[cfg(not(feature = "lsp2"))]
 #[async_trait]
 pub trait Completable {
     async fn completion_item(
@@ -28,6 +36,7 @@ pub trait Completable {
     fn matches(&self, text: String, info: CompletionInfo) -> bool;
 }
 
+#[cfg(not(feature = "lsp2"))]
 #[derive(Clone)]
 pub enum VarType {
     Int,
@@ -42,6 +51,7 @@ pub enum VarType {
     Time,
 }
 
+#[cfg(not(feature = "lsp2"))]
 #[derive(Clone)]
 pub struct VarResult {
     pub name: String,
@@ -50,6 +60,7 @@ pub struct VarResult {
     pub package_name: Option<String>,
 }
 
+#[cfg(not(feature = "lsp2"))]
 impl VarResult {
     pub fn detail(&self) -> String {
         match self.var_type {
@@ -67,6 +78,7 @@ impl VarResult {
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 #[async_trait]
 impl Completable for VarResult {
     async fn completion_item(
@@ -128,10 +140,12 @@ pub struct PackageResult {
     pub full_name: String,
 }
 
+#[cfg(not(feature = "lsp2"))]
 fn create_import_paths(imports: Vec<Import>) -> Vec<String> {
     imports.into_iter().map(|x| x.path).collect::<Vec<String>>()
 }
 
+#[cfg(not(feature = "lsp2"))]
 fn find_alias_name(
     imports: Vec<Import>,
     name: String,
@@ -163,6 +177,7 @@ fn find_alias_name(
     Some(format!("{}{}", name, iteration))
 }
 
+#[cfg(not(feature = "lsp2"))]
 #[async_trait]
 impl Completable for PackageResult {
     async fn completion_item(
@@ -243,10 +258,12 @@ impl Completable for PackageResult {
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 fn default_arg_insert_text(arg: &str, index: usize) -> String {
     format!("{}: ${}", arg, index + 1)
 }
 
+#[cfg(not(feature = "lsp2"))]
 fn bucket_list_to_snippet(
     buckets: Vec<String>,
     index: usize,
@@ -262,6 +279,7 @@ fn bucket_list_to_snippet(
     return format!("{}: {}", arg, text);
 }
 
+#[cfg(not(feature = "lsp2"))]
 async fn get_bucket_insert_text(
     arg: &str,
     index: usize,
@@ -278,6 +296,7 @@ async fn get_bucket_insert_text(
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 async fn arg_insert_text(
     arg: &str,
     index: usize,
@@ -289,6 +308,7 @@ async fn arg_insert_text(
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 #[derive(Clone)]
 pub struct FunctionResult {
     pub name: String,
@@ -299,6 +319,7 @@ pub struct FunctionResult {
     pub signature: String,
 }
 
+#[cfg(not(feature = "lsp2"))]
 impl FunctionResult {
     async fn insert_text(&self, ctx: RequestContext) -> String {
         let mut insert_text = format!("{}(", self.name);
@@ -325,10 +346,12 @@ impl FunctionResult {
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 fn make_documentation(package: String) -> String {
     String::from("from ") + package.as_str()
 }
 
+#[cfg(not(feature = "lsp2"))]
 #[async_trait]
 impl Completable for FunctionResult {
     async fn completion_item(
@@ -520,6 +543,7 @@ pub fn create_function_signature(
     )
 }
 
+#[cfg(not(feature = "lsp2"))]
 fn walk(
     package: String,
     list: &mut Vec<Box<dyn Completable + Send + Sync>>,
@@ -649,6 +673,7 @@ pub fn get_package_infos() -> Vec<PackageInfo> {
     result
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub fn add_package_result(
     name: String,
     list: &mut Vec<Box<dyn Completable + Send + Sync>>,
@@ -662,6 +687,7 @@ pub fn add_package_result(
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub fn get_packages(
     list: &mut Vec<Box<dyn Completable + Send + Sync>>,
 ) {
@@ -717,6 +743,7 @@ pub fn get_package_functions(name: String) -> Vec<Function> {
     list
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub fn get_specific_package_functions(
     list: &mut Vec<Box<dyn Completable + Send + Sync>>,
     name: String,
@@ -813,6 +840,7 @@ pub fn get_builtin_functions() -> Vec<Function> {
     list
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub fn get_builtins(
     list: &mut Vec<Box<dyn Completable + Sync + Send>>,
 ) {
@@ -893,6 +921,7 @@ pub fn get_builtins(
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub fn get_stdlib() -> Vec<Box<dyn Completable + Sync + Send>> {
     let mut list = vec![];
 
@@ -902,7 +931,7 @@ pub fn get_stdlib() -> Vec<Box<dyn Completable + Sync + Send>> {
     list
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "lsp2")))]
 mod test {
     use super::*;
     #[test]

--- a/src/visitors/ast/package_finder.rs
+++ b/src/visitors/ast/package_finder.rs
@@ -1,12 +1,16 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+#[cfg(not(feature = "lsp2"))]
 use flux::ast::walk::walk_rc;
 use flux::ast::walk::{Node, Visitor};
 
+#[cfg(not(feature = "lsp2"))]
 use crate::cache::Cache;
+#[cfg(not(feature = "lsp2"))]
 use crate::shared::ast::create_ast_package;
 use crate::shared::conversion::flux_position_to_position;
+#[cfg(not(feature = "lsp2"))]
 use crate::shared::RequestContext;
 
 use lsp_types as lsp;
@@ -27,6 +31,7 @@ pub struct PackageFinderVisitor {
     pub state: Rc<RefCell<PackageFinderState>>,
 }
 
+#[cfg(not(feature = "lsp2"))]
 impl PackageFinderVisitor {
     pub fn find(
         uri: lsp::Url,

--- a/src/visitors/semantic/completion/mod.rs
+++ b/src/visitors/semantic/completion/mod.rs
@@ -1,6 +1,8 @@
+#[cfg(not(feature = "lsp2"))]
 mod results;
 mod utils;
 
+#[cfg(not(feature = "lsp2"))]
 use results::*;
 use utils::*;
 
@@ -9,6 +11,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::shared::signatures::get_argument_names;
 use crate::shared::Function;
+#[cfg(not(feature = "lsp2"))]
 use crate::stdlib::Completable;
 
 use flux::semantic::nodes::*;
@@ -92,16 +95,19 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 #[derive(Default)]
 pub struct CompletableFinderState {
     pub completables: Vec<Arc<dyn Completable + Send + Sync>>,
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub struct CompletableFinderVisitor {
     pub pos: lsp::Position,
     pub state: Arc<Mutex<CompletableFinderState>>,
 }
 
+#[cfg(not(feature = "lsp2"))]
 impl<'a> Visitor<'a> for CompletableFinderVisitor {
     fn visit(&mut self, node: Rc<Node<'a>>) -> bool {
         if let Ok(mut state) = self.state.lock() {
@@ -168,6 +174,7 @@ impl<'a> Visitor<'a> for CompletableFinderVisitor {
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 impl CompletableFinderVisitor {
     pub fn new(pos: lsp::Position) -> Self {
         CompletableFinderVisitor {
@@ -275,16 +282,19 @@ impl<'a> Visitor<'a> for ObjectFunctionFinderVisitor {
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 #[derive(Default)]
 pub struct CompletableObjectFinderState {
     pub completables: Vec<Arc<dyn Completable + Send + Sync>>,
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub struct CompletableObjectFinderVisitor {
     pub name: String,
     pub state: Arc<Mutex<CompletableObjectFinderState>>,
 }
 
+#[cfg(not(feature = "lsp2"))]
 impl CompletableObjectFinderVisitor {
     pub fn new(name: String) -> Self {
         CompletableObjectFinderVisitor {
@@ -296,6 +306,7 @@ impl CompletableObjectFinderVisitor {
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 impl<'a> Visitor<'a> for CompletableObjectFinderVisitor {
     fn visit(&mut self, node: Rc<Node<'a>>) -> bool {
         if let Ok(mut state) = self.state.lock() {

--- a/src/visitors/semantic/completion/utils.rs
+++ b/src/visitors/semantic/completion/utils.rs
@@ -1,9 +1,12 @@
 use flux::ast::SourceLocation;
+#[cfg(not(feature = "lsp2"))]
 use flux::semantic::nodes::*;
+#[cfg(not(feature = "lsp2"))]
 use flux::semantic::types::MonoType;
 
 use lsp_types as lsp;
 
+#[cfg(not(feature = "lsp2"))]
 pub fn follow_function_pipes(c: &CallExpr) -> &MonoType {
     if let Some(Expression::Call(call)) = &c.pipe {
         return follow_function_pipes(call);

--- a/src/visitors/semantic/functions.rs
+++ b/src/visitors/semantic/functions.rs
@@ -20,6 +20,7 @@ pub struct FunctionFinderVisitor {
     pub state: Rc<RefCell<FunctionFinderState>>,
 }
 
+#[cfg(not(feature = "lsp2"))]
 impl FunctionFinderVisitor {
     pub fn new(pos: lsp::Position) -> Self {
         FunctionFinderVisitor {

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::rc::Rc;
+#[cfg(not(feature = "lsp2"))]
 use std::sync::{Arc, Mutex};
 
 use crate::shared::get_package_name;
@@ -13,10 +14,14 @@ mod completion;
 mod symbols;
 
 pub mod functions;
+#[cfg(not(feature = "lsp2"))]
 pub mod utils;
 
+#[cfg(not(feature = "lsp2"))]
 pub use completion::{
     CompletableFinderVisitor, CompletableObjectFinderVisitor,
+};
+pub use completion::{
     FunctionFinderVisitor, ObjectFunctionFinderVisitor,
 };
 pub use symbols::SymbolsVisitor;
@@ -46,17 +51,20 @@ fn contains_position(node: Rc<Node<'_>>, pos: lsp::Position) -> bool {
     true
 }
 
+#[cfg(not(feature = "lsp2"))]
 pub struct CallFinderState<'a> {
     pub node: Option<Rc<Node<'a>>>,
     pub position: lsp::Position,
     pub path: Vec<Rc<Node<'a>>>,
 }
 
+#[cfg(not(feature = "lsp2"))]
 #[derive(Clone)]
 pub struct CallFinderVisitor<'a> {
     pub state: Arc<Mutex<CallFinderState<'a>>>,
 }
 
+#[cfg(not(feature = "lsp2"))]
 impl<'a> Visitor<'a> for CallFinderVisitor<'a> {
     fn visit(&mut self, node: Rc<Node<'a>>) -> bool {
         if let Ok(mut state) = self.state.lock() {
@@ -79,6 +87,7 @@ impl<'a> Visitor<'a> for CallFinderVisitor<'a> {
     }
 }
 
+#[cfg(not(feature = "lsp2"))]
 impl<'a> CallFinderVisitor<'a> {
     pub fn new(pos: lsp::Position) -> CallFinderVisitor<'a> {
         CallFinderVisitor {


### PR DESCRIPTION
This patch hides all non-lsp2 code behind a feature flag. This work was
needed two-fold: document code that can be deleted soon, and (b) shrink
the size of the resulting wasm binary. Unfortunately, the wasm binary is
mostly optimized already, so the size difference is pretty negligible.