### PR TITLE
chore: add some benchmark tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,9 @@ web-sys = { version = "0.3.51", features = ["console"] }
 
 [dev-dependencies]
 futures = "0.3.15"
+criterion = "0.3"
+
+[[bench]]
+name = "server"
+path = "benches/server.rs"
+harness = false

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -1,0 +1,138 @@
+use async_std::task::block_on;
+use criterion::{
+    black_box, criterion_group, criterion_main, Criterion,
+};
+use flux_lsp::LspServer;
+use lsp_types;
+use lspower::LanguageServer;
+
+fn create_server() -> LspServer {
+    LspServer::default()
+}
+
+fn open_file(server: &LspServer, text: String) {
+    let params = lsp_types::DidOpenTextDocumentParams {
+        text_document: lsp_types::TextDocumentItem::new(
+            lsp_types::Url::parse("file:///home/user/file.flux")
+                .unwrap(),
+            "flux".to_string(),
+            1,
+            text,
+        ),
+    };
+    block_on(server.did_open(params));
+}
+
+/// Benchmark the response for a package completion
+fn server_completion_package(c: &mut Criterion) {
+    let fluxscript = r#"import "sql"
+
+sql."#;
+    let server = create_server();
+    open_file(&server, fluxscript.to_string());
+
+    let params = lsp_types::CompletionParams {
+        text_document_position:
+            lsp_types::TextDocumentPositionParams {
+                text_document: lsp_types::TextDocumentIdentifier {
+                    uri: lsp_types::Url::parse(
+                        "file:///home/user/file.flux",
+                    )
+                    .unwrap(),
+                },
+                position: lsp_types::Position {
+                    line: 2,
+                    character: 3,
+                },
+            },
+        work_done_progress_params:
+            lsp_types::WorkDoneProgressParams {
+                work_done_token: None,
+            },
+        partial_result_params: lsp_types::PartialResultParams {
+            partial_result_token: None,
+        },
+        context: Some(lsp_types::CompletionContext {
+            trigger_kind:
+                lsp_types::CompletionTriggerKind::TriggerCharacter,
+            trigger_character: Some(".".to_string()),
+        }),
+    };
+
+    c.bench_function("server completion", |b| {
+        b.iter(|| {
+            block_on(black_box(server.completion(params.clone())))
+                .unwrap()
+                .unwrap();
+        })
+    });
+}
+
+fn server_completion_variable(c: &mut Criterion) {
+    let fluxscript = r#"import "strings"
+import "csv"
+
+cal = 10
+env = "prod01-us-west-2"
+
+cool = (a) => a + 1
+
+c
+
+errorCounts = from(bucket:"kube-infra/monthly")
+    |> range(start: -3d)
+    |> filter(fn: (r) => r._measurement == "query_log" and
+                         r.error != "" and
+                         r._field == "responseSize" and
+                         r.env == env)
+    |> group(columns:["env", "error"])
+    |> count()
+    |> group(columns:["env", "_stop", "_start"])
+
+errorCounts
+    |> filter(fn: (r) => strings.containsStr(v: r.error, substr: "AppendMappedRecordWithNulls"))
+"#;
+    let server = create_server();
+    open_file(&server, fluxscript.to_string());
+
+    let params = lsp_types::CompletionParams {
+        text_document_position:
+            lsp_types::TextDocumentPositionParams {
+                text_document: lsp_types::TextDocumentIdentifier {
+                    uri: lsp_types::Url::parse(
+                        "file:///home/user/file.flux",
+                    )
+                    .unwrap(),
+                },
+                position: lsp_types::Position {
+                    line: 8,
+                    character: 1,
+                },
+            },
+        work_done_progress_params:
+            lsp_types::WorkDoneProgressParams {
+                work_done_token: None,
+            },
+        partial_result_params: lsp_types::PartialResultParams {
+            partial_result_token: None,
+        },
+        context: Some(lsp_types::CompletionContext {
+            trigger_kind: lsp_types::CompletionTriggerKind::Invoked,
+            trigger_character: None,
+        }),
+    };
+
+    c.bench_function("server completion", |b| {
+        b.iter(|| {
+            block_on(black_box(server.completion(params.clone())))
+                .unwrap();
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    server_completion_package,
+    server_completion_variable
+);
+criterion_main!(benches);

--- a/src/server.rs
+++ b/src/server.rs
@@ -2101,11 +2101,11 @@ ab = 10
     #[test]
     fn test_object_param_completion() {
         let fluxscript = r#"obj = {
-	func: (name, age) => name + age
+    func: (name, age) => name + age
 }
 
 obj.func(
-		"#;
+        "#;
         let server = create_server();
         open_file(&server, fluxscript.to_string());
 
@@ -2157,7 +2157,7 @@ obj.func(
         let fluxscript = r#"import "csv"
 
 csv.from(
-		"#;
+        "#;
         let server = create_server();
         open_file(&server, fluxscript.to_string());
 
@@ -2472,18 +2472,18 @@ impl CompletionInfo {
                                     );
 
                                     return Ok(Some(CompletionInfo {
-															completion_type:
-																CompletionType::Logical(
-																	be.operator.clone(),
-																),
-																ident: name,
-																position,
-																uri: uri.clone(),
-																imports: get_imports(
-																	uri, position, source,
-																)?,
-																package,
-														}));
+                                                            completion_type:
+                                                                CompletionType::Logical(
+                                                                    be.operator.clone(),
+                                                                ),
+                                                                ident: name,
+                                                                position,
+                                                                uri: uri.clone(),
+                                                                imports: get_imports(
+                                                                    uri, position, source,
+                                                                )?,
+                                                                package,
+                                                        }));
                                 }
                             }
                             _ => {}

--- a/src/visitors/ast.rs
+++ b/src/visitors/ast.rs
@@ -34,35 +34,6 @@ fn contains_position(
     true
 }
 
-pub struct DefinitionFinderState<'a> {
-    pub name: String,
-    pub node: Option<Rc<walk::Node<'a>>>,
-}
-
-#[derive(Clone)]
-pub struct DefinitionFinderVisitor<'a> {
-    pub state: Rc<RefCell<DefinitionFinderState<'a>>>,
-}
-
-impl<'a> Visitor<'a> for DefinitionFinderVisitor<'a> {
-    fn visit(&self, node: Rc<walk::Node<'a>>) -> Option<Self> {
-        let mut state = self.state.borrow_mut();
-
-        match node.as_ref() {
-            walk::Node::VariableAssgn(v) => {
-                if v.id.name == state.name {
-                    state.node = Some(node.clone());
-                    return None;
-                }
-
-                Some(self.clone())
-            }
-            walk::Node::FunctionExpr(_) => None,
-            _ => Some(self.clone()),
-        }
-    }
-}
-
 pub struct CallFinderState<'a> {
     pub node: Option<Rc<walk::Node<'a>>>,
 }


### PR DESCRIPTION
This patch adds two benchmark tests, and the underlying setup required
to run those tests. This work was exploratory while chasing some
potential performance issues that I was experiencing in vsflux. It ended
up being informative but not entirely helpful. However, I think it's
still valuable work to commit.

Additionally, a file got reformatted and a visitor was deleted because
it wasn't used.