### PR TITLE
feat: log panics from wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ async-std = { version = "1.9.0", features = ["attributes"] }
 async-trait = "0.1.50"
 clap = "2.33.3"
 combinations = "0.1.0"
+console_error_panic_hook = "0.1.7"
 flux = { git = "https://github.com/influxdata/flux", tag = "v0.135.0" }
 futures = "0.3.15"
 js-sys = "0.3.51"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,10 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
-extern crate clap;
-
 mod convert;
 mod server;
 mod shared;
 mod stdlib;
-mod wasm;
-
 mod visitors;
+mod wasm;
 
 pub use server::LspServer;
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -68,6 +68,8 @@ impl Server {
         disable_folding: bool,
         _support_multiple_files: bool,
     ) -> Self {
+        console_error_panic_hook::set_once();
+
         let (service, _messages) =
             lspower::LspService::new(|_client| {
                 let mut server = LspServer::default();


### PR DESCRIPTION
This patch adds an external dependency that will set up a panic handler
that will log panics originating in wasm to the browser console. This
dependency has worked through support in multiple browsers, so I'm
confident it's going to be better than anything we come up with.

Catching the panic and recovering would be neat, but right now, we get
`RuntimeError: unreachable` which gives us no information and looks like
it's an invocation of `unreachable!`, which has led to some wild goose
chases recently. Having a backtrace would go a long way to fixing
issues.