### PR TITLE
feat: implement a cleaner wasm interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,9 @@ jobs:
       - checkout
       - run:
           name: "run tests"
-          command: wasm-pack test --node
+          command: |
+            wasm-pack test --node
+            wasm-pack test --node --features=api_next
 
   build:
     docker:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ lto = true
 [features]
 default = ["strict"]
 strict = []
+api_next = []
 
 [lib]
 name = "flux_lsp"

--- a/src/server.rs
+++ b/src/server.rs
@@ -49,7 +49,7 @@ const PRELUDE_PACKAGE: &str = "prelude";
 // is preferred at this point.
 type FileStore = Arc<Mutex<HashMap<lsp::Url, String>>>;
 
-fn parse_and_analyze(
+pub(crate) fn parse_and_analyze(
     code: &str,
 ) -> Result<flux::semantic::nodes::Package> {
     let mut analyzer = flux::new_semantic_analyzer(
@@ -2831,9 +2831,8 @@ impl CompletionInfo {
             params.text_document_position.text_document.uri.clone();
         let position = params.text_document_position.position;
 
-        let pkg: Package =
-            parse_string(uri.to_string(), source.as_str()).into();
-        let walker = Rc::new(AstNode::File(&pkg.files[0]));
+        let file = parse_string(uri.to_string(), source.as_str());
+        let walker = Rc::new(AstNode::File(&file));
         let visitor = NodeFinderVisitor::new(move_back(position, 1));
 
         walk_rc(&visitor, walker);

--- a/wasm-build.sh
+++ b/wasm-build.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+#EXTRA_ARGS=--features=api_next
+EXTRA_ARGS=
+
 set -e
 
-wasm-pack build -t nodejs -d pkg-node --out-name flux-lsp-node --scope influxdata --release
-wasm-pack build -t browser -d pkg-browser --out-name flux-lsp-browser --scope influxdata --release
+wasm-pack build -t nodejs -d pkg-node --out-name flux-lsp-node --scope influxdata --release -- $EXTRA_ARGS
+wasm-pack build -t browser -d pkg-browser --out-name flux-lsp-browser --scope influxdata --release -- $EXTRA_ARGS
 
 cat pkg-node/package.json | sed s/@influxdata\\/flux-lsp\"/@influxdata\\/flux-lsp-node\"/g > pkg-node/package-new.json
 mv pkg-node/package-new.json pkg-node/package.json


### PR DESCRIPTION
This patch implements the interface described in #319, including tests.
It currently puts that work behind a feature flag so that the work isn't
consumable until the bit is flipped for that feature.

Not only does this work provide a cleaner interface, but the resulting
binary is about 20k smaller than the current release binaries.

Closes #319