### PR TITLE
chore: remove lsp_types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ futures = "0.3.15"
 js-sys = "0.3.51"
 line-col = "0.2.1"
 log = "0.4.14"
-lsp-types = "0.89.2"
 lspower = { version = "1.1.0", default-features = false, features = ["runtime-agnostic" ] }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,31 +1,27 @@
 use flux::ast;
 use flux::semantic::walk::Node;
+use lspower::lsp;
 
-/// Convert a flux::ast::Position to a lsp_types::Position
+/// Convert a flux::ast::Position to a lsp::Position
 /// https://microsoft.github.io/language-server-protocol/specification#position
 // XXX: rockstar (28 Jul 2021) - This can't be implemented in a From trait
 // without some clownshoes type aliasing, so this conversion function will work.
-fn ast_to_lsp_position(
-    position: &ast::Position,
-) -> lsp_types::Position {
-    lsp_types::Position {
+fn ast_to_lsp_position(position: &ast::Position) -> lsp::Position {
+    lsp::Position {
         line: position.line - 1,
         character: position.column - 1,
     }
 }
 
-/// Convert a flux::semantic::walk::Node to a lsp_types::Location
+/// Convert a flux::semantic::walk::Node to a lsp::Location
 /// https://microsoft.github.io/language-server-protocol/specification#location
 // XXX: rockstar (28 Jul 2021) - This can't be implemented in a From trait
 // without some clownshoes type aliasing, so this conversion function will work.
-pub fn node_to_location(
-    node: &Node,
-    uri: lsp_types::Url,
-) -> lsp_types::Location {
+pub fn node_to_location(node: &Node, uri: lsp::Url) -> lsp::Location {
     let node_location = node.loc();
-    lsp_types::Location {
+    lsp::Location {
         uri,
-        range: lsp_types::Range {
+        range: lsp::Range {
             start: ast_to_lsp_position(&node_location.start),
             end: ast_to_lsp_position(&node_location.end),
         },
@@ -43,7 +39,7 @@ mod tests {
 
     #[test]
     fn test_ast_to_lsp_position() {
-        let expected = lsp_types::Position {
+        let expected = lsp::Position {
             line: 22,
             character: 7,
         };
@@ -59,15 +55,15 @@ mod tests {
 
     #[test]
     fn test_node_to_location() {
-        let expected = lsp_types::Location {
-            uri: lsp_types::Url::parse("file:///path/to/file.flux")
+        let expected = lsp::Location {
+            uri: lsp::Url::parse("file:///path/to/file.flux")
                 .unwrap(),
-            range: lsp_types::Range {
-                start: lsp_types::Position {
+            range: lsp::Range {
+                start: lsp::Position {
                     line: 22,
                     character: 7,
                 },
-                end: lsp_types::Position {
+                end: lsp::Position {
                     line: 22,
                     character: 8,
                 },
@@ -94,8 +90,7 @@ mod tests {
 
         let result = node_to_location(
             &node,
-            lsp_types::Url::parse("file:///path/to/file.flux")
-                .unwrap(),
+            lsp::Url::parse("file:///path/to/file.flux").unwrap(),
         );
 
         assert_eq!(expected, result);

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -2,7 +2,7 @@ mod callbacks;
 mod signatures;
 
 use combinations::Combinations;
-use lsp_types as lsp;
+use lspower::lsp;
 
 pub use callbacks::Callbacks;
 pub use signatures::{

--- a/src/shared/signatures.rs
+++ b/src/shared/signatures.rs
@@ -1,10 +1,9 @@
 use std::collections::BTreeMap;
 
 use flux::semantic::types::{Function, MonoType};
+use lspower::lsp;
 
 use crate::shared::all_combos;
-
-use lsp_types as lsp;
 
 #[allow(clippy::implicit_hasher)]
 pub fn get_argument_names(

--- a/src/visitors/ast.rs
+++ b/src/visitors/ast.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use flux::ast::walk::{self, Node, Visitor};
-use lsp_types as lsp;
+use lspower::lsp;
 
 use crate::shared::flux_position_to_position;
 

--- a/src/visitors/semantic/completion.rs
+++ b/src/visitors/semantic/completion.rs
@@ -4,7 +4,7 @@ use flux::ast::SourceLocation;
 use flux::semantic::nodes::*;
 use flux::semantic::types::MonoType;
 use flux::semantic::walk::{Node, Visitor};
-use lsp_types as lsp;
+use lspower::lsp;
 
 use crate::shared::get_argument_names;
 use crate::shared::Function;

--- a/src/visitors/semantic/functions.rs
+++ b/src/visitors/semantic/functions.rs
@@ -5,10 +5,9 @@ use flux::ast::SourceLocation;
 use flux::semantic::nodes::Expression;
 use flux::semantic::types::MonoType;
 use flux::semantic::walk::{Node, Visitor};
+use lspower::lsp;
 
 use crate::shared::FunctionInfo;
-
-use lsp_types as lsp;
 
 #[derive(Default)]
 pub struct FunctionFinderState {

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -5,8 +5,7 @@ use crate::shared::get_package_name;
 
 use flux::semantic::nodes::*;
 use flux::semantic::walk::{self, Node, Visitor};
-
-use lsp_types as lsp;
+use lspower::lsp;
 
 mod completion;
 mod symbols;

--- a/src/visitors/semantic/symbols.rs
+++ b/src/visitors/semantic/symbols.rs
@@ -4,8 +4,7 @@ use std::rc::Rc;
 
 use flux::semantic::nodes::{self, Expression};
 use flux::semantic::walk::{Node, Visitor};
-
-use lsp_types as lsp;
+use lspower::lsp;
 
 fn parse_variable_assignment(
     uri: lsp::Url,


### PR DESCRIPTION
`lspower` re-exports `lsp_types` as `lspower::lsp`. We were using the
straight `lsp_types` types as a way to transition between old lsp and
new lsp. The issue shows up when `lsp_types` gets updated, and then
thoses types are incompatible with the `lspower` types.

This patch removes `lsp_types` entirely and uses the `lspower::lsp`
types instead.