### PR TITLE
refactor: Reduce the risk of deadlocks in server.rs

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -4564,8 +4564,11 @@ fn find_node(
 struct FunctionResult {
     name: String,
     package: String,
+    #[allow(dead_code)]
     package_name: Option<String>,
+    #[allow(dead_code)]
     required_args: Vec<String>,
+    #[allow(dead_code)]
     optional_args: Vec<String>,
     signature: String,
 }


### PR DESCRIPTION
Saw the heavy use of a sync-mutex in async code and got a bit worried about deadlocks so I refactored its use to reduce the scope that the lock exists (and refactored some nearby code).