### PR TITLE
feat: no more unwrap/expect/panic

### DIFF
--- a/src/bin/flux-lsp.rs
+++ b/src/bin/flux-lsp.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 use std::fs::OpenOptions;
 
 use clap::{App, Arg};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
+#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod convert;
 mod server;
 mod shared;

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -139,12 +139,13 @@ pub struct PackageInfo {
 
 pub fn get_package_infos() -> Vec<PackageInfo> {
     let mut result: Vec<PackageInfo> = vec![];
-    let env = imports().unwrap();
 
-    for (path, _val) in env.values {
-        let name = get_package_name(path.clone());
-        if let Some(name) = name {
-            result.push(PackageInfo { name, path })
+    if let Some(env) = imports() {
+        for (path, _val) in env.values {
+            let name = get_package_name(path.clone());
+            if let Some(name) = name {
+                result.push(PackageInfo { name, path })
+            }
         }
     }
 
@@ -181,14 +182,15 @@ fn walk_package_functions(
 }
 
 pub fn get_package_functions(name: String) -> Vec<Function> {
-    let env = imports().unwrap();
-
     let mut list = vec![];
 
-    for (key, val) in env.values {
-        if let Some(package_name) = get_package_name(key.clone()) {
-            if package_name == name {
-                walk_package_functions(key, &mut list, val.expr);
+    if let Some(env) = imports() {
+        for (key, val) in env.values {
+            if let Some(package_name) = get_package_name(key.clone())
+            {
+                if package_name == name {
+                    walk_package_functions(key, &mut list, val.expr);
+                }
             }
         }
     }
@@ -222,43 +224,44 @@ fn walk_functions(
 
 pub fn get_stdlib_functions() -> Vec<FunctionInfo> {
     let mut results = vec![];
-    let env = prelude().unwrap();
 
-    for (name, val) in env.values {
-        if let MonoType::Fun(f) = val.expr {
-            results.push(FunctionInfo::new(
-                name,
-                f.as_ref(),
-                BUILTIN_PACKAGE.to_string(),
-            ));
+    if let Some(env) = prelude() {
+        for (name, val) in env.values {
+            if let MonoType::Fun(f) = val.expr {
+                results.push(FunctionInfo::new(
+                    name,
+                    f.as_ref(),
+                    BUILTIN_PACKAGE.to_string(),
+                ));
+            }
         }
     }
 
-    let impts = imports().unwrap();
-
-    for (name, val) in impts.values {
-        walk_functions(name, &mut results, val.expr);
+    if let Some(imports) = imports() {
+        for (name, val) in imports.values {
+            walk_functions(name, &mut results, val.expr);
+        }
     }
 
     results
 }
 
 pub fn get_builtin_functions() -> Vec<Function> {
-    let env = prelude().unwrap();
-
     let mut list = vec![];
 
-    for (key, val) in env.values {
-        if let MonoType::Fun(f) = val.expr {
-            let mut params = get_argument_names(f.req);
-            for opt in get_argument_names(f.opt) {
-                params.push(opt);
-            }
+    if let Some(env) = prelude() {
+        for (key, val) in env.values {
+            if let MonoType::Fun(f) = val.expr {
+                let mut params = get_argument_names(f.req);
+                for opt in get_argument_names(f.opt) {
+                    params.push(opt);
+                }
 
-            list.push(Function {
-                name: key.clone(),
-                params,
-            })
+                list.push(Function {
+                    name: key.clone(),
+                    params,
+                })
+            }
         }
     }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,4 +1,12 @@
-#![allow(dead_code, unused_imports)]
+// `rustc` incorrectly identifies the `pub` symbols as dead code, as wasm_bindgen
+// is the tool that exports the interfaces. In this case, it is not a reliable lint.
+//
+// The `wasm_bindgen` macro itself expands to use `panic`, which `clippy::panic`
+// isn't a big fan of. _This_ code should not call `panic`, but there isn't a
+// way to enforce it on the macro-generated code.
+#![allow(dead_code, clippy::panic)]
+/// Wasm functionality, including wasm exported functions.
+///
 use std::ops::Add;
 use std::str;
 
@@ -30,20 +38,16 @@ struct ResponseError {
 #[wasm_bindgen]
 #[derive(Deserialize)]
 struct ServerResponse {
-    #[allow(dead_code)]
     message: Option<String>,
-    #[allow(dead_code)]
     error: Option<String>,
 }
 
 #[wasm_bindgen]
 impl ServerResponse {
-    #[allow(dead_code)]
     pub fn get_message(&self) -> Option<String> {
         self.message.clone()
     }
 
-    #[allow(dead_code)]
     pub fn get_error(&self) -> Option<String> {
         self.error.clone()
     }
@@ -87,7 +91,18 @@ impl Server {
             msg.lines().skip(2).fold(String::new(), |c, l| c.add(l));
 
         let message: lspower::jsonrpc::Incoming =
-            serde_json::from_str(&json_contents).unwrap();
+            match serde_json::from_str(&json_contents) {
+                Ok(value) => value,
+                Err(err) => {
+                    return Promise::resolve(
+                        &ServerResponse {
+                            message: None,
+                            error: Some(format!("{}", err)),
+                        }
+                        .into(),
+                    )
+                }
+            };
         let call = self.service.call(message);
         future_to_promise(async move {
             match call.await {
@@ -114,7 +129,13 @@ impl Server {
                         lspower::jsonrpc::Outgoing::Request(
                             _client_request,
                         ) => {
-                            panic!("Outgoing requests from server to client are not implemented");
+                            // Outgoing requests from server to client are
+                            // not currently implemented. This should never be
+                            // reached.
+                            Ok(JsValue::from(ServerResponse {
+                                message: None,
+                                error: Some("Server attempted to send a request to the client.".into()),
+                            }))
                         }
                     },
                     None => {
@@ -147,7 +168,13 @@ pub fn parse(script: &str) -> JsValue {
     let mut parser = Parser::new(script);
     let parsed = parser.parse_file("".to_string());
 
-    JsValue::from_serde(&parsed).unwrap()
+    match JsValue::from_serde(&parsed) {
+        Ok(value) => value,
+        Err(err) => {
+            log::error!("{}", err);
+            JsValue::from(script)
+        }
+    }
 }
 
 /// Format a flux script from AST.


### PR DESCRIPTION
This patch removes all blind unwrap and panic. This came out of an
iterative need while designing the new API, as I had all sorts issues
where the wasm would stop working because of a panic, and while it was a
coding error, I'd rather get some sort of output.