### PR TITLE
refactor: Shrink server.rs

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -3697,15 +3697,9 @@ fn walk_package(
                     list.push(Box::new(FunctionResult {
                         name: head.k.clone(),
                         package: package.clone(),
-                        signature: create_function_signature(
-                            f
-                        ),
-                        required_args: get_argument_names(
-                            &f.req,
-                        ),
-                        optional_args: get_argument_names(
-                            &f.opt,
-                        ),
+                        signature: create_function_signature(f),
+                        required_args: get_argument_names(&f.req),
+                        optional_args: get_argument_names(&f.opt),
                         package_name: get_package_name(
                             package.clone(),
                         ),
@@ -3980,9 +3974,7 @@ fn get_builtins(list: &mut Vec<Box<dyn Completable>>) {
                         package: PRELUDE_PACKAGE.to_string(),
                         package_name: None,
                         name: key.to_string(),
-                        signature: create_function_signature(
-                            &f,
-                        ),
+                        signature: create_function_signature(f),
                         required_args: get_argument_names(&f.req),
                         optional_args: get_argument_names(&f.opt),
                     }))

--- a/src/server.rs
+++ b/src/server.rs
@@ -3683,19 +3683,28 @@ fn walk_package(
 ) {
     if let MonoType::Record(record) = t {
         if let Record::Extension { head, tail } = record.as_ref() {
+            let mut push_var_result = |name: &str, var_type| {
+                list.push(Box::new(VarResult {
+                    name: name.to_owned(),
+                    var_type,
+                    package: package.clone(),
+                    package_name: get_package_name(package.clone()),
+                }));
+            };
+
             match &head.v {
                 MonoType::Fun(f) => {
                     list.push(Box::new(FunctionResult {
                         name: head.k.clone(),
                         package: package.clone(),
                         signature: create_function_signature(
-                            f.deref().clone(),
+                            f
                         ),
                         required_args: get_argument_names(
-                            f.req.clone(),
+                            &f.req,
                         ),
                         optional_args: get_argument_names(
-                            f.opt.clone(),
+                            &f.opt,
                         ),
                         package_name: get_package_name(
                             package.clone(),
@@ -3703,84 +3712,28 @@ fn walk_package(
                     }));
                 }
                 MonoType::Int => {
-                    list.push(Box::new(VarResult {
-                        name: head.k.clone(),
-                        var_type: VarType::Int,
-                        package: package.clone(),
-                        package_name: get_package_name(
-                            package.clone(),
-                        ),
-                    }));
+                    push_var_result(&head.k, VarType::Int)
                 }
                 MonoType::Float => {
-                    list.push(Box::new(VarResult {
-                        name: head.k.clone(),
-                        var_type: VarType::Float,
-                        package: package.clone(),
-                        package_name: get_package_name(
-                            package.clone(),
-                        ),
-                    }));
+                    push_var_result(&head.k, VarType::Float)
                 }
                 MonoType::Bool => {
-                    list.push(Box::new(VarResult {
-                        name: head.k.clone(),
-                        var_type: VarType::Bool,
-                        package: package.clone(),
-                        package_name: get_package_name(
-                            package.clone(),
-                        ),
-                    }));
+                    push_var_result(&head.k, VarType::Bool)
                 }
                 MonoType::Arr(_) => {
-                    list.push(Box::new(VarResult {
-                        name: head.k.clone(),
-                        var_type: VarType::Array,
-                        package: package.clone(),
-                        package_name: get_package_name(
-                            package.clone(),
-                        ),
-                    }));
+                    push_var_result(&head.k, VarType::Array)
                 }
                 MonoType::Bytes => {
-                    list.push(Box::new(VarResult {
-                        name: head.k.clone(),
-                        var_type: VarType::Bytes,
-                        package: package.clone(),
-                        package_name: get_package_name(
-                            package.clone(),
-                        ),
-                    }));
+                    push_var_result(&head.k, VarType::Bytes)
                 }
                 MonoType::Duration => {
-                    list.push(Box::new(VarResult {
-                        name: head.k.clone(),
-                        var_type: VarType::Duration,
-                        package: package.clone(),
-                        package_name: get_package_name(
-                            package.clone(),
-                        ),
-                    }));
+                    push_var_result(&head.k, VarType::Duration)
                 }
                 MonoType::Regexp => {
-                    list.push(Box::new(VarResult {
-                        name: head.k.clone(),
-                        var_type: VarType::Regexp,
-                        package: package.clone(),
-                        package_name: get_package_name(
-                            package.clone(),
-                        ),
-                    }));
+                    push_var_result(&head.k, VarType::Regexp)
                 }
                 MonoType::String => {
-                    list.push(Box::new(VarResult {
-                        name: head.k.clone(),
-                        var_type: VarType::String,
-                        package: package.clone(),
-                        package_name: get_package_name(
-                            package.clone(),
-                        ),
-                    }));
+                    push_var_result(&head.k, VarType::String)
                 }
                 _ => {}
             }
@@ -4013,85 +3966,39 @@ fn get_packages(list: &mut Vec<Box<dyn Completable>>) {
 fn get_builtins(list: &mut Vec<Box<dyn Completable>>) {
     if let Some(env) = prelude() {
         for (key, val) in env.values {
-            match val.expr {
+            let mut push_var_result = |var_type| {
+                list.push(Box::new(VarResult {
+                    name: key.to_string(),
+                    package: PRELUDE_PACKAGE.to_string(),
+                    package_name: None,
+                    var_type,
+                }));
+            };
+            match &val.expr {
                 MonoType::Fun(f) => {
                     list.push(Box::new(FunctionResult {
                         package: PRELUDE_PACKAGE.to_string(),
                         package_name: None,
                         name: key.to_string(),
                         signature: create_function_signature(
-                            (*f).clone(),
+                            &f,
                         ),
-                        required_args: get_argument_names(
-                            f.req.clone(),
-                        ),
-                        optional_args: get_argument_names(
-                            f.opt.clone(),
-                        ),
+                        required_args: get_argument_names(&f.req),
+                        optional_args: get_argument_names(&f.opt),
                     }))
                 }
-                MonoType::String => list.push(Box::new(VarResult {
-                    name: key.to_string(),
-                    package: PRELUDE_PACKAGE.to_string(),
-                    package_name: None,
-                    var_type: VarType::String,
-                })),
-                MonoType::Int => list.push(Box::new(VarResult {
-                    name: key.to_string(),
-                    package: PRELUDE_PACKAGE.to_string(),
-                    package_name: None,
-                    var_type: VarType::Int,
-                })),
-                MonoType::Float => list.push(Box::new(VarResult {
-                    name: key.to_string(),
-                    package: PRELUDE_PACKAGE.to_string(),
-                    package_name: None,
-                    var_type: VarType::Float,
-                })),
-                MonoType::Arr(_) => list.push(Box::new(VarResult {
-                    name: key.to_string(),
-                    package: PRELUDE_PACKAGE.to_string(),
-                    package_name: None,
-                    var_type: VarType::Array,
-                })),
-                MonoType::Bool => list.push(Box::new(VarResult {
-                    name: key.to_string(),
-                    package: PRELUDE_PACKAGE.to_string(),
-                    package_name: None,
-                    var_type: VarType::Bool,
-                })),
-                MonoType::Bytes => list.push(Box::new(VarResult {
-                    name: key.to_string(),
-                    package: PRELUDE_PACKAGE.to_string(),
-                    package_name: None,
-                    var_type: VarType::Bytes,
-                })),
+                MonoType::String => push_var_result(VarType::String),
+                MonoType::Int => push_var_result(VarType::Int),
+                MonoType::Float => push_var_result(VarType::Float),
+                MonoType::Arr(_) => push_var_result(VarType::Array),
+                MonoType::Bool => push_var_result(VarType::Bool),
+                MonoType::Bytes => push_var_result(VarType::Bytes),
                 MonoType::Duration => {
-                    list.push(Box::new(VarResult {
-                        name: key.to_string(),
-                        package: PRELUDE_PACKAGE.to_string(),
-                        package_name: None,
-                        var_type: VarType::Duration,
-                    }))
+                    push_var_result(VarType::Duration)
                 }
-                MonoType::Uint => list.push(Box::new(VarResult {
-                    name: key.to_string(),
-                    package: PRELUDE_PACKAGE.to_string(),
-                    package_name: None,
-                    var_type: VarType::Uint,
-                })),
-                MonoType::Regexp => list.push(Box::new(VarResult {
-                    name: key.to_string(),
-                    package: PRELUDE_PACKAGE.to_string(),
-                    package_name: None,
-                    var_type: VarType::Regexp,
-                })),
-                MonoType::Time => list.push(Box::new(VarResult {
-                    name: key.to_string(),
-                    package: PRELUDE_PACKAGE.to_string(),
-                    package_name: None,
-                    var_type: VarType::Time,
-                })),
+                MonoType::Uint => push_var_result(VarType::Uint),
+                MonoType::Regexp => push_var_result(VarType::Regexp),
+                MonoType::Time => push_var_result(VarType::Time),
                 _ => {}
             }
         }
@@ -4368,14 +4275,14 @@ fn create_function_result(
     expr: &SemanticExpression,
 ) -> Option<UserFunctionResult> {
     if let SemanticExpression::Function(f) = expr {
-        if let MonoType::Fun(fun) = f.typ.clone() {
+        if let MonoType::Fun(fun) = &f.typ {
             return Some(UserFunctionResult {
                 name,
                 package: "self".to_string(),
                 package_name: Some("self".to_string()),
-                optional_args: get_argument_names(fun.opt.clone()),
-                required_args: get_argument_names(fun.req.clone()),
-                signature: create_function_signature((*fun).clone()),
+                optional_args: get_argument_names(&fun.opt),
+                required_args: get_argument_names(&fun.req),
+                signature: create_function_signature(fun),
             });
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -4256,7 +4256,7 @@ fn get_var_type(
         SemanticExpression::Call(c) => {
             let result_type = follow_function_pipes(c);
 
-            match CompletionVarType::from_monotype(&result_type) {
+            match CompletionVarType::from_monotype(result_type) {
                 Some(typ) => Some(typ),
                 None => match result_type {
                     MonoType::Record(_) => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -3765,13 +3765,12 @@ impl Completable for PackageResult {
         let mut insert_text = self.name.clone();
 
         if imports
-            .clone()
-            .into_iter()
-            .map(|x| x.path)
-            .any(|x| x == self.full_name)
+            .iter()
+            .map(|x| &x.path)
+            .any(|x| *x == self.full_name)
         {
             let alias =
-                find_alias_name(imports, self.name.clone(), 1);
+                find_alias_name(&imports, self.name.clone(), 1);
 
             let new_text = if let Some(alias) = alias {
                 insert_text = alias.clone();
@@ -3998,7 +3997,7 @@ fn get_builtins(list: &mut Vec<Box<dyn Completable>>) {
 }
 
 fn find_alias_name(
-    imports: Vec<Import>,
+    imports: &[Import],
     name: String,
     iteration: i32,
 ) -> Option<String> {
@@ -4009,13 +4008,13 @@ fn find_alias_name(
         format!("{}{}", name, iteration)
     };
 
-    for import in imports.clone() {
+    for import in imports {
         if import.alias == pkg_name {
             return find_alias_name(imports, name, iteration + 1);
         }
 
-        if let Some(initial_name) = import.initial_name {
-            if initial_name == pkg_name && first_iteration {
+        if let Some(initial_name) = &import.initial_name {
+            if *initial_name == pkg_name && first_iteration {
                 return find_alias_name(imports, name, iteration + 1);
             }
         }

--- a/src/shared/signatures.rs
+++ b/src/shared/signatures.rs
@@ -7,7 +7,7 @@ use crate::shared::all_combos;
 
 #[allow(clippy::implicit_hasher)]
 pub fn get_argument_names(
-    args: BTreeMap<String, MonoType>,
+    args: &BTreeMap<String, MonoType>,
 ) -> Vec<String> {
     args.keys().map(String::from).collect()
 }
@@ -62,8 +62,8 @@ impl FunctionInfo {
         FunctionInfo {
             name,
             package_name,
-            required_args: get_argument_names(f.req.clone()),
-            optional_args: get_argument_names(f.opt.clone()),
+            required_args: get_argument_names(&f.req),
+            optional_args: get_argument_names(&f.opt),
         }
     }
 

--- a/src/visitors/semantic/completion.rs
+++ b/src/visitors/semantic/completion.rs
@@ -54,10 +54,8 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
 
                 if let Expression::Function(f) = assgn.init.clone() {
                     if let MonoType::Fun(fun) = f.typ.clone() {
-                        let mut params =
-                            get_argument_names(fun.req.clone());
-                        for opt in get_argument_names(fun.opt.clone())
-                        {
+                        let mut params = get_argument_names(&fun.req);
+                        for opt in get_argument_names(&fun.opt) {
                             params.push(opt);
                         }
 
@@ -80,10 +78,8 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
                     {
                         if let MonoType::Fun(fun) = f.typ.clone() {
                             let mut params =
-                                get_argument_names(fun.req.clone());
-                            for opt in
-                                get_argument_names(fun.opt.clone())
-                            {
+                                get_argument_names(&fun.req);
+                            for opt in get_argument_names(&fun.opt) {
                                 params.push(opt);
                             }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -96,7 +96,7 @@ impl Outgoing {
                 format!(
                     "Content-Length:{}\r\n\r\n{}",
                     lines[0],
-                    body[..length].to_string()
+                    &body[..length]
                 )
             } else {
                 format!("Content-Length:{}", possible_message)


### PR DESCRIPTION
At almost 5k lines, `server.rs` is quite large, with the tests taking up a large part of it so I moved the test module to its own file and merged some duplicated match arms. See individual commits