### PR TITLE
chore: Add rust toolchain file.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.56"
+components = [ "rustfmt", "clippy" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.56"
 components = [ "rustfmt", "clippy" ]
+targets = [ "wasm32-unknown-unknown", ]


### PR DESCRIPTION
Per <https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file>
`rustup` will check cargo projects for a toolchain file and will fetch
the specified toolchain version if it isn't already present in
`$CARGO_HOME`.

In this, the toolchain file provides a _project-specific_ toolchain
override, allowing individual projects to be pinned to different
versions (if desired).

The intent here is to help unify the standards (lints) applied between
local dev and CI and also signal when a toolchain bump is expected.

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
