### PR TITLE
feat: add new wasm-export LSP API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           command: cargo fmt --all -- --check
       - run:
           name: "run lint"
-          command: cargo clippy --all -- -Dclippy::all
+          command: cargo clippy --all --features=wasm_next -- -Dclippy::all
 
   test:
     docker:
@@ -37,7 +37,7 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - run: cargo build --verbose
+      - run: cargo build --verbose --features=wasm_next
 
   wasm-build:
     docker:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ lto = true
 [features]
 default = ["strict"]
 strict = []
+wasm_next = []
 
 [lib]
 name = "flux_lsp"
@@ -37,6 +38,7 @@ async-trait = "0.1.50"
 clap = "2.33.3"
 combinations = "0.1.0"
 console_error_panic_hook = "0.1.7"
+console_log = { version = "0.2", optional = true }
 flux = { git = "https://github.com/influxdata/flux", tag = "v0.140.0" }
 futures = "0.3.15"
 js-sys = "0.3.51"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,13 +6,7 @@ mod shared;
 mod stdlib;
 mod visitors;
 mod wasm;
+#[cfg(feature = "wasm_next")]
+mod wasm2;
 
 pub use server::LspServer;
-
-#[cfg(target_arch = "wasm32")]
-#[macro_export]
-macro_rules! console_log {
-    ( $( $t:tt )* ) => {
-        web_sys::console::log_1(&format!( $( $t )* ).into());
-    }
-}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -12,6 +12,7 @@ use std::str;
 
 use flux::ast::File;
 use flux::formatter::convert_to_string;
+use flux::parser::Parser;
 use futures::prelude::*;
 use js_sys::{Function, Promise};
 use serde::{Deserialize, Serialize};
@@ -20,7 +21,6 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
 use crate::LspServer;
-use flux::parser::Parser;
 
 fn wrap_message(s: String) -> String {
     let st = s.clone();

--- a/src/wasm2.rs
+++ b/src/wasm2.rs
@@ -1,0 +1,221 @@
+#![allow(dead_code, clippy::panic, clippy::unwrap_used)]
+use std::sync::{Arc, Mutex};
+
+use futures::prelude::*;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::future_to_promise;
+
+use crate::LspServer;
+
+/// Initialize logging - this requires the "console_log" feature to function,
+/// as this library adds 180k to the wasm binary being shipped.
+#[allow(non_snake_case, dead_code)]
+#[wasm_bindgen]
+pub fn initLog() {
+    #[cfg(feature = "console_log")]
+    console_log::init_with_level(log::Level::Trace)
+        .expect("error initializing log");
+}
+
+struct Incoming {
+    messages: Arc<Mutex<Vec<String>>>,
+}
+
+impl futures::io::AsyncRead for Incoming {
+    #[inline]
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut async_std::task::Context<'_>,
+        buffer: &mut [u8],
+    ) -> async_std::task::Poll<async_std::io::Result<usize>> {
+        let mut messages = self.messages.lock().unwrap();
+        if messages.is_empty() {
+            return async_std::task::Poll::Pending;
+        }
+        let mut byte_count = 0;
+        for message in messages.iter() {
+            log::debug!("writing message for read: {:?}", message);
+            let length = message.len();
+            buffer[byte_count..length]
+                .copy_from_slice(&message.as_bytes()[..length]);
+            byte_count += length;
+        }
+        // Empty out messages
+        messages.retain(|_x| false);
+        assert!(messages.len() == 0);
+        async_std::task::Poll::Ready(Ok(byte_count))
+    }
+}
+
+struct Outgoing {
+    server: Arc<Lsp>,
+    messages: Arc<Mutex<Vec<String>>>,
+}
+
+impl Outgoing {
+    pub fn new(server: Arc<Lsp>) -> Self {
+        Outgoing {
+            server,
+            messages: Arc::new(Mutex::new(vec![])),
+        }
+    }
+}
+
+impl async_std::io::Write for Outgoing {
+    #[inline]
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut async_std::task::Context<'_>,
+        buf: &[u8],
+    ) -> async_std::task::Poll<async_std::io::Result<usize>> {
+        let string = std::str::from_utf8(buf).unwrap();
+        log::debug!("string: \"{}\"", string);
+        let parts = string.split("Content-Length:");
+        let mut byte_count = 0;
+        for part in parts.filter(|msg| !msg.is_empty()) {
+            let message = format!("Content-Length:{}", part);
+            byte_count += message.len();
+            self.server.fire(&message);
+        }
+
+        async_std::task::Poll::Ready(Ok(byte_count))
+    }
+
+    #[inline]
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut async_std::task::Context<'_>,
+    ) -> async_std::task::Poll<async_std::io::Result<()>> {
+        async_std::task::Poll::Ready(Ok(()))
+    }
+
+    #[inline]
+    fn poll_close(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut async_std::task::Context<'_>,
+    ) -> async_std::task::Poll<async_std::io::Result<()>> {
+        async_std::task::Poll::Ready(Ok(()))
+    }
+}
+
+/// Lsp is the core lsp server interface.
+#[wasm_bindgen]
+pub struct Lsp {
+    message_handlers: Vec<js_sys::Function>,
+    incoming: Arc<Mutex<Vec<String>>>,
+}
+
+impl Default for Lsp {
+    fn default() -> Self {
+        console_error_panic_hook::set_once();
+
+        let incoming = Arc::new(Mutex::new(vec![]));
+
+        Lsp {
+            message_handlers: vec![],
+            incoming,
+        }
+    }
+}
+
+#[wasm_bindgen]
+impl Lsp {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fire the message handlers with the server message.
+    pub(crate) fn fire(&self, msg: &str) {
+        for handler in self.message_handlers.iter() {
+            // Set the context to `undefined` explicitly, so the error
+            // message on `this` usage is clear.
+            log::debug!("firing");
+            if let Err(err) =
+                handler.call1(&JsValue::UNDEFINED, &msg.into())
+            {
+                log::error!("{:?}", err);
+            }
+        }
+    }
+
+    /// Attach a message handler to server messages.
+    #[allow(non_snake_case)]
+    pub fn onMessage(&mut self, func: js_sys::Function) {
+        self.message_handlers.push(func)
+    }
+
+    /// Send a message to the server.
+    pub fn send(&mut self, msg: String) -> js_sys::Promise {
+        let incoming = self.incoming.clone();
+        future_to_promise(async move {
+            let mut messages = incoming.lock().unwrap();
+            messages.push(msg);
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
+    /// Run the server.
+    ///
+    /// Note: this will run for the lifetime of the server. It should not be
+    /// `await`ed. However, as it returns a Promise, it's a good idea to attach
+    /// handlers for completion and error. If the promise ever resolves, the server
+    /// is no longer running, which may serve as a hint that attention is needed.
+    pub fn run(self) -> js_sys::Promise {
+        let (service, messages) =
+            lspower::LspService::new(|_client| LspServer::default());
+        let server = lspower::Server::new(
+            Incoming {
+                messages: self.incoming.clone(),
+            },
+            Outgoing::new(Arc::new(self)),
+        )
+        .interleave(messages);
+        let future =
+            std::panic::AssertUnwindSafe(server.serve(service));
+        future_to_promise(
+            async move {
+                future.await;
+                Ok(JsValue::UNDEFINED)
+            }
+            .catch_unwind()
+            .unwrap_or_else(|err| {
+                Err(JsValue::from({
+                    err.downcast::<String>()
+                        .map(|s| *s)
+                        .unwrap_or_else(|err| {
+                            err.downcast::<&str>()
+                                .ok()
+                                .map(|s| s.to_string())
+                                .unwrap_or_else(|| {
+                                    "Unknown panic occurred"
+                                        .to_string()
+                                })
+                        })
+                }))
+            }),
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use wasm_bindgen_test::*;
+
+    use super::*;
+
+    #[wasm_bindgen_test]
+    async fn test_lsp() {
+        let message = r#"Content-Length: 84
+
+{"method": "initialize", "params": { "capabilities": {}}, "jsonrpc": "2.0", "id": 1}"#;
+
+        let mut server = Lsp::new();
+        let _ = server.send(message.into());
+
+        let promise = server.run();
+        let _result = wasm_bindgen_futures::JsFuture::from(promise)
+            .await
+            .unwrap();
+    }
+}


### PR DESCRIPTION
This patch adds a new `Lsp` struct that represents the next
wasm-exported API for flux-lsp. It sits behind a `wasm_next` feature
flag, as it is still a work-in-progress and will need some extensive
testing before it's released.

This API has very small interface, and would look like this:

```
const { Lsp } = await import('@influxdata/flux-lsp-node');
const server = new Lsp();

server.onMessage((message) => {
  // Handle the message
})

server.run();

const request = 'Content-Length: 83\r\n\r\n{...}';
await server.send(request)
```

The core change here is the message handler API, and `server.send`
(which is roughly equivalent `server.process` in the current api)
doesn't return a value anymore (though still returns a promise, for
async reasons). The message handler can now receive messages from the
server regardless of whether they were initiated by the client, which
enables `ClientRequest` functionality.

Additionally, this patch carries another potential feature flag in
`console_log`, which enables the `log` mechanism for the javascript
console. This became invaluable in debugging, but carries a heavy size
penalty (see docs for `initLog`), so should only be enabled during
debugging.

_Please note:_ While this work represents a significant effort, this API
is still highly experimental and will need some integration work with
clients before it can be considered mature and ready for production.

Closes #333