### PR TITLE
feat: buffer the writes and fire on flush

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,10 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
-#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#![deny(
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::wildcard_imports
+)]
 mod convert;
 mod server;
 mod shared;

--- a/src/visitors/semantic/completion.rs
+++ b/src/visitors/semantic/completion.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use flux::ast::SourceLocation;
-use flux::semantic::nodes::*;
+use flux::semantic::nodes::Expression;
 use flux::semantic::types::MonoType;
 use flux::semantic::walk::{Node, Visitor};
 use lspower::lsp;

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use crate::shared::get_package_name;
 
-use flux::semantic::nodes::*;
+use flux::semantic::nodes::Expression;
 use flux::semantic::walk::{self, Node, Visitor};
 use lspower::lsp;
 


### PR DESCRIPTION
This patch converts the `Outgoing` interface to buffer writes and
then fire the event handlers when `flush` is called. The naive parsing
of bytes to messages has been made a bit more robust, but has a (noted)
glaring issue with it.

Much of this work will likely be heavily refactored/removed after the
fact. The important deliverable here is the external API, and everything
behind-the-scenes can be comfortably re-worked.