### PR TITLE
feat: update to flux v0.143.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,7 +654,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.5.1"
-source = "git+https://github.com/influxdata/flux?tag=v0.140.0#25a872ef8ddec9c3fffa464c1465fd2a632f201f"
+source = "git+https://github.com/influxdata/flux?tag=v0.143.1#b15224a579e4c0aacdef6def3abc81ffada88d0a"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -658,7 +671,7 @@ dependencies = [
 [[package]]
 name = "flux-core"
 version = "0.4.0"
-source = "git+https://github.com/influxdata/flux?tag=v0.140.0#25a872ef8ddec9c3fffa464c1465fd2a632f201f"
+source = "git+https://github.com/influxdata/flux?tag=v0.143.1#b15224a579e4c0aacdef6def3abc81ffada88d0a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -667,6 +680,7 @@ dependencies = [
  "derivative",
  "derive_more",
  "ena",
+ "env_logger",
  "flatbuffers",
  "fnv",
  "lazy_static",
@@ -689,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "flux-lsp"
-version = "0.6.12"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-std",
@@ -901,6 +915,12 @@ name = "httparse"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ clap = "2.33.3"
 combinations = "0.1.0"
 console_error_panic_hook = "0.1.7"
 console_log = { version = "0.2", optional = true }
-flux = { git = "https://github.com/influxdata/flux", tag = "v0.140.0" }
+flux = { git = "https://github.com/influxdata/flux", tag = "v0.143.1" }
 futures = "0.3.15"
 js-sys = "0.3.51"
 line-col = "0.2.1"

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -84,7 +84,7 @@ mod tests {
                 source: None,
             },
             typ: MonoType::String,
-            name: "a".to_string(),
+            name: "a".into(),
         };
         let node = Node::IdentifierExpr(&expr);
 

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -143,9 +143,12 @@ pub fn get_package_infos() -> Vec<PackageInfo> {
 
     if let Some(env) = imports() {
         for (path, _val) in env.values {
-            let name = get_package_name(path.clone());
+            let name = get_package_name(path.to_string());
             if let Some(name) = name {
-                result.push(PackageInfo { name, path })
+                result.push(PackageInfo {
+                    name,
+                    path: path.to_string(),
+                })
             }
         }
     }
@@ -191,10 +194,15 @@ pub fn get_package_functions(name: String) -> Vec<Function> {
 
     if let Some(env) = imports() {
         for (key, val) in env.values {
-            if let Some(package_name) = get_package_name(key.clone())
+            if let Some(package_name) =
+                get_package_name(key.to_string())
             {
                 if package_name == name {
-                    walk_package_functions(key, &mut list, val.expr);
+                    walk_package_functions(
+                        key.to_string(),
+                        &mut list,
+                        val.expr,
+                    );
                 }
             }
         }
@@ -234,7 +242,7 @@ pub fn get_stdlib_functions() -> Vec<FunctionInfo> {
         for (name, val) in env.values {
             if let MonoType::Fun(f) = val.expr {
                 results.push(FunctionInfo::new(
-                    name,
+                    name.to_string(),
                     f.as_ref(),
                     BUILTIN_PACKAGE.to_string(),
                 ));
@@ -244,7 +252,7 @@ pub fn get_stdlib_functions() -> Vec<FunctionInfo> {
 
     if let Some(imports) = imports() {
         for (name, val) in imports.values {
-            walk_functions(name, &mut results, val.expr);
+            walk_functions(name.to_string(), &mut results, val.expr);
         }
     }
 
@@ -263,7 +271,7 @@ pub fn get_builtin_functions() -> Vec<Function> {
                 }
 
                 list.push(Function {
-                    name: key.clone(),
+                    name: key.to_string(),
                     params,
                 })
             }

--- a/src/visitors/semantic/completion.rs
+++ b/src/visitors/semantic/completion.rs
@@ -61,9 +61,10 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
                             params.push(opt);
                         }
 
-                        state
-                            .functions
-                            .push(Function { name, params })
+                        state.functions.push(Function {
+                            name: name.to_string(),
+                            params,
+                        })
                     }
                 }
             }
@@ -86,9 +87,10 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
                                 params.push(opt);
                             }
 
-                            state
-                                .functions
-                                .push(Function { name, params })
+                            state.functions.push(Function {
+                                name: name.to_string(),
+                                params,
+                            })
                         }
                     }
                 }
@@ -132,14 +134,14 @@ impl<'a> Visitor<'a> for ObjectFunctionFinderVisitor {
                             let params = fun
                                 .params
                                 .into_iter()
-                                .map(|p| p.key.name)
+                                .map(|p| p.key.name.to_string())
                                 .collect::<Vec<String>>();
 
                             if let Ok(mut state) = self.state.lock() {
                                 state.results.push(ObjectFunction {
-                                    object: object_name,
+                                    object: object_name.to_string(),
                                     function: Function {
-                                        name: func_name,
+                                        name: func_name.to_string(),
                                         params,
                                     },
                                 });
@@ -166,7 +168,7 @@ impl<'a> Visitor<'a> for ObjectFunctionFinderVisitor {
                                 let params = fun
                                     .params
                                     .into_iter()
-                                    .map(|p| p.key.name)
+                                    .map(|p| p.key.name.to_string())
                                     .collect::<Vec<String>>();
 
                                 if let Ok(mut state) =
@@ -174,9 +176,11 @@ impl<'a> Visitor<'a> for ObjectFunctionFinderVisitor {
                                 {
                                     state.results.push(
                                         ObjectFunction {
-                                            object: object_name,
+                                            object: object_name
+                                                .to_string(),
                                             function: Function {
-                                                name: func_name,
+                                                name: func_name
+                                                    .to_string(),
                                                 params,
                                             },
                                         },

--- a/src/visitors/semantic/functions.rs
+++ b/src/visitors/semantic/functions.rs
@@ -61,7 +61,7 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
 
         if let Node::VariableAssgn(assgn) = node {
             if let Some(f) = create_function_result(
-                assgn.id.name.clone(),
+                assgn.id.name.to_string(),
                 &assgn.init,
             ) {
                 let mut state = self.state.borrow_mut();

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -97,19 +97,19 @@ impl<'a> Visitor<'a> for IdentFinderVisitor<'a> {
         match node.clone() {
             walk::Node::MemberExpr(m) => {
                 if let Expression::Identifier(i) = m.object.clone() {
-                    if i.name == state.name {
+                    if *i.name == state.name {
                         return true;
                     }
                 }
                 return false;
             }
             walk::Node::Identifier(n) => {
-                if n.name == state.name {
+                if *n.name == state.name {
                     state.identifiers.push(node.clone());
                 }
             }
             walk::Node::IdentifierExpr(n) => {
-                if n.name == state.name {
+                if *n.name == state.name {
                     state.identifiers.push(node.clone());
                 }
             }
@@ -146,7 +146,7 @@ impl<'a> Visitor<'a> for DefinitionFinderVisitor<'a> {
 
         match node {
             walk::Node::VariableAssgn(v) => {
-                if v.id.name == state.name {
+                if *v.id.name == state.name {
                     state.node = Some(node.clone());
                     return false;
                 }
@@ -215,7 +215,7 @@ impl<'a> Visitor<'a> for ImportFinderVisitor {
 
         if let Node::ImportDeclaration(import) = node {
             let alias = match import.alias.clone() {
-                Some(alias) => alias.name,
+                Some(alias) => alias.name.to_string(),
                 None => get_package_name(import.path.value.clone())
                     .unwrap_or_else(|| "".to_string()),
             };

--- a/src/visitors/semantic/symbols.rs
+++ b/src/visitors/semantic/symbols.rs
@@ -16,7 +16,7 @@ fn parse_variable_assignment(
     if let Expression::Function(f) = va.init.clone() {
         result.push(lsp::SymbolInformation {
             kind: lsp::SymbolKind::Function,
-            name: va.id.name.clone(),
+            name: va.id.name.to_string(),
             location: lsp::Location {
                 uri: uri.clone(),
                 range: lsp::Range {
@@ -38,7 +38,7 @@ fn parse_variable_assignment(
         for param in f.params {
             result.push(lsp::SymbolInformation {
                 kind: lsp::SymbolKind::Variable,
-                name: param.key.name,
+                name: param.key.name.to_string(),
                 location: lsp::Location {
                     uri: uri.clone(),
                     range: lsp::Range {
@@ -60,7 +60,7 @@ fn parse_variable_assignment(
     } else {
         result.push(lsp::SymbolInformation {
             kind: lsp::SymbolKind::Variable,
-            name: va.id.name.clone(),
+            name: va.id.name.to_string(),
             location: lsp::Location {
                 uri,
                 range: lsp::Range {
@@ -92,7 +92,7 @@ fn parse_call_expression(
     if let Expression::Identifier(ident) = c.callee.clone() {
         result.push(lsp::SymbolInformation {
             kind: lsp::SymbolKind::Function,
-            name: ident.name,
+            name: ident.name.to_string(),
             location: lsp::Location {
                 uri: uri.clone(),
                 range: lsp::Range {
@@ -116,7 +116,7 @@ fn parse_call_expression(
         if let Expression::Function(_) = arg.value {
             result.push(lsp::SymbolInformation {
                 kind: lsp::SymbolKind::Function,
-                name: arg.key.name.clone(),
+                name: arg.key.name.to_string(),
                 location: lsp::Location {
                     uri: uri.clone(),
                     range: lsp::Range {
@@ -137,7 +137,7 @@ fn parse_call_expression(
         } else {
             result.push(lsp::SymbolInformation {
                 kind: lsp::SymbolKind::Variable,
-                name: arg.key.name.clone(),
+                name: arg.key.name.to_string(),
                 location: lsp::Location {
                     uri: uri.clone(),
                     range: lsp::Range {
@@ -170,7 +170,7 @@ fn parse_binary_expression(
     if let Expression::Identifier(ident) = be.left.clone() {
         result.push(lsp::SymbolInformation {
             kind: lsp::SymbolKind::Variable,
-            name: ident.name.clone(),
+            name: ident.name.to_string(),
             location: lsp::Location {
                 uri: uri.clone(),
                 range: lsp::Range {
@@ -193,7 +193,7 @@ fn parse_binary_expression(
     if let Expression::Identifier(ident) = be.right.clone() {
         result.push(lsp::SymbolInformation {
             kind: lsp::SymbolKind::Variable,
-            name: ident.name.clone(),
+            name: ident.name.to_string(),
             location: lsp::Location {
                 uri,
                 range: lsp::Range {


### PR DESCRIPTION
This patch updates flux-lsp to work with flux `v0.143.1`. It highlights
a number of places where the code is poorly factored. There is a lot of
`String` use where it's probably not needed, and a copious amount of
`clone`-gone-`to_string` calls made. Rather than pulling on the thread
and watching a refactoring unravel everything, I opted for the smallest
change to get the newest flux formatter changes, will file more specific
issues to make things better in these other places.