### PR TITLE
fix: don't complete stdlib items starting with underscore

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -604,10 +604,11 @@ fn get_stdlib_matches(
     let mut matches = vec![];
     let completes = get_stdlib_completables();
 
-    for c in completes.into_iter() {
-        if c.matches(name.clone(), info.clone()) {
-            matches.push(c.completion_item(info.clone()));
-        }
+    for c in completes
+        .into_iter()
+        .filter(|x| x.matches(name.clone(), info.clone()))
+    {
+        matches.push(c.completion_item(info.clone()));
     }
 
     matches
@@ -1197,6 +1198,10 @@ fn get_packages(list: &mut Vec<Box<dyn Completable>>) {
 fn get_builtins(list: &mut Vec<Box<dyn Completable>>) {
     if let Some(env) = prelude() {
         for (key, val) in env.values {
+            if key.starts_with('_') {
+                // Don't allow users to "discover" private-ish functionality.
+                continue;
+            }
             match val.expr {
                 MonoType::Fun(f) => {
                     list.push(Box::new(FunctionResult {

--- a/src/server.rs
+++ b/src/server.rs
@@ -2331,7 +2331,6 @@ ab = 10
             items.iter().map(|i| i.label.as_str()).collect();
 
         let want: HashSet<&str> = vec![
-            "_window",
             "aggregateWindow",
             "cardinality",
             "chandeMomentumOscillator",
@@ -2604,9 +2603,6 @@ errorCounts
             items.iter().map(|i| i.label.as_str()).collect();
 
         let want: HashSet<&str> = vec![
-            "_fillEmpty",
-            "_highestOrLowest",
-            "_sortLimit",
             "aggregateWindow",
             "bottom",
             "buckets",


### PR DESCRIPTION
Some functionality was introduced in flux which is...well, sort of private.
It wouldn't be detrimental to know about and use, necessarily, but we don't
want the lsp to help users discover that functionality. This patch changes
the stdlib completion code to not complete items that start with an
underscore.

Fixes #308