### PR TITLE
feat: add an LspServerBuilder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,4 +12,4 @@ mod stdlib;
 mod visitors;
 mod wasm;
 
-pub use server::LspServer;
+pub use server::LspServerBuilder;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -5,7 +5,7 @@ use futures::prelude::*;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
-use crate::LspServer;
+use crate::server::LspServerBuilder;
 
 /// Initialize logging - this requires the "console_log" feature to function,
 /// as this library adds 180k to the wasm binary being shipped.
@@ -209,7 +209,9 @@ impl Lsp {
     /// is no longer running, which may serve as a hint that attention is needed.
     pub fn run(self) -> js_sys::Promise {
         let (service, messages) =
-            lspower::LspService::new(|_client| LspServer::default());
+            lspower::LspService::new(|_client| {
+                LspServerBuilder::default().build()
+            });
         let server = lspower::Server::new(
             Incoming {
                 messages: self.incoming.clone(),


### PR DESCRIPTION
We always used the builder pattern, kinda. Not using a separate struct
certainly carried with it some baggage, which makes it clear why it's
usually implemented that way. This patch rectifies that.

Additionally, it removes some of the options from `LspServerOptions`
because they never should have been there in the first place. Holding on
to secrets and uris isn't really the job of the lsp server, and we
should explicitly forbid that as a pattern.