### PR TITLE
feat: add ability to publish diagnostics

### DIFF
--- a/integration/lsp.test.ts
+++ b/integration/lsp.test.ts
@@ -95,8 +95,23 @@ describe('LSP Server', () => {
         // If the test runs without a timeout then it passed.
         const runner = server.run();
         await init(server);
+        await shutdown(server, runner);
+    });
+
+    it('sends diagnostics', async () => {
+        const callback = jest.fn((message) => {
+            console.log('callback', message);
+        });
+        server.onMessage(callback);
+        const runner = server.run();
+        await init(server);
+
+        const openRequest = '{"jsonrpc": "2.0", "id": 2, "method": "textDocument/didOpen", "params": { "textDocument": {"uri":"file:///main.flux","languageId":"flux","version":1,"text":"x ="}}}';
+        await server.send(openRequest)
 
         await shutdown(server, runner);
+
+        expect(callback).toHaveBeenCalled();
     });
 });
 describe('module', () => {

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -12,6 +12,13 @@ fn ast_to_lsp_position(position: &ast::Position) -> lsp::Position {
         character: position.column - 1,
     }
 }
+/// Convert a flux::ast::SourceLocation to a lsp::Range.
+pub fn ast_to_lsp_range(loc: &ast::SourceLocation) -> lsp::Range {
+    lsp::Range {
+        start: ast_to_lsp_position(&loc.start),
+        end: ast_to_lsp_position(&loc.end),
+    }
+}
 
 /// Convert a flux::semantic::walk::Node to a lsp::Location
 /// https://microsoft.github.io/language-server-protocol/specification#location


### PR DESCRIPTION
With this change we now publish diagnostics for Flux files based on the
results of analysis.

This change depends on two other changes:

~https://github.com/silvanshade/lspower/pull/20~
https://github.com/influxdata/flux/pull/4314 (Merged)

Based on ~https://github.com/influxdata/flux-lsp/pull/357~ and https://github.com/influxdata/flux-lsp/pull/356 (Merged)

~#357 is not required and if it gets delayed we can make that change later~

Update: Rebased the change to not require #357 to be merged.

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
