### PR TITLE
fix: adds important await to integration tests

### DIFF
--- a/integration/lsp.test.ts
+++ b/integration/lsp.test.ts
@@ -22,6 +22,7 @@ describe('LSP Server', () => {
         const exit = '{"jsonrpc": "2.0", "method": "exit"}';
         await server.send(shutdown)
         await server.send(exit)
+        await runner
     }
 
     it('responds to initialize request', async () => {


### PR DESCRIPTION
Somewhere in the refactor the await to wait for the server to finish
running was lost. This adds it back in. Thankfully the tests still pass
but now we ensure they will continue to test the to correct behavior.
