### PR TITLE
fix: update to Flux master for ExportEnvironment changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,13 +654,13 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.5.1"
-source = "git+https://github.com/influxdata/flux?tag=v0.143.1#b15224a579e4c0aacdef6def3abc81ffada88d0a"
+source = "git+https://github.com/influxdata/flux?tag=v0.144.0#eb10cfb089b18e702dd81e3f64a660425c7c6b82"
 dependencies = [
  "anyhow",
  "flatbuffers",
  "flux-core",
  "getrandom",
- "lazy_static",
+ "once_cell",
  "serde",
  "serde-aux",
  "serde_derive",
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "flux-core"
 version = "0.4.0"
-source = "git+https://github.com/influxdata/flux?tag=v0.143.1#b15224a579e4c0aacdef6def3abc81ffada88d0a"
+source = "git+https://github.com/influxdata/flux?tag=v0.144.0#eb10cfb089b18e702dd81e3f64a660425c7c6b82"
 dependencies = [
  "anyhow",
  "chrono",
@@ -683,10 +683,10 @@ dependencies = [
  "env_logger",
  "flatbuffers",
  "fnv",
- "lazy_static",
  "libflate",
  "log",
  "maplit",
+ "once_cell",
  "pad",
  "pulldown-cmark",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ clap = "2.33.3"
 combinations = "0.1.0"
 console_error_panic_hook = "0.1.7"
 console_log = { version = "0.2", optional = true }
-flux = { git = "https://github.com/influxdata/flux", tag = "v0.143.1" }
+flux = { git = "https://github.com/influxdata/flux", tag = "v0.144.0" }
 futures = "0.3.15"
 js-sys = "0.3.51"
 line-col = "0.2.1"

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -31,7 +31,7 @@ where
     result
 }
 
-pub fn get_package_name(name: String) -> Option<String> {
+pub fn get_package_name(name: &str) -> Option<String> {
     let items = name.split('/');
     items.last().map(|n| n.to_string())
 }

--- a/src/shared/signatures.rs
+++ b/src/shared/signatures.rs
@@ -7,7 +7,7 @@ use crate::shared::all_combos;
 
 #[allow(clippy::implicit_hasher)]
 pub fn get_argument_names(
-    args: BTreeMap<String, MonoType>,
+    args: &BTreeMap<String, MonoType>,
 ) -> Vec<String> {
     args.keys().map(String::from).collect()
 }
@@ -62,8 +62,8 @@ impl FunctionInfo {
         FunctionInfo {
             name,
             package_name,
-            required_args: get_argument_names(f.req.clone()),
-            optional_args: get_argument_names(f.opt.clone()),
+            required_args: get_argument_names(&f.req),
+            optional_args: get_argument_names(&f.opt),
         }
     }
 

--- a/src/visitors/semantic/completion.rs
+++ b/src/visitors/semantic/completion.rs
@@ -54,10 +54,8 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
 
                 if let Expression::Function(f) = assgn.init.clone() {
                     if let MonoType::Fun(fun) = f.typ.clone() {
-                        let mut params =
-                            get_argument_names(fun.req.clone());
-                        for opt in get_argument_names(fun.opt.clone())
-                        {
+                        let mut params = get_argument_names(&fun.req);
+                        for opt in get_argument_names(&fun.opt) {
                             params.push(opt);
                         }
 
@@ -80,10 +78,8 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
                     {
                         if let MonoType::Fun(fun) = f.typ.clone() {
                             let mut params =
-                                get_argument_names(fun.req.clone());
-                            for opt in
-                                get_argument_names(fun.opt.clone())
-                            {
+                                get_argument_names(&fun.req);
+                            for opt in get_argument_names(&fun.opt) {
                                 params.push(opt);
                             }
 

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -216,7 +216,7 @@ impl<'a> Visitor<'a> for ImportFinderVisitor {
         if let Node::ImportDeclaration(import) = node {
             let alias = match import.alias.clone() {
                 Some(alias) => alias.name.to_string(),
-                None => get_package_name(import.path.value.clone())
+                None => get_package_name(import.path.value.as_str())
                     .unwrap_or_else(|| "".to_string()),
             };
 
@@ -224,7 +224,7 @@ impl<'a> Visitor<'a> for ImportFinderVisitor {
                 path: import.path.value.clone(),
                 alias,
                 initial_name: get_package_name(
-                    import.path.value.clone(),
+                    import.path.value.as_str(),
                 ),
             });
         }


### PR DESCRIPTION
The ExportEnvironment now only exposes references to MonoTypes this
change updates the code to be able to use those references without the
need to clone.

