### PR TITLE
fix: readds parse and format_from_js_file functions

### DIFF
--- a/integration/lsp.test.ts
+++ b/integration/lsp.test.ts
@@ -99,3 +99,26 @@ describe('LSP Server', () => {
         await shutdown(server, runner);
     });
 });
+describe('module', () => {
+
+    it('can parse Flux source' , async () => {
+        const { parse } = await import('@influxdata/flux-lsp-node');
+        const ast = parse('x = 1');
+        // expect some basic parts of this ast
+        expect(ast).toBeDefined();
+        expect(ast).toHaveProperty('type', 'File');
+        expect(ast).toHaveProperty('location.source', 'x = 1');
+        expect(ast).toHaveProperty('metadata', 'parser-type=rust');
+        expect(ast).toHaveProperty('body');
+    })
+
+    it('can format Flux source' , async () => {
+        const { parse, format_from_js_file } = await import('@influxdata/flux-lsp-node');
+        const ast = parse('x = 1');
+        // Change AST
+        ast.body[0].init.value = '2';
+        // Format into new source
+        const src = format_from_js_file(ast);
+        expect(src).toBe('x = 2');
+    })
+})

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -2,6 +2,7 @@
 
 use std::mem;
 
+use flux::{ast, formatter, parser};
 use futures::prelude::*;
 use lspower::{LspService, MessageStream};
 use tower_service::Service;
@@ -210,6 +211,41 @@ impl Lsp {
     }
 }
 
+/// Parse flux into an AST representation. The AST will be generated regardless
+/// of valid flux. As such, no error handling is needed.
+#[allow(dead_code)]
+#[wasm_bindgen]
+pub fn parse(script: &str) -> JsValue {
+    let mut parser = parser::Parser::new(script);
+    let parsed = parser.parse_file("".to_string());
+
+    match JsValue::from_serde(&parsed) {
+        Ok(value) => value,
+        Err(err) => {
+            log::error!("{}", err);
+            JsValue::from(script)
+        }
+    }
+}
+
+/// Format a flux script from AST.
+///
+/// In the event that the flux is invalid syntax, an Err will be returned,
+/// which will translate into a JavaScript exception being thrown.
+#[allow(dead_code)]
+#[wasm_bindgen]
+pub fn format_from_js_file(
+    js_file: JsValue,
+) -> Result<String, JsValue> {
+    match js_file.into_serde::<ast::File>() {
+        Ok(file) => match formatter::convert_to_string(&file) {
+            Ok(formatted) => Ok(formatted),
+            Err(e) => Err(format!("{}", e).into()),
+        },
+        Err(e) => Err(format!("{}", e).into()),
+    }
+}
+
 #[cfg(test)]
 mod test {
     use wasm_bindgen_test::*;
@@ -227,5 +263,60 @@ mod test {
         let _result = wasm_bindgen_futures::JsFuture::from(promise)
             .await
             .unwrap();
+    }
+
+    /// Valid flux is parsed, and a JavaScript object is returned.
+    #[wasm_bindgen_test]
+    fn test_parse() {
+        let script = r#"option task = { name: "beetle", every: 1h }
+from(bucket: "inbucket")
+  |> range(start: -task.every)
+  |> filter(fn: (r) => r["_measurement"] == "activity")
+  |> filter(fn: (r) => r["target"] == "crumbs")"#;
+
+        let parsed = parse(&script);
+
+        assert!(parsed.is_object());
+    }
+
+    /// Invalid flux is still parsed, and a JavaScript object is returned.
+    #[wasm_bindgen_test]
+    fn test_parse_invalid() {
+        let script = r#"this isn't flux"#;
+
+        let parsed = parse(&script);
+
+        assert!(parsed.is_object());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_format_from_js_file() {
+        let expected = r#"option task = {name: "beetle", every: 1h}
+from(bucket: "inbucket")
+    |> range(start: -task.every)
+    |> filter(fn: (r) => r["_measurement"] == "activity")"#;
+
+        let script = r#"option task={name:"beetle",every:1h} from(bucket:"inbucket")
+|>range(start:-task.every)|>filter(fn:(r)=>r["_measurement"]=="activity")"#;
+        let parsed = parse(&script);
+
+        let formatted = format_from_js_file(parsed).unwrap();
+
+        assert_eq!(expected, formatted);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_format_from_js_file_invalid() {
+        let script = r#"from(bucket:this isn't flux"#;
+        let parsed = parse(&script);
+
+        if let Err(error) = format_from_js_file(parsed) {
+            assert_eq!(
+                "invalid type: map, expected a string at line 1 column 2134",
+                error.as_string().unwrap()
+            );
+        } else {
+            panic!("Formatting invalid flux did not throw an error");
+        }
     }
 }


### PR DESCRIPTION
These functions accidentally got removed during the LSP refactor of the
WASM API. We now have integration tests to assert they are packaged in
the module.
