### PR TITLE
fix: Don't inject duplicate package imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dissimilar"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31ad93652f40969dead8d4bf897a41e9462095152eb21c56e5830537e41179dd"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +630,16 @@ name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
+name = "expect-test"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffc5e8bf4af3ae147a7797c5d0566d9f038e49179213e29f44ddb031aea96c7"
+dependencies = [
+ "dissimilar",
+ "once_cell",
+]
 
 [[package]]
 name = "fake-simd"
@@ -713,6 +729,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "criterion",
+ "expect-test",
  "flux",
  "futures",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ clap = "2.33.3"
 combinations = "0.1.0"
 console_error_panic_hook = "0.1.7"
 console_log = { version = "0.2", optional = true }
+expect-test = "1"
 flux = { git = "https://github.com/influxdata/flux", tag = "v0.146.0" }
 futures = "0.3.15"
 js-sys = "0.3.51"

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -893,7 +893,7 @@ impl Completable for stdlib::PackageResult {
         if imports
             .iter()
             .map(|x| &x.path)
-            .any(|x| *x == self.full_name)
+            .all(|x| *x != self.full_name)
         {
             let alias =
                 find_alias_name(&imports, self.name.clone(), 1);

--- a/src/server.rs
+++ b/src/server.rs
@@ -1187,8 +1187,7 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     use async_std::test;
-    use lspower::lsp;
-    use lspower::LanguageServer;
+    use lspower::{lsp, LanguageServer};
 
     use super::*;
 
@@ -3087,5 +3086,62 @@ errorCounts
         let result = server.references(params.clone()).await.unwrap();
 
         assert!(result.is_none());
+    }
+
+    #[test]
+    async fn test_package_completion_when_it_is_imported() {
+        let fluxscript = r#"import "sql"
+
+sql"#;
+        let server = create_server();
+        open_file(&server, fluxscript.to_string()).await;
+
+        let params = lsp::CompletionParams {
+            text_document_position: lsp::TextDocumentPositionParams {
+                text_document: lsp::TextDocumentIdentifier {
+                    uri: lsp::Url::parse(
+                        "file:///home/user/file.flux",
+                    )
+                    .unwrap(),
+                },
+                position: lsp::Position {
+                    line: 2,
+                    character: 2,
+                },
+            },
+            work_done_progress_params: lsp::WorkDoneProgressParams {
+                work_done_token: None,
+            },
+            partial_result_params: lsp::PartialResultParams {
+                partial_result_token: None,
+            },
+            context: Some(lsp::CompletionContext {
+                trigger_kind: lsp::CompletionTriggerKind::INVOKED,
+                trigger_character: None,
+            }),
+        };
+
+        let result =
+            server.completion(params.clone()).await.unwrap().unwrap();
+
+        // We should not try to insert the `sql` import again
+        expect_test::expect![[r#"
+            {
+              "isIncomplete": false,
+              "items": [
+                {
+                  "label": "sql",
+                  "kind": 9,
+                  "detail": "Package",
+                  "documentation": "sql",
+                  "sortText": "sql",
+                  "filterText": "sql",
+                  "insertText": "sql",
+                  "insertTextFormat": 1,
+                  "additionalTextEdits": []
+                }
+              ]
+            }"#]]
+        .assert_eq(&serde_json::to_string_pretty(&result).unwrap());
     }
 }


### PR DESCRIPTION
For code like this

```flux
import "sampledata"

sampledata
```

Completing on `sampledata` would insert
`import sampledata2 "sampledata"` before completing the code to

```flux
import sampledata2 "sampledata"
import "sampledata"

sampledata2
```

Which is rather redundant when the package is already imported.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
