### PR TITLE
refactor: cleanup completion code to not clone the contents

### DIFF
--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -37,11 +37,15 @@ pub fn get_package_name(name: &str) -> Option<String> {
 }
 
 pub fn flux_position_to_position(
-    pos: flux::ast::Position,
+    pos: &flux::ast::Position,
 ) -> lsp::Position {
-    lsp::Position {
-        line: pos.line - 1,
-        character: pos.column - 1,
+    if pos.line == 0 || pos.column == 0 {
+        lsp::Position::default()
+    } else {
+        lsp::Position {
+            line: pos.line - 1,
+            character: pos.column - 1,
+        }
     }
 }
 

--- a/src/visitors/ast.rs
+++ b/src/visitors/ast.rs
@@ -1,7 +1,10 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use flux::ast::walk::{self, Node, Visitor};
+use flux::ast::{
+    walk::{self, Visitor},
+    Package,
+};
 use lspower::lsp;
 
 use crate::shared::flux_position_to_position;
@@ -167,27 +170,13 @@ pub struct PackageInfo {
     pub position: lsp::Position,
 }
 
-#[derive(Default)]
-pub struct PackageFinderState {
-    pub info: Option<PackageInfo>,
-}
-
-#[derive(Clone, Default)]
-pub struct PackageFinderVisitor {
-    pub state: Rc<RefCell<PackageFinderState>>,
-}
-
-impl<'a> Visitor<'a> for PackageFinderVisitor {
-    fn visit(&self, node: Rc<Node<'a>>) -> Option<Self> {
-        if let Node::PackageClause(p) = node.as_ref() {
-            let mut state = self.state.borrow_mut();
-            state.info = Some(PackageInfo {
-                name: "".to_string(),
-                position: flux_position_to_position(
-                    p.base.location.clone().start,
-                ),
-            })
+impl From<&Package> for PackageInfo {
+    fn from(pkg: &Package) -> Self {
+        Self {
+            name: pkg.package.clone(),
+            position: flux_position_to_position(
+                &pkg.base.location.start,
+            ),
         }
-        Some(self.clone())
     }
 }


### PR DESCRIPTION
Additionally this change removes a few places where we parsed the same
contents multiple times in order access the AST

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
