### PR TITLE
feat: add documentHighlight support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -114,15 +114,17 @@ Also ensure that the wasm file is not being parsed by any file loader plugins, a
 
 # Supported LSP features
 
+- completionItem/resolve
 - initialize
 - shutdown
+- textDocument/completion
 - textDocument/definition
 - textDocument/didChange
 - textDocument/didOpen
 - textDocument/didSave
+- textDocument/documentHighlight
+- textDocument/documentSymbol
 - textDocument/foldingRange
+- textDocument/hover
 - textDocument/references
 - textDocument/rename
-- textDocument/completion
-- textDocument/documentSymbol
-- completionItem/resolve

--- a/src/server.rs
+++ b/src/server.rs
@@ -229,6 +229,7 @@ impl LspServer {
             }
         }
     }
+
     fn get_document(&self, key: &lsp::Url) -> RpcResult<String> {
         let store = match self.store.lock() {
             Ok(value) => value,
@@ -246,9 +247,28 @@ impl LspServer {
         if let Some(contents) = store.get(key) {
             Ok(contents.clone())
         } else {
-            Err(file_not_opened(key))
+            Err(lspower::jsonrpc::Error::invalid_params(format!(
+                "file not opened: {}",
+                key
+            )))
         }
     }
+
+    fn parse_analyze_document(
+        &self,
+        key: &lsp::Url,
+    ) -> RpcResult<flux::semantic::nodes::Package> {
+        let contents = self.get_document(key)?;
+        match parse_and_analyze(&contents) {
+            Ok(pkg) => Ok(pkg),
+            Err(err) => RpcResult::Err(RpcError {
+                code: RpcErrorCode::InternalError,
+                message: format!("{}", err),
+                data: None,
+            }),
+        }
+    }
+
     // Publish any diagnostics to the client
     async fn publish_diagnostics(&self, key: &lsp::Url, text: &str) {
         // If we have a client back to the editor report any diagnostics found in the document
@@ -271,6 +291,7 @@ impl LspServer {
             };
         };
     }
+
     fn compute_diagnostics(
         &self,
         key: &lsp::Url,
@@ -398,6 +419,7 @@ impl LanguageServer for LspServer {
             }),
         })
     }
+
     async fn shutdown(&self) -> RpcResult<()> {
         let mut client = match self.client.lock() {
             Ok(client) => client,
@@ -416,6 +438,7 @@ impl LanguageServer for LspServer {
         *client = None;
         Ok(())
     }
+
     async fn did_open(
         &self,
         params: lsp::DidOpenTextDocumentParams,
@@ -450,6 +473,7 @@ impl LanguageServer for LspServer {
             }
         }
     }
+
     async fn did_change(
         &self,
         params: lsp::DidChangeTextDocumentParams,
@@ -495,6 +519,7 @@ impl LanguageServer for LspServer {
         };
         self.publish_diagnostics(&key, contents.as_str()).await;
     }
+
     async fn did_save(
         &self,
         params: lsp::DidSaveTextDocumentParams,
@@ -526,6 +551,7 @@ impl LanguageServer for LspServer {
             self.publish_diagnostics(&k, c.as_str()).await;
         }
     }
+
     async fn did_close(
         &self,
         params: lsp::DidCloseTextDocumentParams,
@@ -553,22 +579,14 @@ impl LanguageServer for LspServer {
             );
         }
     }
+
     async fn signature_help(
         &self,
         params: lsp::SignatureHelpParams,
     ) -> RpcResult<Option<lsp::SignatureHelp>> {
         let key =
             params.text_document_position_params.text_document.uri;
-        let pkg = {
-            let data = self.get_document(&key)?;
-            match parse_and_analyze(data.as_str()) {
-                Ok(pkg) => pkg,
-                Err(err) => {
-                    log::debug!("{}", err);
-                    return Ok(None);
-                }
-            }
-        };
+        let pkg = self.parse_analyze_document(&key)?;
 
         let mut signatures = vec![];
         let node_finder_result = find_node(
@@ -610,33 +628,15 @@ impl LanguageServer for LspServer {
         };
         Ok(Some(response))
     }
+
     async fn formatting(
         &self,
         params: lsp::DocumentFormattingParams,
     ) -> RpcResult<Option<Vec<lsp::TextEdit>>> {
         let key = params.text_document.uri;
 
-        let store = match self.store.lock() {
-            Ok(value) => value,
-            Err(err) => {
-                return Err(lspower::jsonrpc::Error {
-                    code: lspower::jsonrpc::ErrorCode::InternalError,
-                    message: format!(
-                        "Could not acquire store lock. Error: {}",
-                        err
-                    ),
-                    data: None,
-                });
-            }
-        };
-        let contents = store.get(&key).ok_or_else(|| {
-            log::error!(
-                "formatting failed: file {} not open on server",
-                key
-            );
-            file_not_opened(&key)
-        })?;
-        let mut formatted = match flux::formatter::format(contents) {
+        let contents = self.get_document(&key)?;
+        let mut formatted = match flux::formatter::format(&contents) {
             Ok(value) => value,
             Err(err) => {
                 return Err(lspower::jsonrpc::Error {
@@ -696,41 +696,13 @@ impl LanguageServer for LspServer {
 
         Ok(Some(vec![edit]))
     }
+
     async fn folding_range(
         &self,
         params: lsp::FoldingRangeParams,
     ) -> RpcResult<Option<Vec<lsp::FoldingRange>>> {
         let key = params.text_document.uri;
-        let pkg = {
-            let store = match self.store.lock() {
-                Ok(value) => value,
-                Err(err) => {
-                    return Err(lspower::jsonrpc::Error {
-                        code:
-                            lspower::jsonrpc::ErrorCode::InternalError,
-                        message: format!(
-                            "Could not acquire store lock. Error: {}",
-                            err
-                        ),
-                        data: None,
-                    });
-                }
-            };
-            let contents = store.get(&key).ok_or_else(|| {
-                log::error!(
-                    "formatting failed: file {} not open on server",
-                    key
-                );
-                file_not_opened(&key)
-            })?;
-            match parse_and_analyze(contents.as_str()) {
-                Ok(pkg) => pkg,
-                Err(err) => {
-                    log::debug!("{}", err);
-                    return Ok(None);
-                }
-            }
-        };
+        let pkg = self.parse_analyze_document(&key)?;
         let mut visitor = semantic::FoldFinderVisitor::default();
         let pkg_node = walk::Node::Package(&pkg);
 
@@ -752,42 +724,13 @@ impl LanguageServer for LspServer {
 
         Ok(Some(results))
     }
+
     async fn document_symbol(
         &self,
         params: lsp::DocumentSymbolParams,
     ) -> RpcResult<Option<lsp::DocumentSymbolResponse>> {
         let key = params.text_document.uri;
-        let pkg = {
-            let store = match self.store.lock() {
-                Ok(value) => value,
-                Err(err) => {
-                    return Err(lspower::jsonrpc::Error {
-                        code:
-                            lspower::jsonrpc::ErrorCode::InternalError,
-                        message: format!(
-                            "Could not acquire store lock. Error: {}",
-                            err
-                        ),
-                        data: None,
-                    });
-                }
-            };
-            let contents = store.get(&key).ok_or_else(|| {
-                log::error!(
-                    "documentSymbol request failed: file {} not open on server",
-                    key,
-                );
-                file_not_opened(&key)
-            })?;
-
-            match parse_and_analyze(contents) {
-                Ok(pkg) => pkg,
-                Err(err) => {
-                    log::debug!("{}", err);
-                    return Ok(None);
-                }
-            }
-        };
+        let pkg = self.parse_analyze_document(&key)?;
         let pkg_node = walk::Node::Package(&pkg);
         let mut visitor = semantic::SymbolsVisitor::new(key);
         walk::walk(&mut visitor, pkg_node);
@@ -810,39 +753,14 @@ impl LanguageServer for LspServer {
 
         Ok(Some(response))
     }
+
     async fn goto_definition(
         &self,
         params: lsp::GotoDefinitionParams,
     ) -> RpcResult<Option<lsp::GotoDefinitionResponse>> {
         let key =
             params.text_document_position_params.text_document.uri;
-        let store = match self.store.lock() {
-            Ok(value) => value,
-            Err(err) => {
-                return Err(lspower::jsonrpc::Error {
-                    code: lspower::jsonrpc::ErrorCode::InternalError,
-                    message: format!(
-                        "Could not acquire store lock. Error: {}",
-                        err
-                    ),
-                    data: None,
-                });
-            }
-        };
-        let contents = store.get(&key).ok_or_else(|| {
-            log::error!(
-                "formatting failed: file {} not open on server",
-                key
-            );
-            file_not_opened(&key)
-        })?;
-        let pkg = match parse_and_analyze(contents) {
-            Ok(pkg) => pkg,
-            Err(err) => {
-                log::debug!("{}", err);
-                return Ok(None);
-            }
-        };
+        let pkg = self.parse_analyze_document(&key)?;
         let pkg_node = walk::Node::Package(&pkg);
         let mut visitor = semantic::NodeFinderVisitor::new(
             params.text_document_position_params.position,
@@ -915,42 +833,14 @@ impl LanguageServer for LspServer {
         }
         Ok(None)
     }
+
     async fn rename(
         &self,
         params: lsp::RenameParams,
     ) -> RpcResult<Option<lsp::WorkspaceEdit>> {
         let key =
             params.text_document_position.text_document.uri.clone();
-        let pkg = {
-            let store = match self.store.lock() {
-                Ok(value) => value,
-                Err(err) => {
-                    return Err(lspower::jsonrpc::Error {
-                        code:
-                            lspower::jsonrpc::ErrorCode::InternalError,
-                        message: format!(
-                            "Could not acquire store lock. Error: {}",
-                            err
-                        ),
-                        data: None,
-                    });
-                }
-            };
-            let contents = store.get(&key).ok_or_else(|| {
-                log::error!(
-                    "textDocument/rename called on unknown file {}",
-                    key
-                );
-                file_not_opened(&key)
-            })?;
-            match parse_and_analyze(contents) {
-                Ok(pkg) => pkg,
-                Err(err) => {
-                    log::debug!("{}", err);
-                    return Ok(None);
-                }
-            }
-        };
+        let pkg = self.parse_analyze_document(&key)?;
         let node = find_node(
             walk::Node::Package(&pkg),
             params.text_document_position.position,
@@ -975,20 +865,14 @@ impl LanguageServer for LspServer {
         };
         Ok(Some(response))
     }
+
     async fn document_highlight(
         &self,
         params: lsp::DocumentHighlightParams,
     ) -> RpcResult<Option<Vec<lsp::DocumentHighlight>>> {
         let key =
             params.text_document_position_params.text_document.uri;
-        let contents = self.get_document(&key)?;
-        let pkg = match parse_and_analyze(&contents) {
-            Ok(pkg) => pkg,
-            Err(err) => {
-                log::debug!("{}", err);
-                return Ok(None);
-            }
-        };
+        let pkg = self.parse_analyze_document(&key)?;
         let node = find_node(
             walk::Node::Package(&pkg),
             params.text_document_position_params.position,
@@ -1005,19 +889,13 @@ impl LanguageServer for LspServer {
                 .collect(),
         ))
     }
+
     async fn references(
         &self,
         params: lsp::ReferenceParams,
     ) -> RpcResult<Option<Vec<lsp::Location>>> {
         let key = params.text_document_position.text_document.uri;
-        let contents = self.get_document(&key)?;
-        let pkg = match parse_and_analyze(&contents) {
-            Ok(pkg) => pkg,
-            Err(err) => {
-                log::debug!("{}", err);
-                return Ok(None);
-            }
-        };
+        let pkg = self.parse_analyze_document(&key)?;
         let node = find_node(
             walk::Node::Package(&pkg),
             params.text_document_position.position,
@@ -1025,22 +903,14 @@ impl LanguageServer for LspServer {
 
         Ok(Some(find_references(key, node)))
     }
+
     async fn hover(
         &self,
         params: lsp::HoverParams,
     ) -> RpcResult<Option<lsp::Hover>> {
         let key =
             params.text_document_position_params.text_document.uri;
-        let pkg = {
-            let data = self.get_document(&key)?;
-            match parse_and_analyze(data.as_str()) {
-                Ok(pkg) => pkg,
-                Err(err) => {
-                    log::debug!("{}", err);
-                    return Ok(None);
-                }
-            }
-        };
+        let pkg = self.parse_analyze_document(&key)?;
 
         let node_finder_result = find_node(
             walk::Node::Package(&pkg),
@@ -1137,13 +1007,6 @@ impl LanguageServer for LspServer {
         let response = lsp::CompletionResponse::List(items);
         Ok(Some(response))
     }
-}
-
-fn file_not_opened(key: &lsp::Url) -> lspower::jsonrpc::Error {
-    lspower::jsonrpc::Error::invalid_params(format!(
-        "file not opened: {}",
-        key
-    ))
 }
 
 #[derive(Default, Clone)]
@@ -3040,9 +2903,9 @@ errorCounts
             },
         };
 
-        let result = server.signature_help(params).await.unwrap();
+        let result = server.signature_help(params).await;
 
-        assert!(result.is_none())
+        assert!(result.is_err())
     }
 
     #[test]
@@ -3064,9 +2927,9 @@ errorCounts
             },
         };
 
-        let result = server.folding_range(params).await.unwrap();
+        let result = server.folding_range(params).await;
 
-        assert!(result.is_none());
+        assert!(result.is_err());
     }
 
     #[test]
@@ -3087,9 +2950,9 @@ errorCounts
                 partial_result_token: None,
             },
         };
-        let result = server.document_symbol(params).await.unwrap();
+        let result = server.document_symbol(params).await;
 
-        assert!(result.is_none());
+        assert!(result.is_err());
     }
 
     #[test]
@@ -3117,9 +2980,9 @@ errorCounts
             },
         };
 
-        let result = server.goto_definition(params).await.unwrap();
+        let result = server.goto_definition(params).await;
 
-        assert!(result.is_none());
+        assert!(result.is_err());
     }
 
     #[test]
@@ -3153,8 +3016,8 @@ errorCounts
             },
         };
 
-        let result = server.references(params.clone()).await.unwrap();
+        let result = server.references(params.clone()).await;
 
-        assert!(result.is_none());
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
With this change the server now supports the
textDocument/documentHighlight feature. The implementation is to report
all references of the identifier at the position.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass