### PR TITLE
refactor: Remove unnecessary Rc<RefCell<_>> wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,6 +557,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +725,7 @@ dependencies = [
  "line-col",
  "log",
  "lspower",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "serde_repr",
@@ -1147,6 +1154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "pad"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1284,18 @@ name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0cfe1b2403f172ba0f234e500906ee0a3e493fb81092dac23ebefe129301cc"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ js-sys = "0.3.51"
 line-col = "0.2.1"
 log = "0.4.14"
 lspower = { version = "=1.4.0", default-features = false, features = ["runtime-agnostic" ] }
+pretty_assertions = "1"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 serde_repr = "0.1.7"

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -391,9 +391,7 @@ fn get_imports(
 
     flux::semantic::walk::walk(&mut visitor, walker);
 
-    let state = visitor.state.borrow();
-
-    Ok((*state).imports.clone())
+    Ok(visitor.imports)
 }
 
 fn get_imports_removed(
@@ -407,9 +405,7 @@ fn get_imports_removed(
 
     flux::semantic::walk::walk(&mut visitor, walker);
 
-    let state = visitor.state.borrow();
-
-    Ok((*state).imports.clone())
+    Ok(visitor.imports)
 }
 
 fn move_back(position: lsp::Position, count: u32) -> lsp::Position {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,8 @@ mod stdlib;
 mod visitors;
 mod wasm;
 
+#[cfg(test)]
+#[macro_use]
+extern crate pretty_assertions;
+
 pub use server::LspServerBuilder;

--- a/src/server.rs
+++ b/src/server.rs
@@ -85,9 +85,8 @@ fn is_scope(name: &str, n: walk::Node<'_>) -> bool {
     let mut dvisitor =
         semantic::DefinitionFinderVisitor::new(name.to_string());
     walk::walk(&mut dvisitor, n.clone());
-    let state = dvisitor.state.borrow();
 
-    state.node.is_some()
+    dvisitor.node.is_some()
 }
 
 fn find_references(
@@ -124,9 +123,7 @@ fn find_references(
             semantic::IdentFinderVisitor::new(name.to_string());
         walk::walk(&mut visitor, scope);
 
-        let state = visitor.state.borrow();
-
-        let locations: Vec<lsp::Location> = (*state)
+        let locations: Vec<lsp::Location> = visitor
             .identifiers
             .iter()
             .map(|node| convert::node_to_location(node, uri.clone()))
@@ -734,8 +731,7 @@ impl LanguageServer for LspServer {
 
         walk::walk(&mut visitor, pkg_node);
 
-        let state = visitor.state.borrow();
-        let nodes = (*state).nodes.clone();
+        let nodes = visitor.nodes;
 
         let mut results = vec![];
         for node in nodes {
@@ -790,8 +786,7 @@ impl LanguageServer for LspServer {
         let mut visitor = semantic::SymbolsVisitor::new(key);
         walk::walk(&mut visitor, pkg_node);
 
-        let state = visitor.state.borrow();
-        let mut symbols = (*state).symbols.clone();
+        let mut symbols = visitor.symbols;
 
         symbols.sort_by(|a, b| {
             let a_start = a.location.range.start;
@@ -848,9 +843,8 @@ impl LanguageServer for LspServer {
 
         flux::semantic::walk::walk(&mut visitor, pkg_node);
 
-        let state = visitor.state.borrow();
-        let node = (*state).node.clone();
-        let path = (*state).path.clone();
+        let node = visitor.node.clone();
+        let path = visitor.path;
 
         if let Some(node) = node {
             let name = match node {
@@ -892,9 +886,9 @@ impl LanguageServer for LspServer {
                                 n.clone(),
                             );
 
-                            let state =
-                                definition_visitor.state.borrow();
-                            if let Some(node) = state.node.clone() {
+                            if let Some(node) =
+                                definition_visitor.node.clone()
+                            {
                                 let location =
                                     convert::node_to_location(
                                         &node, key,
@@ -1171,10 +1165,8 @@ fn find_node(
 
     flux::semantic::walk::walk(&mut visitor, node);
 
-    let state = visitor.state.borrow();
-
-    result.node = (*state).node.clone();
-    result.path = (*state).path.clone();
+    result.node = visitor.node;
+    result.path = visitor.path;
 
     result
 }


### PR DESCRIPTION
These are no longer necessary after I refactored the `Visitor`  trait a while back to take `&mut self`