### PR TITLE
refactor: give None when invalid flux source means a meaningful response body can't be built

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -3082,8 +3082,7 @@ errorCounts
         };
 
         let result = server.signature_help(params).await;
-
-        assert!(result.is_err())
+        assert!(matches!(result, Ok(None)));
     }
 
     #[test]
@@ -3106,8 +3105,7 @@ errorCounts
         };
 
         let result = server.folding_range(params).await;
-
-        assert!(result.is_err());
+        assert!(matches!(result, Ok(None)));
     }
 
     #[test]
@@ -3130,7 +3128,7 @@ errorCounts
         };
         let result = server.document_symbol(params).await;
 
-        assert!(result.is_err());
+        assert!(matches!(result, Ok(None)));
     }
 
     #[test]
@@ -3159,8 +3157,7 @@ errorCounts
         };
 
         let result = server.goto_definition(params).await;
-
-        assert!(result.is_err());
+        assert!(matches!(result, Ok(None)));
     }
 
     #[test]
@@ -3196,7 +3193,7 @@ errorCounts
 
         let result = server.references(params.clone()).await;
 
-        assert!(result.is_err());
+        assert!(matches!(result, Ok(None)));
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1086,16 +1086,11 @@ impl LanguageServer for LspServer {
         let items = match items {
             Ok(items) => items,
             Err(e) => {
-                log::error!(
-                    "error getting completion items: {}",
+                log::warn!(
+                    "failed to get completion items: {}",
                     e.msg
                 );
-                return Err(lspower::jsonrpc::Error::invalid_params(
-                    format!(
-                        "error getting completion items: {}",
-                        e.msg
-                    ),
-                ));
+                return Ok(None);
             }
         };
 


### PR DESCRIPTION
In a situation where the flux document fails to type check, requesting
completions would lead to an RPC error.

~~Clients like the one used in the `com.github.gtache.lsp` will crash when they
encounter an RPC error, while the JS-based clients such as vscode and
the web UI seem to ignore them.~~

From a practical standpoint, it seems as though returning "no items" is
roughly equivalent to ignoring the error. The client will get no
completion information either way.


**Update:** after switching to a new LSP client API and finding similar breakage, and remarks from Markus in the standup today about "[RPC Errors] really signalling the client to close," I came back and tried to make this PR more comprehensive.

The gist here is to try and separate _programmer error_ (client and server) problems from _userland_ problems by handing back empty responses when we're unable to offer anything more meaningful due to the input document being invalid.

This initial effort focuses on the package analysis code, signalling the analysis may not possible by changing the return value to be a `Result<Option<T>>` instead of a `Result<T>`. 

Longer-term it may be beneficial to revisit the error handling so we can be more explicit about how things are failing when they do. Right now I think we're losing information by leaning on `anyhow` as we are. By retaining more detail in our errors we might signal this specific case without the `Option`.

Closes <https://github.com/influxdata/intellij-flux/issues/5>

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
