### PR TITLE
refactor: Remove some redundant code/cloning

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -796,37 +796,10 @@ fn walk_package(
                     &head.k.clone().into(),
                     VarType::Array,
                 ),
-                MonoType::Builtin(b) => match b {
-                    BuiltinType::Int => push_var_result(
-                        &head.k.clone().into(),
-                        VarType::Int,
-                    ),
-                    BuiltinType::Float => push_var_result(
-                        &head.k.clone().into(),
-                        VarType::Float,
-                    ),
-                    BuiltinType::Bool => push_var_result(
-                        &head.k.clone().into(),
-                        VarType::Bool,
-                    ),
-                    BuiltinType::Bytes => push_var_result(
-                        &head.k.clone().into(),
-                        VarType::Bytes,
-                    ),
-                    BuiltinType::Duration => push_var_result(
-                        &head.k.clone().into(),
-                        VarType::Duration,
-                    ),
-                    BuiltinType::Regexp => push_var_result(
-                        &head.k.clone().into(),
-                        VarType::Regexp,
-                    ),
-                    BuiltinType::String => push_var_result(
-                        &head.k.clone().into(),
-                        VarType::String,
-                    ),
-                    _ => (),
-                },
+                MonoType::Builtin(b) => push_var_result(
+                    &head.k.clone().into(),
+                    VarType::from(*b),
+                ),
                 _ => (),
             }
 
@@ -1077,33 +1050,9 @@ fn get_builtins(list: &mut Vec<Box<dyn Completable>>) {
                     }))
                 }
                 MonoType::Arr(_) => push_var_result(VarType::Array),
-                MonoType::Builtin(b) => match b {
-                    BuiltinType::String => {
-                        push_var_result(VarType::String)
-                    }
-                    BuiltinType::Int => push_var_result(VarType::Int),
-                    BuiltinType::Float => {
-                        push_var_result(VarType::Float)
-                    }
-                    BuiltinType::Bool => {
-                        push_var_result(VarType::Bool)
-                    }
-                    BuiltinType::Bytes => {
-                        push_var_result(VarType::Bytes)
-                    }
-                    BuiltinType::Duration => {
-                        push_var_result(VarType::Duration)
-                    }
-                    BuiltinType::Uint => {
-                        push_var_result(VarType::Uint)
-                    }
-                    BuiltinType::Regexp => {
-                        push_var_result(VarType::Regexp)
-                    }
-                    BuiltinType::Time => {
-                        push_var_result(VarType::Time)
-                    }
-                },
+                MonoType::Builtin(b) => {
+                    push_var_result(VarType::from(*b))
+                }
                 _ => (),
             }
         }
@@ -1653,6 +1602,22 @@ enum VarType {
     Regexp,
     Uint,
     Time,
+}
+
+impl From<BuiltinType> for VarType {
+    fn from(b: BuiltinType) -> Self {
+        match b {
+            BuiltinType::String => VarType::String,
+            BuiltinType::Int => VarType::Int,
+            BuiltinType::Float => VarType::Float,
+            BuiltinType::Bool => VarType::Bool,
+            BuiltinType::Bytes => VarType::Bytes,
+            BuiltinType::Duration => VarType::Duration,
+            BuiltinType::Uint => VarType::Uint,
+            BuiltinType::Regexp => VarType::Regexp,
+            BuiltinType::Time => VarType::Time,
+        }
+    }
 }
 
 fn create_completion_package_removed(

--- a/src/server.rs
+++ b/src/server.rs
@@ -798,9 +798,7 @@ impl LanguageServer for LspServer {
 
         if let Some(node) = visitor.node {
             let name = match node {
-                walk::Node::Identifier(ident) => {
-                    Some(&ident.name)
-                }
+                walk::Node::Identifier(ident) => Some(&ident.name),
                 walk::Node::IdentifierExpr(ident) => {
                     Some(&ident.name)
                 }
@@ -860,8 +858,7 @@ impl LanguageServer for LspServer {
         &self,
         params: lsp::RenameParams,
     ) -> RpcResult<Option<lsp::WorkspaceEdit>> {
-        let key =
-            params.text_document_position.text_document.uri;
+        let key = params.text_document_position.text_document.uri;
         let maybe_pkg = self.parse_analyze_document(&key)?;
         let pkg = match maybe_pkg {
             Some(pkg) => pkg,

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -179,7 +179,7 @@ fn walk_package_functions(
     }
 }
 
-pub fn get_package_functions(name: String) -> Vec<Function> {
+pub fn get_package_functions(name: &str) -> Vec<Function> {
     let mut list = vec![];
 
     if let Some(env) = imports() {

--- a/src/visitors/semantic/completion.rs
+++ b/src/visitors/semantic/completion.rs
@@ -50,10 +50,10 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
             }
 
             if let Node::VariableAssgn(assgn) = node {
-                let name = assgn.id.name.clone();
+                let name = &assgn.id.name;
 
-                if let Expression::Function(f) = assgn.init.clone() {
-                    if let MonoType::Fun(fun) = f.typ.clone() {
+                if let Expression::Function(f) = &assgn.init {
+                    if let MonoType::Fun(fun) = &f.typ {
                         let mut params = get_argument_names(&fun.req);
                         for opt in get_argument_names(&fun.opt) {
                             params.push(opt);
@@ -72,11 +72,9 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
                     assgn,
                 ) = &opt.assignment
                 {
-                    let name = assgn.id.name.clone();
-                    if let Expression::Function(f) =
-                        assgn.init.clone()
-                    {
-                        if let MonoType::Fun(fun) = f.typ.clone() {
+                    let name = &assgn.id.name;
+                    if let Expression::Function(f) = &assgn.init {
+                        if let MonoType::Fun(fun) = &f.typ {
                             let mut params =
                                 get_argument_names(&fun.req);
                             for opt in get_argument_names(&fun.opt) {
@@ -117,19 +115,17 @@ impl<'a> Visitor<'a> for ObjectFunctionFinderVisitor {
     fn visit(&mut self, node: Node<'a>) -> bool {
         match node {
             Node::VariableAssgn(assignment) => {
-                let object_name = assignment.id.name.clone();
+                let object_name = &assignment.id.name;
 
-                if let Expression::Object(obj) =
-                    assignment.init.clone()
-                {
-                    for prop in obj.properties.clone() {
-                        let func_name = prop.key.name;
+                if let Expression::Object(obj) = &assignment.init {
+                    for prop in &obj.properties {
+                        let func_name = &prop.key.name;
 
-                        if let Expression::Function(fun) = prop.value
+                        if let Expression::Function(fun) = &prop.value
                         {
                             let params = fun
                                 .params
-                                .into_iter()
+                                .iter()
                                 .map(|p| p.key.name.to_string())
                                 .collect::<Vec<String>>();
 
@@ -151,19 +147,20 @@ impl<'a> Visitor<'a> for ObjectFunctionFinderVisitor {
             Node::OptionStmt(opt) => {
                 if let flux::semantic::nodes::Assignment::Variable(
                     assignment,
-                ) = opt.assignment.clone()
+                ) = &opt.assignment
                 {
-                    let object_name = assignment.id.name;
-                    if let Expression::Object(obj) = assignment.init {
-                        for prop in obj.properties.clone() {
-                            let func_name = prop.key.name;
+                    let object_name = &assignment.id.name;
+                    if let Expression::Object(obj) = &assignment.init
+                    {
+                        for prop in &obj.properties {
+                            let func_name = &prop.key.name;
 
                             if let Expression::Function(fun) =
-                                prop.value
+                                &prop.value
                             {
                                 let params = fun
                                     .params
-                                    .into_iter()
+                                    .iter()
                                     .map(|p| p.key.name.to_string())
                                     .collect::<Vec<String>>();
 

--- a/src/visitors/semantic/functions.rs
+++ b/src/visitors/semantic/functions.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::rc::Rc;
 
 use flux::ast::SourceLocation;
@@ -9,14 +8,9 @@ use lspower::lsp;
 
 use crate::shared::FunctionInfo;
 
-#[derive(Default)]
-pub struct FunctionFinderState {
-    pub functions: Vec<Rc<FunctionInfo>>,
-}
-
 pub struct FunctionFinderVisitor {
     pub pos: lsp::Position,
-    pub state: Rc<RefCell<FunctionFinderState>>,
+    pub functions: Vec<Rc<FunctionInfo>>,
 }
 
 fn create_function_result(
@@ -64,8 +58,7 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
                 assgn.id.name.to_string(),
                 &assgn.init,
             ) {
-                let mut state = self.state.borrow_mut();
-                (*state).functions.push(Rc::new(f));
+                self.functions.push(Rc::new(f));
             }
         }
         true


### PR DESCRIPTION
## refactor: Borrow instead of cloning where it is possible

## refactor: Remove unneecssary *State structs in visitors

No longer necessary since visitors always take `&mut self` now

Based on #375 