### PR TITLE
test: use a large resource class on wasm-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
   wasm-test:
     docker:
       - image: quay.io/influxdb/wasm-build
+    resource_class: large
     steps:
       - checkout
       - run:


### PR DESCRIPTION
`wasm-build` already added this, to great results. I guess the resource
class didn't get added when `wasm-test` got added.