### PR TITLE
feat: Update to flux 0.149.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.5.1"
-source = "git+https://github.com/influxdata/flux?tag=v0.148.0#5b80111fa0eecb5454156f88a1e4463d55c47fdb"
+source = "git+https://github.com/influxdata/flux?tag=v0.149.0#e401eeca8585c09974e33b6f3c0c0aa2475a8b97"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "flux-core"
 version = "0.4.0"
-source = "git+https://github.com/influxdata/flux?tag=v0.148.0#5b80111fa0eecb5454156f88a1e4463d55c47fdb"
+source = "git+https://github.com/influxdata/flux?tag=v0.149.0#e401eeca8585c09974e33b6f3c0c0aa2475a8b97"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ combinations = "0.1.0"
 console_error_panic_hook = "0.1.7"
 console_log = { version = "0.2", optional = true }
 expect-test = "1"
-flux = { git = "https://github.com/influxdata/flux", tag = "v0.148.0" }
+flux = { git = "https://github.com/influxdata/flux", tag = "v0.149.0" }
 futures = "0.3.15"
 js-sys = "0.3.51"
 line-col = "0.2.1"

--- a/src/server.rs
+++ b/src/server.rs
@@ -1119,7 +1119,7 @@ fn find_node(
 #[cfg(all(test, not(target_arch = "wasm32")))]
 #[allow(deprecated)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::{HashMap, BTreeSet};
 
     use async_std::test;
     use lspower::{lsp, LanguageServer};
@@ -2469,10 +2469,10 @@ errorCounts
             _ => unreachable!(),
         };
 
-        let got: HashSet<&str> =
+        let got: BTreeSet<&str> =
             items.iter().map(|i| i.label.as_str()).collect();
 
-        let want: HashSet<&str> = vec![
+        let want: BTreeSet<&str> = vec![
             "buckets",
             "cardinality",
             "chandeMomentumOscillator",
@@ -2504,6 +2504,7 @@ errorCounts
             "increase",
             "influxdata/influxdb/schema",
             "influxdata/influxdb/secrets",
+            "internal/location",
             "logarithmicBins",
             "lowestCurrent",
             "reduce",
@@ -2658,10 +2659,10 @@ ab = 10
             _ => unreachable!(),
         };
 
-        let got: HashSet<&str> =
+        let got: BTreeSet<&str> =
             items.iter().map(|i| i.label.as_str()).collect();
 
-        let want: HashSet<&str> = vec![
+        let want: BTreeSet<&str> = vec![
             "aggregateWindow",
             "cardinality",
             "chandeMomentumOscillator",
@@ -2702,6 +2703,7 @@ ab = 10
             "internal/boolean",
             "internal/gen",
             "internal/influxql",
+            "internal/location",
             "interpolate",
             "join",
             "json",
@@ -2930,10 +2932,10 @@ errorCounts
             _ => unreachable!(),
         };
 
-        let got: HashSet<&str> =
+        let got: BTreeSet<&str> =
             items.iter().map(|i| i.label.as_str()).collect();
 
-        let want: HashSet<&str> = vec![
+        let want: BTreeSet<&str> = vec![
             "aggregateWindow",
             "bottom",
             "buckets",
@@ -2989,6 +2991,7 @@ errorCounts
             "int",
             "integral",
             "internal/testutil",
+            "internal/location",
             "interpolate",
             "last",
             "length",

--- a/src/server.rs
+++ b/src/server.rs
@@ -1119,7 +1119,7 @@ fn find_node(
 #[cfg(all(test, not(target_arch = "wasm32")))]
 #[allow(deprecated)]
 mod tests {
-    use std::collections::{HashMap, BTreeSet};
+    use std::collections::{BTreeSet, HashMap};
 
     use async_std::test;
     use lspower::{lsp, LanguageServer};


### PR DESCRIPTION
Switched to `BTreeSet` so that the display of want/got have consistent ordering in the assert