### PR TITLE
feat: Distinguish references using Symbol's refernce equality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "criterion",
+ "env_logger",
  "expect-test",
  "flux",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.5.1"
-source = "git+https://github.com/influxdata/flux?tag=v0.148.0#5b80111fa0eecb5454156f88a1e4463d55c47fdb"
+source = "git+https://github.com/influxdata/flux?tag=v0.149.0#e401eeca8585c09974e33b6f3c0c0aa2475a8b97"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "flux-core"
 version = "0.4.0"
-source = "git+https://github.com/influxdata/flux?tag=v0.148.0#5b80111fa0eecb5454156f88a1e4463d55c47fdb"
+source = "git+https://github.com/influxdata/flux?tag=v0.149.0#e401eeca8585c09974e33b6f3c0c0aa2475a8b97"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ clap = "2.33.3"
 combinations = "0.1.0"
 console_error_panic_hook = "0.1.7"
 console_log = { version = "0.2", optional = true }
+env_logger = "0.9"
 expect-test = "1"
 flux = { git = "https://github.com/influxdata/flux", tag = "v0.149.0" }
 futures = "0.3.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ combinations = "0.1.0"
 console_error_panic_hook = "0.1.7"
 console_log = { version = "0.2", optional = true }
 expect-test = "1"
-flux = { git = "https://github.com/influxdata/flux", tag = "v0.148.0" }
+flux = { git = "https://github.com/influxdata/flux", tag = "v0.149.0" }
 futures = "0.3.15"
 js-sys = "0.3.51"
 line-col = "0.2.1"

--- a/src/server.rs
+++ b/src/server.rs
@@ -1119,7 +1119,7 @@ fn find_node(
 #[cfg(all(test, not(target_arch = "wasm32")))]
 #[allow(deprecated)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::{HashMap, BTreeSet};
 
     use async_std::test;
     use lspower::{lsp, LanguageServer};
@@ -2469,10 +2469,10 @@ errorCounts
             _ => unreachable!(),
         };
 
-        let got: HashSet<&str> =
+        let got: BTreeSet<&str> =
             items.iter().map(|i| i.label.as_str()).collect();
 
-        let want: HashSet<&str> = vec![
+        let want: BTreeSet<&str> = vec![
             "buckets",
             "cardinality",
             "chandeMomentumOscillator",
@@ -2504,6 +2504,7 @@ errorCounts
             "increase",
             "influxdata/influxdb/schema",
             "influxdata/influxdb/secrets",
+            "internal/location",
             "logarithmicBins",
             "lowestCurrent",
             "reduce",
@@ -2658,10 +2659,10 @@ ab = 10
             _ => unreachable!(),
         };
 
-        let got: HashSet<&str> =
+        let got: BTreeSet<&str> =
             items.iter().map(|i| i.label.as_str()).collect();
 
-        let want: HashSet<&str> = vec![
+        let want: BTreeSet<&str> = vec![
             "aggregateWindow",
             "cardinality",
             "chandeMomentumOscillator",
@@ -2702,6 +2703,7 @@ ab = 10
             "internal/boolean",
             "internal/gen",
             "internal/influxql",
+            "internal/location",
             "interpolate",
             "join",
             "json",
@@ -2930,10 +2932,10 @@ errorCounts
             _ => unreachable!(),
         };
 
-        let got: HashSet<&str> =
+        let got: BTreeSet<&str> =
             items.iter().map(|i| i.label.as_str()).collect();
 
-        let want: HashSet<&str> = vec![
+        let want: BTreeSet<&str> = vec![
             "aggregateWindow",
             "bottom",
             "buckets",
@@ -2989,6 +2991,7 @@ errorCounts
             "int",
             "integral",
             "internal/testutil",
+            "internal/location",
             "interpolate",
             "last",
             "length",

--- a/src/server.rs
+++ b/src/server.rs
@@ -1100,14 +1100,16 @@ mod tests {
 
     use super::*;
 
-    fn position_of(s: &str) -> lsp::Position {
-        s.lines().enumerate().find_map(|(line, line_str)| {
+    /// Finds a `// ^` comment in `source` and returns the `lsp::Position` that the comment points
+    /// at
+    fn position_of(source: &str) -> lsp::Position {
+        source.lines().enumerate().find_map(|(line, line_str)| {
             line_str.find("// ^").map(|j| lsp::Position {
                 // The marker is on the line after the position we indicate
                 line: line as u32 - 1,
                 character: (line_str[..j].chars().count() + "// ^".len()) as u32,
             })
-        }).unwrap_or_else(|| panic!("Could not find the position marker `// ^` in `{}`", s))
+        }).unwrap_or_else(|| panic!("Could not find the position marker `// ^` in `{}`", source))
     }
 
     fn create_server() -> LspServer {

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -41,6 +41,7 @@ fn contains_position(node: Node<'_>, pos: lsp::Position) -> bool {
     true
 }
 
+#[derive(Debug)]
 pub struct NodeFinderVisitor<'a> {
     pub node: Option<Node<'a>>,
     pub position: lsp::Position,
@@ -112,7 +113,7 @@ impl<'a> IdentFinderVisitor<'a> {
 }
 
 pub struct DefinitionFinderVisitor<'a> {
-    pub name: String,
+    pub name: Symbol,
     pub node: Option<Node<'a>>,
 }
 
@@ -120,21 +121,28 @@ impl<'a> Visitor<'a> for DefinitionFinderVisitor<'a> {
     fn visit(&mut self, node: Node<'a>) -> bool {
         match node {
             walk::Node::VariableAssgn(v) => {
-                if *v.id.name == self.name {
-                    self.node = Some(node.clone());
+                if v.id.name == self.name {
+                    self.node = Some(node);
                     return false;
                 }
 
                 true
             }
-            walk::Node::FunctionExpr(_) => false,
+            walk::Node::FunctionParameter(param) => {
+                if param.key.name == self.name {
+                    self.node = Some(node);
+                    return false;
+                }
+
+                true
+            }
             _ => true,
         }
     }
 }
 
 impl<'a> DefinitionFinderVisitor<'a> {
-    pub fn new(name: String) -> DefinitionFinderVisitor<'a> {
+    pub fn new(name: Symbol) -> DefinitionFinderVisitor<'a> {
         DefinitionFinderVisitor { name, node: None }
     }
 }

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -1,7 +1,9 @@
 use crate::shared::get_package_name;
 
-use flux::semantic::nodes::Expression;
-use flux::semantic::walk::{self, Node, Visitor};
+use flux::semantic::{
+    nodes::{Expression, Symbol},
+    walk::{self, Node, Visitor},
+};
 use lspower::lsp;
 
 mod completion;
@@ -69,7 +71,7 @@ impl<'a> NodeFinderVisitor<'a> {
 }
 
 pub struct IdentFinderVisitor<'a> {
-    pub name: String,
+    pub name: Symbol,
     pub identifiers: Vec<walk::Node<'a>>,
 }
 
@@ -77,20 +79,20 @@ impl<'a> Visitor<'a> for IdentFinderVisitor<'a> {
     fn visit(&mut self, node: walk::Node<'a>) -> bool {
         match node.clone() {
             walk::Node::MemberExpr(m) => {
-                if let Expression::Identifier(i) = m.object.clone() {
-                    if *i.name == self.name {
+                if let Expression::Identifier(i) = &m.object {
+                    if i.name == self.name {
                         return true;
                     }
                 }
                 return false;
             }
             walk::Node::Identifier(n) => {
-                if *n.name == self.name {
+                if n.name == self.name {
                     self.identifiers.push(node.clone());
                 }
             }
             walk::Node::IdentifierExpr(n) => {
-                if *n.name == self.name {
+                if n.name == self.name {
                     self.identifiers.push(node.clone());
                 }
             }
@@ -101,7 +103,7 @@ impl<'a> Visitor<'a> for IdentFinderVisitor<'a> {
 }
 
 impl<'a> IdentFinderVisitor<'a> {
-    pub fn new(name: String) -> IdentFinderVisitor<'a> {
+    pub fn new(name: Symbol) -> IdentFinderVisitor<'a> {
         IdentFinderVisitor {
             name,
             identifiers: vec![],


### PR DESCRIPTION
With `Symbol` now implementing reference equality we can now easily determine whether two identifiers in the semantic graph refer to the same thing. Fixes one bug with `find references` and simplifies `goto definition` by comparing `Symbol == Symbol` instead of `String == String`