### PR TITLE
fix: don't produce dev binaries as final builds

### DIFF
--- a/wasm-build.sh
+++ b/wasm-build.sh
@@ -2,32 +2,43 @@
 
 set -e
 
-MODE=${BUILD_MODE-dev}
+BUILD_MODE=${BUILD_MODE-release}
 
-MODE_ARGS=""
-if [ $MODE = "dev" ]
-then
-    MODE_ARGS="--features console_log"
-fi
+BUILD_FLAG=""
+BUILD_MODE_ARGS=""
+case $BUILD_MODE in
+    "release")
+        BUILD_FLAG="--release"
+        ;;
+    "dev")
+        BUILD_FLAG="--dev"
+        BUILD_MODE_ARGS="--features console_log"
+        ;;
+    *)
+        echo "Invalid build mode: ${BUILD_MODE}"
+        echo "Only 'release' and 'dev' build mode options are supported"
+        exit 1
+        ;;
+esac
 
 wasm-pack build \
     -t nodejs \
     -d pkg-node \
     --out-name flux-lsp-node \
     --scope influxdata \
-    "--${MODE}" \
+    ${BUILD_FLAG} \
     -- \
     --locked \
-    $MODE_ARGS
+    $BUILD_MODE_ARGS
 wasm-pack build \
     -t browser \
     -d pkg-browser \
     --out-name flux-lsp-browser \
     --scope influxdata \
-    "--${MODE}" \
+    ${BUILD_FLAG} \
     -- \
     --locked \
-    $MODE_ARGS
+    $BUILD_MODE_ARGS
 
 cat pkg-node/package.json | sed s/@influxdata\\/flux-lsp\"/@influxdata\\/flux-lsp-node\"/g > pkg-node/package-new.json
 mv pkg-node/package-new.json pkg-node/package.json


### PR DESCRIPTION
`wasm-build.sh` had a bug in it where it was producing dev binaries for
the final wasm builds, as well as including `console_log`, which more
than doubles the wasm binary size. This patch changes the release
process to produce a release binary without `console_log`.