### PR TITLE
fix: allow env variable GITHUB_TOKEN in release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -25,7 +25,7 @@ if [[ ! $(command -v hub) ]]; then
     echo "Please install the hub tool and re-run."
     exit 1
 fi
-if [[ ! -f $HOME/.config/hub ]]; then
+if [[ ! -f $HOME/.config/hub && "${GITHUB_TOKEN}" == "" ]]; then
     echo "Please authenticate your hub command. See https://github.com/github/hub/issues/2655#issuecomment-735836048"
     exit 1
 fi


### PR DESCRIPTION
I've been using `GITHUB_TOKEN` as an environment variable for my `hub`
authentication, and this `hub` auth verification breaks in my use case.
This patch makes the release script allow that environment variable.