### PR TITLE
feat: remove LspServerBuilder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,4 +17,4 @@ mod wasm;
 #[macro_use]
 extern crate pretty_assertions;
 
-pub use server::LspServerBuilder;
+pub use server::LspServer;

--- a/src/server.rs
+++ b/src/server.rs
@@ -172,51 +172,17 @@ pub fn find_stdlib_signatures(
         })
 }
 
-#[derive(Clone)]
-struct LspServerOptions {
-    folding: bool,
-}
-
-pub struct LspServerBuilder {
-    options: LspServerOptions,
-}
-
-impl LspServerBuilder {
-    pub fn disable_folding(self) -> Self {
-        Self {
-            options: LspServerOptions { folding: false },
-        }
-    }
-
-    pub fn build(self, client: Option<Client>) -> LspServer {
-        LspServer::new(client, self.options)
-    }
-}
-
-impl Default for LspServerBuilder {
-    fn default() -> Self {
-        LspServerBuilder {
-            options: LspServerOptions { folding: true },
-        }
-    }
-}
-
 #[allow(dead_code)]
 pub struct LspServer {
     client: Arc<Mutex<Option<Client>>>,
     store: FileStore,
-    options: LspServerOptions,
 }
 
 impl LspServer {
-    fn new(
-        client: Option<Client>,
-        options: LspServerOptions,
-    ) -> Self {
+    pub fn new(client: Option<Client>) -> Self {
         Self {
             client: Arc::new(Mutex::new(client)),
             store: Arc::new(Mutex::new(HashMap::new())),
-            options,
         }
     }
 
@@ -385,9 +351,7 @@ impl LanguageServer for LspServer {
                 execute_command_provider: None,
                 experimental: None,
                 folding_range_provider: Some(
-                    lsp::FoldingRangeProviderCapability::Simple(
-                        self.options.folding,
-                    ),
+                    lsp::FoldingRangeProviderCapability::Simple(true),
                 ),
                 hover_provider: Some(
                     lsp::HoverProviderCapability::Simple(true),
@@ -1115,7 +1079,7 @@ mod tests {
 
     fn create_server() -> LspServer {
         let _ = env_logger::try_init();
-        LspServerBuilder::default().build(None)
+        LspServer::new(None)
     }
 
     async fn open_file(server: &LspServer, text: String) {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -9,7 +9,7 @@ use tower_service::Service;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
-use crate::LspServerBuilder;
+use crate::LspServer;
 
 /// Initialize logging - this requires the "console_log" feature to function,
 /// as this library adds 180k to the wasm binary being shipped.
@@ -75,8 +75,7 @@ impl Default for Lsp {
 
         let (service, messages) =
             lspower::LspService::new(|client| {
-                let builder = LspServerBuilder::default();
-                builder.build(Some(client))
+                LspServer::new(Some(client))
             });
         Lsp {
             processor: Some(MessageProcessor {


### PR DESCRIPTION
`LspServerBuilder` was meant to abstract away a bunch of options that we
ported over from the previous lsp implementation. Slowly, those options
have been phased out. The last option left was about disabling folding,
which was odd, because the client should signal whether it supports
folding or not, so there's no need to flip that off and on.

This patch removes the `LspServerBuilder` entirely and just uses the
`LspServer::new` function directly.