### PR TITLE
fix: Provide hover information (and more) in the face of type errors

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -124,7 +124,6 @@ impl CompletionInfo {
             NodeFinderVisitor::new(move_back(position, 1));
 
         walk(&mut visitor, walker);
-        dbg!(&visitor.node);
 
         let package = PackageInfo::from(&pkg);
 

--- a/src/visitors/ast.rs
+++ b/src/visitors/ast.rs
@@ -63,7 +63,7 @@ impl<'a> Visitor<'a> for CallFinderVisitor<'a> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct NodeFinderNode<'a> {
     pub node: walk::Node<'a>,
     pub parent: Option<Box<NodeFinderNode<'a>>>,
@@ -105,7 +105,7 @@ impl<'a> Visitor<'a> for NodeFinderVisitor<'a> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PackageInfo {
     pub name: String,
     pub position: lsp::Position,

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -170,7 +170,7 @@ impl<'a> Visitor<'a> for FoldFinderVisitor<'a> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Import {
     pub path: String,
     pub initial_name: Option<String>,


### PR DESCRIPTION
Thought this would be enough to fix #391 but it seems to take some more changes, still this at least
fixes `hover` (and probably some other LSP methods)