### PR TITLE
refactor: don't use Result if the Err never matters

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1005,10 +1005,10 @@ impl LanguageServer for LspServer {
                         // completion will live, e.g. buckets, measurements and
                         // tag keys/values. There are multiple issues open to support
                         // this functionality open currently.
-                        Ok(lsp::CompletionList {
+                        lsp::CompletionList {
                             is_incomplete: false,
                             items: vec![],
-                        })
+                        }
                     }
                     "(" | "," => completion::find_param_completions(
                         Some(c),
@@ -1027,17 +1027,6 @@ impl LanguageServer for LspServer {
             }
         } else {
             completion::find_completions(params, contents.as_str())
-        };
-
-        let items = match items {
-            Ok(items) => items,
-            Err(e) => {
-                log::warn!(
-                    "failed to get completion items: {}",
-                    e.msg
-                );
-                return Ok(None);
-            }
         };
 
         let response = lsp::CompletionResponse::List(items);


### PR DESCRIPTION
The completion code we have was brought over from the old lsp, and has
some non-idiomatic things in it. It's a bit tangled, but I was trying to
fix some issues in the completion code and find some way to express the
completion code better, and this patch is what came out. It simplifies
things a bit, but isn't at all a final solution. Rather, it's a refactor
of code that should continue to be refactored.