### PR TITLE
chore: make bench test running faster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,16 +20,7 @@ jobs:
       - checkout
       - run:
           name: "run cargo tests"
-          command: cargo test --locked
-
-  bench-test:
-    docker:
-      - image: quay.io/influxdb/wasm-build
-    steps:
-      - checkout
-      - run:
-          name: "run cargo bench"
-          command: cargo bench
+          command: cargo test --locked --benches
 
   wasm-test:
     docker:
@@ -83,7 +74,6 @@ workflows:
       - wasm-build
       - test
       - wasm-test
-      - bench-test
 
   build-and-deploy:
     jobs:


### PR DESCRIPTION
With the bench tests, we only care that they still work when run in CI.
I didn't see a comment by @marwes before merge of #400 wher it was
suggested that we run these using the test configuration so it'll be
faster. This patch applies that change.