### PR TITLE
refactor: Remove unused code

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -534,47 +534,50 @@ pub fn find_param_completions(
     if let Some(AstNode::CallExpr(call)) = visitor.node {
         let provided = get_provided_arguments(call);
 
-        if let Expression::Identifier(ident) = &call.callee {
-            items.extend(get_function_params(
-                ident.name.as_str(),
-                stdlib::get_builtin_functions(),
-                &provided,
-            ));
-
-            let user_functions =
-                get_user_functions(uri, position, source);
-            items.extend(get_function_params(
-                ident.name.as_str(),
-                user_functions,
-                &provided,
-            ));
-        }
-        if let Expression::Member(me) = &call.callee {
-            if let Expression::Identifier(ident) = &me.object {
-                let package_functions =
-                    stdlib::get_package_functions(&ident.name);
-
-                let object_functions = get_object_functions(
-                    uri,
-                    position,
-                    ident.name.as_str(),
-                    source,
-                );
-
-                let key = property_key_str(&me.property);
-
+        match &call.callee {
+            Expression::Identifier(ident) => {
                 items.extend(get_function_params(
-                    key,
-                    package_functions,
+                    ident.name.as_str(),
+                    stdlib::get_builtin_functions(),
                     &provided,
                 ));
 
+                let user_functions =
+                    get_user_functions(uri, position, source);
                 items.extend(get_function_params(
-                    key,
-                    object_functions,
+                    ident.name.as_str(),
+                    user_functions,
                     &provided,
                 ));
             }
+            Expression::Member(me) => {
+                if let Expression::Identifier(ident) = &me.object {
+                    let package_functions =
+                        stdlib::get_package_functions(&ident.name);
+
+                    let object_functions = get_object_functions(
+                        uri,
+                        position,
+                        ident.name.as_str(),
+                        source,
+                    );
+
+                    let key = property_key_str(&me.property);
+
+                    items.extend(get_function_params(
+                        key,
+                        package_functions,
+                        &provided,
+                    ));
+
+                    items.extend(get_function_params(
+                        key,
+                        object_functions,
+                        &provided,
+                    ));
+                }
+            }
+            _ => (),
         }
     }
 

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -760,7 +760,8 @@ fn walk_package(
                     name: name.to_owned(),
                     var_type,
                     package: package.into(),
-                    package_name: get_package_name(package),
+                    package_name: get_package_name(package)
+                        .map(|s| s.to_owned()),
                 }));
             };
 
@@ -1020,10 +1021,9 @@ fn add_package_result(
     name: &str,
     list: &mut Vec<Box<dyn Completable>>,
 ) {
-    let package_name = get_package_name(name);
-    if let Some(package_name) = package_name {
+    if let Some(package_name) = get_package_name(name) {
         list.push(Box::new(PackageResult {
-            name: package_name,
+            name: package_name.into(),
             full_name: name.to_string(),
         }));
     }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -183,14 +183,8 @@ impl CompletionInfo {
                             if let Expression::Identifier(ident) =
                                 &left.object
                             {
-                                let key = match &left.property {
-                                    PropertyKey::Identifier(
-                                        ident,
-                                    ) => &ident.name,
-                                    PropertyKey::StringLit(lit) => {
-                                        &lit.value
-                                    }
-                                };
+                                let key =
+                                    property_key_str(&left.property);
 
                                 let name =
                                     format!("{}.{}", ident.name, key);
@@ -226,14 +220,7 @@ impl CompletionInfo {
                             grandparent.node,
                             greatgrandparent.node,
                         ) {
-                            let name = match &prop.key {
-                                PropertyKey::Identifier(ident) => {
-                                    &ident.name
-                                }
-                                PropertyKey::StringLit(lit) => {
-                                    &lit.value
-                                }
-                            };
+                            let name = property_key_str(&prop.key);
 
                             if let Expression::Identifier(func) =
                                 &call.callee
@@ -243,7 +230,7 @@ impl CompletionInfo {
                                         CompletionType::CallProperty(
                                             func.name.clone(),
                                         ),
-                                    ident: name.clone(),
+                                    ident: name.to_owned(),
                                     position,
                                     uri: uri.clone(),
                                     imports: get_imports(
@@ -337,6 +324,13 @@ impl CompletionInfo {
         }
 
         None
+    }
+}
+
+fn property_key_str(p: &PropertyKey) -> &str {
+    match p {
+        PropertyKey::Identifier(i) => &i.name,
+        PropertyKey::StringLit(l) => &l.value,
     }
 }
 
@@ -567,19 +561,16 @@ pub fn find_param_completions(
                     source,
                 );
 
-                let key = match &me.property {
-                    PropertyKey::Identifier(i) => &i.name,
-                    PropertyKey::StringLit(l) => &l.value,
-                };
+                let key = property_key_str(&me.property);
 
                 items.extend(get_function_params(
-                    key.as_str(),
+                    key,
                     package_functions,
                     &provided,
                 ));
 
                 items.extend(get_function_params(
-                    key.as_str(),
+                    key,
                     object_functions,
                     &provided,
                 ));

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1020,7 +1020,7 @@ impl LanguageServer for LspServer {
                         // package available for import.
                         let imports = flux::imports()?;
                         let potential_imports: Vec<&String> = imports.iter().filter(|x| match crate::shared::get_package_name(x.0) {
-                            Some(name) => &name == identifier,
+                            Some(name) => name == identifier,
                             None => false,
                         }).map(|x| x.0 ).collect();
                         if potential_imports.is_empty() {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,8 +1,8 @@
 use lspower::lsp;
 
-pub fn get_package_name(name: &str) -> Option<String> {
+pub fn get_package_name(name: &str) -> Option<&str> {
     let items = name.split('/');
-    items.last().map(|n| n.to_string())
+    items.last()
 }
 
 #[allow(clippy::implicit_hasher)]
@@ -19,6 +19,18 @@ pub fn get_argument_names(
 pub struct Function {
     pub name: String,
     pub params: Vec<String>,
+}
+
+impl Function {
+    pub(crate) fn new(
+        name: String,
+        f: &flux::semantic::types::Function,
+    ) -> Self {
+        let mut params = get_argument_names(&f.req);
+        params.extend(get_argument_names(&f.opt));
+
+        Self { name, params }
+    }
 }
 
 pub struct FunctionSignature {

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -148,11 +148,7 @@ pub fn get_package_infos() -> Vec<PackageInfo> {
     result
 }
 
-fn walk_package_functions(
-    package: String,
-    list: &mut Vec<Function>,
-    t: &MonoType,
-) {
+fn walk_package_functions(list: &mut Vec<Function>, t: &MonoType) {
     if let MonoType::Record(record) = t {
         if let Record::Extension { head, tail } = record.as_ref() {
             if let MonoType::Fun(f) = &head.v {
@@ -167,7 +163,7 @@ fn walk_package_functions(
                 });
             }
 
-            walk_package_functions(package, list, tail);
+            walk_package_functions(list, tail);
         }
     }
 }
@@ -180,7 +176,6 @@ pub fn get_package_functions(name: &str) -> Vec<Function> {
             if let Some(package_name) = get_package_name(key) {
                 if package_name == name {
                     walk_package_functions(
-                        key.to_string(),
                         &mut list,
                         &val.typ().expr,
                     );

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -136,10 +136,9 @@ pub fn get_package_infos() -> Vec<PackageInfo> {
 
     if let Some(env) = imports() {
         for (path, _val) in env.iter() {
-            let name = get_package_name(path);
-            if let Some(name) = name {
+            if let Some(name) = get_package_name(path) {
                 result.push(PackageInfo {
-                    name,
+                    name: name.into(),
                     path: path.to_string(),
                 })
             }
@@ -207,7 +206,7 @@ fn walk_functions(
                     list.push(FunctionInfo::new(
                         head.k.clone().into(),
                         f.as_ref(),
-                        package_name,
+                        package_name.into(),
                     ));
                 }
             }

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -1,6 +1,4 @@
-use crate::shared::{
-    get_argument_names, get_package_name, Function, FunctionInfo,
-};
+use crate::shared::{get_package_name, Function, FunctionInfo};
 
 use flux::imports;
 use flux::prelude;
@@ -169,15 +167,7 @@ fn walk_package_functions(list: &mut Vec<Function>, t: &MonoType) {
     if let MonoType::Record(record) = t {
         for head in record_fields(record) {
             if let MonoType::Fun(f) = &head.v {
-                let mut params = vec![];
-
-                params.extend(get_argument_names(&f.req));
-                params.extend(get_argument_names(&f.opt));
-
-                list.push(Function {
-                    params,
-                    name: head.k.clone().into(),
-                });
+                list.push(Function::new(head.k.clone().into(), f));
             }
         }
     }
@@ -258,13 +248,7 @@ pub fn get_builtin_functions() -> Vec<Function> {
     if let Some(env) = prelude() {
         for (key, val) in env.iter() {
             if let MonoType::Fun(f) = &val.expr {
-                let mut params = get_argument_names(&f.req);
-                params.extend(get_argument_names(&f.opt));
-
-                list.push(Function {
-                    name: key.to_string(),
-                    params,
-                })
+                list.push(Function::new(key.to_string(), f));
             }
         }
     }

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -188,7 +188,8 @@ impl<'a> Visitor<'a> for ImportFinderVisitor {
             let alias = match import.alias.clone() {
                 Some(alias) => alias.name.to_string(),
                 None => get_package_name(import.path.value.as_str())
-                    .unwrap_or_else(|| "".to_string()),
+                    .unwrap_or_else(|| "")
+                    .to_owned(),
             };
 
             self.imports.push(Import {
@@ -196,7 +197,8 @@ impl<'a> Visitor<'a> for ImportFinderVisitor {
                 alias,
                 initial_name: get_package_name(
                     import.path.value.as_str(),
-                ),
+                )
+                .map(|s| s.to_owned()),
             });
         }
 

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -188,7 +188,7 @@ impl<'a> Visitor<'a> for ImportFinderVisitor {
             let alias = match import.alias.clone() {
                 Some(alias) => alias.name.to_string(),
                 None => get_package_name(import.path.value.as_str())
-                    .unwrap_or_else(|| "")
+                    .unwrap_or_default()
                     .to_owned(),
             };
 


### PR DESCRIPTION
Refactorings I have done so far trying to understand what is needed for #392 . The only big thing is the first commit which starts caching for the semantic graph so we do not have to re-compile it on every LSP call (adding in https://github.com/salsa-rs/salsa might be nice here to make invalidations automatic, though it is a large/complex dependency).

All commits should be orthogonal and could be reviewed one by one.