### PR TITLE
feat: add support for code actions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
     clippy::wildcard_imports
 )]
 mod completion;
+mod lsp;
 mod server;
 mod shared;
 mod stdlib;

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,0 +1,128 @@
+/// A collection of tools for working with lsp types.
+use lspower::lsp;
+
+/// Return true if two Range structs overlap.
+pub fn ranges_overlap(a: &lsp::Range, b: &lsp::Range) -> bool {
+    position_in_range(&a.start, b) || position_in_range(&a.end, b)
+}
+
+/// Return true if a Position is found within the provided Range
+pub fn position_in_range(
+    position: &lsp::Position,
+    range: &lsp::Range,
+) -> bool {
+    if position.line >= range.start.line
+        && position.line <= range.end.line
+    {
+        if position.line == range.start.line {
+            return position.character >= range.start.character;
+        }
+        if position.line == range.end.line {
+            return position.character <= range.end.character;
+        }
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod test {
+    use lspower::lsp;
+
+    use super::*;
+
+    #[test]
+    fn position_in_range_line_too_early() {
+        let position = lsp::Position {
+            line: 5,
+            character: 12,
+        };
+        let range = lsp::Range {
+            start: lsp::Position {
+                line: 6,
+                character: 7,
+            },
+            end: lsp::Position {
+                line: 15,
+                character: 18,
+            },
+        };
+        assert!(!position_in_range(&position, &range));
+    }
+
+    #[test]
+    fn position_in_range_character_too_early() {
+        let position = lsp::Position {
+            line: 6,
+            character: 6,
+        };
+        let range = lsp::Range {
+            start: lsp::Position {
+                line: 6,
+                character: 7,
+            },
+            end: lsp::Position {
+                line: 15,
+                character: 18,
+            },
+        };
+        assert!(!position_in_range(&position, &range));
+    }
+
+    #[test]
+    fn position_in_range_line_too_late() {
+        let position = lsp::Position {
+            line: 17,
+            character: 12,
+        };
+        let range = lsp::Range {
+            start: lsp::Position {
+                line: 6,
+                character: 7,
+            },
+            end: lsp::Position {
+                line: 15,
+                character: 18,
+            },
+        };
+        assert!(!position_in_range(&position, &range));
+    }
+
+    #[test]
+    fn position_in_range_character_too_late() {
+        let position = lsp::Position {
+            line: 15,
+            character: 19,
+        };
+        let range = lsp::Range {
+            start: lsp::Position {
+                line: 6,
+                character: 7,
+            },
+            end: lsp::Position {
+                line: 15,
+                character: 18,
+            },
+        };
+        assert!(!position_in_range(&position, &range));
+    }
+
+    #[test]
+    fn position_in_range_works() {
+        let position = lsp::Position {
+            line: 7,
+            character: 12,
+        };
+        let range = lsp::Range {
+            start: lsp::Position {
+                line: 6,
+                character: 7,
+            },
+            end: lsp::Position {
+                line: 15,
+                character: 18,
+            },
+        };
+        assert!(position_in_range(&position, &range));
+    }
+}

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -203,3 +203,18 @@ impl<'a> Visitor<'a> for ImportFinderVisitor {
         true
     }
 }
+
+#[derive(Default)]
+pub struct PackageNodeFinderVisitor {
+    pub location: Option<lsp::Range>,
+}
+
+impl<'a> Visitor<'a> for PackageNodeFinderVisitor {
+    fn visit(&mut self, node: Node<'a>) -> bool {
+        if let Node::PackageClause(n) = node {
+            self.location = Some(n.loc.clone().into());
+            return false;
+        }
+        true
+    }
+}


### PR DESCRIPTION
This patch adds support for the code actions capabilities. The only code
action currently supported is importing a package if an unknown
identifier matches a package that can be imported.

This functionality was then removed from the package code completion
logic, as it wasn't working anyway (it creates broken flux in the web
ui).

Fixes #393