### PR TITLE
chore: fix issue detected in rust-analyzer

### DIFF
--- a/src/visitors/ast.rs
+++ b/src/visitors/ast.rs
@@ -284,9 +284,7 @@ impl<'a> Visitor<'a> for SemanticTokenVisitor {
                     token_modifiers_bitset: 0,
                 });
             }
-            _ => {
-                println!("{}", node);
-            }
+            _ => {}
         }
         true
     }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -253,6 +253,7 @@ pub fn format_from_js_file(
 }
 
 #[cfg(test)]
+#[allow(clippy::wildcard_imports, clippy::unwrap_used)]
 mod test {
     use wasm_bindgen_test::*;
 


### PR DESCRIPTION
`rust-analyzer` seemed to not like the wasm tests doing some things we
normally want clippy to catch. However, in tests, those clippy lints
shouldn't matter. For some reason, these lints weren't being caught
previously.

Additionally, there was a rogue `println` that got merged and would gum
up test output when running `cargo test -- --nocapture`.