### PR TITLE
feat: do initial groundwork for multi-file package support

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -184,7 +184,7 @@ impl LspServer {
 
     fn get_document(&self, key: &lsp::Url) -> RpcResult<String> {
         match self.store.get(key) {
-            Ok(contents) => Ok(contents.clone()),
+            Ok(contents) => Ok(contents),
             Err(err) => Err(err.into()),
         }
     }
@@ -396,8 +396,8 @@ impl LanguageServer for LspServer {
             Ok(value) => {
                 let mut contents = Cow::Borrowed(&value);
                 for change in params.content_changes {
-                    contents =
-                        Cow::Owned(if let Some(range) = change.range {
+                    contents = Cow::Owned(
+                        if let Some(range) = change.range {
                             replace_string_in_range(
                                 contents.into_owned(),
                                 range,
@@ -405,13 +405,19 @@ impl LanguageServer for LspServer {
                             )
                         } else {
                             change.text
-                        });
+                        },
+                    );
                 }
                 let new_contents = contents.into_owned();
                 self.store.put(&key, &new_contents.clone());
-                self.publish_diagnostics(&key, new_contents.as_str()).await;
-            },
-            Err(err) => log::error!("Could not update key: {}\n{:?}", key, err),
+                self.publish_diagnostics(&key, new_contents.as_str())
+                    .await;
+            }
+            Err(err) => log::error!(
+                "Could not update key: {}\n{:?}",
+                key,
+                err
+            ),
         }
     }
 
@@ -636,10 +642,10 @@ impl LanguageServer for LspServer {
     ) -> RpcResult<Option<lsp::GotoDefinitionResponse>> {
         let key =
             params.text_document_position_params.text_document.uri;
-            let pkg = match self.store.get_package(&key) {
-                Ok(pkg) => pkg,
-                Err(err) => return Err(err.into()),
-            };
+        let pkg = match self.store.get_package(&key) {
+            Ok(pkg) => pkg,
+            Err(err) => return Err(err.into()),
+        };
 
         let pkg_node = walk::Node::Package(&pkg);
         let mut visitor = semantic::NodeFinderVisitor::new(
@@ -715,10 +721,10 @@ impl LanguageServer for LspServer {
     ) -> RpcResult<Option<Vec<lsp::DocumentHighlight>>> {
         let key =
             params.text_document_position_params.text_document.uri;
-            let pkg = match self.store.get_package(&key) {
-                Ok(pkg) => pkg,
-                Err(err) => return Err(err.into()),
-            };
+        let pkg = match self.store.get_package(&key) {
+            Ok(pkg) => pkg,
+            Err(err) => return Err(err.into()),
+        };
 
         let node = find_node(
             walk::Node::Package(&pkg),
@@ -766,10 +772,10 @@ impl LanguageServer for LspServer {
     ) -> RpcResult<Option<lsp::Hover>> {
         let key =
             params.text_document_position_params.text_document.uri;
-            let pkg = match self.store.get_package(&key) {
-                Ok(pkg) => pkg,
-                Err(err) => return Err(err.into()),
-            };
+        let pkg = match self.store.get_package(&key) {
+            Ok(pkg) => pkg,
+            Err(err) => return Err(err.into()),
+        };
 
         let node_finder_result = find_node(
             walk::Node::Package(&pkg),

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -1,0 +1,173 @@
+#![allow(dead_code)]
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use lspower::lsp;
+
+/// LSPStore acts as the in-memory storage backend for the LSP server.
+/// 
+/// The spec talks specifically about setting versions for files, but isn't
+/// clear on how those versions are surfaced to the client, if ever. This
+/// type could be extended to keep track of versions of files, but simplicity
+/// is preferred at this point.
+pub(crate) struct Store {
+    backend: Arc<Mutex<HashMap<lsp::Url, String>>>,
+}
+
+impl Default for Store {
+    fn default() -> Self {
+        Store {
+            backend: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl Store {
+    pub fn put(
+        &self,
+        key: &lsp::Url,
+        contents: &str,
+    ) {
+        match self.backend.lock() {
+            Ok(mut store) => {
+                match store.entry(key.clone()) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(contents.into());
+                    }
+                    Entry::Occupied(mut entry) => {
+                        // The protocol spec is unclear on whether trying to open a file
+                        // that is already opened is allowed, and research would indicate that
+                        // there are badly behaved clients that do this. Rather than making this
+                        // error, log the issue and move on.
+                        log::warn!(
+                        "Overwriting contents of existing key: {}",
+                        entry.key(),
+                    );
+                        entry.insert(contents.into());
+                    }
+                }
+            }
+            Err(error) => {
+                log::error!(
+                    "Could not acquire store lock. Error: {}",
+                    error
+                );
+            }
+        }
+    }
+
+    pub fn remove(
+        &self,
+        key: &lsp::Url,
+    ) {
+        match self.backend.lock() {
+            Ok(mut store) => {
+                if store.remove(&key).is_none() {
+                    // The protocol spec is unclear on whether trying to close a file
+                    // that isn't open is allowed. To stop consistent with the
+                    // implementation of textDocument/didOpen, this error is logged and
+                    // allowed.
+                    log::warn!(
+                        "Cannot remove non-existent key: {}",
+                        key
+                    );
+                }
+            },
+            Err(error) => {
+                log::error!(
+                    "Could not acquire store lock. Error: {}", error
+                )
+            }
+        }
+    }
+
+    pub fn get(&self, key: &lsp::Url) -> Option<String> {
+        match self.backend.lock() {
+            Ok(mut store) => match store.entry(key.clone()) {
+                Entry::Vacant(_) => None,
+                Entry::Occupied(entry) => Some(entry.get().into()),
+            },
+            Err(error) => {
+                log::error!(
+                    "Could not acquire store lock. Error: {}",
+                    error
+                );
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn put() {
+        let store = Store::default();
+        let key = lsp::Url::parse("file:///a/b/c").unwrap();
+        let contents = "import \"foo\"";
+        store.put(&key, contents);
+
+        match store.backend.lock() {
+            Ok(mut backend) => match backend.entry(key.clone()) {
+                Entry::Vacant(_) => {
+                    panic!("put to {} failed", key)
+                }
+                Entry::Occupied(entry) => {
+                    assert_eq!(entry.get(), contents)
+                }
+            },
+            Err(error) => panic!("Could not acquire lock: {}", error),
+        };
+    }
+
+    #[test]
+    fn get() {
+        let store = Store::default();
+        let key = lsp::Url::parse("file:///a/b/c").unwrap();
+        let contents = "import \"foo\"";
+
+        {
+            let mut backend =
+                store.backend.lock().expect("Could not acquire lock");
+            if let Entry::Vacant(entry) =
+                backend.entry(key.clone())
+            {
+                entry.insert(contents.into());
+            }
+        }
+
+        let result = store.get(&key);
+
+        assert_eq!(
+            contents,
+            result.expect("result is unexpectedly None")
+        )
+    }
+
+    #[test]
+    fn remove() {
+        let store = Store::default();
+        let key = lsp::Url::parse("file:///a/b/c").unwrap();
+        let contents = "import \"foo\"";
+
+        {
+            let mut backend =
+                store.backend.lock().expect("Could not acquire lock");
+            if let Entry::Vacant(entry) =
+                backend.entry(key.clone())
+            {
+                entry.insert(contents.into());
+            }
+        }
+
+        store.remove(&key);
+        let result = store.get(&key);
+
+        assert!(result.is_none());
+    }
+}

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -98,18 +98,9 @@ async fn test_did_open() {
 
     server.did_open(params).await;
 
-    assert_eq!(
-        vec![&lsp::Url::parse("file:///home/user/file.flux").unwrap()],
-        server
-            .store
-            .lock()
-            .unwrap()
-            .keys()
-            .collect::<Vec<&lsp::Url>>()
-    );
     let uri = lsp::Url::parse("file:///home/user/file.flux").unwrap();
     let contents =
-        server.store.lock().unwrap().get(&uri).unwrap().clone();
+        server.store.get(&uri).unwrap().clone();
     assert_eq!("from(", contents);
 }
 
@@ -139,7 +130,7 @@ async fn test_did_change() {
 
     let uri = lsp::Url::parse("file:///home/user/file.flux").unwrap();
     let contents =
-        server.store.lock().unwrap().get(&uri).unwrap().clone();
+        server.store.get(&uri).unwrap().clone();
     assert_eq!(r#"from(bucket: "bucket")"#, contents);
 }
 
@@ -180,7 +171,7 @@ async fn test_did_change_with_range() {
 
     let uri = lsp::Url::parse("file:///home/user/file.flux").unwrap();
     let contents =
-        server.store.lock().unwrap().get(&uri).unwrap().clone();
+        server.store.get(&uri).unwrap().clone();
     assert_eq!(
         r#"from(bucket: "bucket")
 |>  first()"#,
@@ -228,7 +219,7 @@ async fn test_did_change_with_multiline_range() {
 
     let uri = lsp::Url::parse("file:///home/user/file.flux").unwrap();
     let contents =
-        server.store.lock().unwrap().get(&uri).unwrap().clone();
+        server.store.get(&uri).unwrap().clone();
     assert_eq!(
         r#"from(bucket: "bucket")
 |>drop(columns: ["_start", "_stop"])
@@ -255,7 +246,7 @@ async fn test_did_save() {
     server.did_save(params).await;
 
     let contents =
-        server.store.lock().unwrap().get(&uri).unwrap().clone();
+        server.store.get(&uri).unwrap().clone();
     assert_eq!(r#"from(bucket: "test2")"#.to_string(), contents);
 }
 
@@ -264,7 +255,7 @@ async fn test_did_close() {
     let server = create_server();
     open_file(&server, "from(".to_string()).await;
 
-    assert!(server.store.lock().unwrap().keys().next().is_some());
+    assert!(server.store.get(&lsp::Url::parse("file:///home/user/file.flux").unwrap()).is_some());
 
     let params = lsp::DidCloseTextDocumentParams {
         text_document: lsp::TextDocumentIdentifier::new(
@@ -274,7 +265,7 @@ async fn test_did_close() {
 
     server.did_close(params).await;
 
-    assert!(server.store.lock().unwrap().keys().next().is_none());
+    assert!(server.store.get(&lsp::Url::parse("file:///home/user/file.flux").unwrap()).is_none());
 }
 
 // If the file hasn't been opened on the server get, return an error.

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -99,8 +99,7 @@ async fn test_did_open() {
     server.did_open(params).await;
 
     let uri = lsp::Url::parse("file:///home/user/file.flux").unwrap();
-    let contents =
-        server.store.get(&uri).unwrap().clone();
+    let contents = server.store.get(&uri).unwrap().clone();
     assert_eq!("from(", contents);
 }
 
@@ -129,8 +128,7 @@ async fn test_did_change() {
     server.did_change(params).await;
 
     let uri = lsp::Url::parse("file:///home/user/file.flux").unwrap();
-    let contents =
-        server.store.get(&uri).unwrap().clone();
+    let contents = server.store.get(&uri).unwrap().clone();
     assert_eq!(r#"from(bucket: "bucket")"#, contents);
 }
 
@@ -170,8 +168,7 @@ async fn test_did_change_with_range() {
     server.did_change(params).await;
 
     let uri = lsp::Url::parse("file:///home/user/file.flux").unwrap();
-    let contents =
-        server.store.get(&uri).unwrap().clone();
+    let contents = server.store.get(&uri).unwrap().clone();
     assert_eq!(
         r#"from(bucket: "bucket")
 |>  first()"#,
@@ -218,8 +215,7 @@ async fn test_did_change_with_multiline_range() {
     server.did_change(params).await;
 
     let uri = lsp::Url::parse("file:///home/user/file.flux").unwrap();
-    let contents =
-        server.store.get(&uri).unwrap().clone();
+    let contents = server.store.get(&uri).unwrap().clone();
     assert_eq!(
         r#"from(bucket: "bucket")
 |>drop(columns: ["_start", "_stop"])
@@ -245,8 +241,7 @@ async fn test_did_save() {
     };
     server.did_save(params).await;
 
-    let contents =
-        server.store.get(&uri).unwrap().clone();
+    let contents = server.store.get(&uri).unwrap().clone();
     assert_eq!(r#"from(bucket: "test2")"#.to_string(), contents);
 }
 
@@ -255,7 +250,10 @@ async fn test_did_close() {
     let server = create_server();
     open_file(&server, "from(".to_string()).await;
 
-    assert!(server.store.get(&lsp::Url::parse("file:///home/user/file.flux").unwrap()).is_ok());
+    assert!(server
+        .store
+        .get(&lsp::Url::parse("file:///home/user/file.flux").unwrap())
+        .is_ok());
 
     let params = lsp::DidCloseTextDocumentParams {
         text_document: lsp::TextDocumentIdentifier::new(
@@ -265,7 +263,10 @@ async fn test_did_close() {
 
     server.did_close(params).await;
 
-    assert!(server.store.get(&lsp::Url::parse("file:///home/user/file.flux").unwrap()).is_err());
+    assert!(server
+        .store
+        .get(&lsp::Url::parse("file:///home/user/file.flux").unwrap())
+        .is_err());
 }
 
 // If the file hasn't been opened on the server get, return an error.

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -255,7 +255,7 @@ async fn test_did_close() {
     let server = create_server();
     open_file(&server, "from(".to_string()).await;
 
-    assert!(server.store.get(&lsp::Url::parse("file:///home/user/file.flux").unwrap()).is_some());
+    assert!(server.store.get(&lsp::Url::parse("file:///home/user/file.flux").unwrap()).is_ok());
 
     let params = lsp::DidCloseTextDocumentParams {
         text_document: lsp::TextDocumentIdentifier::new(
@@ -265,7 +265,7 @@ async fn test_did_close() {
 
     server.did_close(params).await;
 
-    assert!(server.store.get(&lsp::Url::parse("file:///home/user/file.flux").unwrap()).is_none());
+    assert!(server.store.get(&lsp::Url::parse("file:///home/user/file.flux").unwrap()).is_err());
 }
 
 // If the file hasn't been opened on the server get, return an error.

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -1,0 +1,32 @@
+#[derive(Debug)]
+pub enum LspError {
+    InternalError(String),
+    LockNotAcquired,
+    FileNotFound(String),
+}
+
+impl Into<lspower::jsonrpc::Error> for LspError {
+    fn into(self) -> lspower::jsonrpc::Error {
+        match self {
+            LspError::InternalError(error) => {
+                lspower::jsonrpc::Error {
+                    code: lspower::jsonrpc::ErrorCode::InternalError,
+                    message: error,
+                    data: None,
+                }
+            }
+            LspError::LockNotAcquired => lspower::jsonrpc::Error {
+                code: lspower::jsonrpc::ErrorCode::InternalError,
+                message: "Could not acquire lock".into(),
+                data: None,
+            },
+            LspError::FileNotFound(filename) => {
+                lspower::jsonrpc::Error {
+                    code: lspower::jsonrpc::ErrorCode::InvalidParams,
+                    message: format!("File not fiend: {}", filename),
+                    data: None,
+                }
+            },
+        }
+    }
+}

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -5,9 +5,9 @@ pub enum LspError {
     FileNotFound(String),
 }
 
-impl Into<lspower::jsonrpc::Error> for LspError {
-    fn into(self) -> lspower::jsonrpc::Error {
-        match self {
+impl From<LspError> for lspower::jsonrpc::Error {
+    fn from(error: LspError) -> Self {
+        match error {
             LspError::InternalError(error) => {
                 lspower::jsonrpc::Error {
                     code: lspower::jsonrpc::ErrorCode::InternalError,
@@ -26,7 +26,7 @@ impl Into<lspower::jsonrpc::Error> for LspError {
                     message: format!("File not fiend: {}", filename),
                     data: None,
                 }
-            },
+            }
         }
     }
 }


### PR DESCRIPTION
This patch adds a new `Store` type that handles the internals of the
data store and hides the actual in-memory representation. Additionally,
it _changes_ the in-memory representation a bit to make multi-file
package support just a bit easier. The order of the patches may help in
review, if the final patch is a bit too much.

This patch is the initial groundwork for handling multi-file package
support. The _actual_ implementation of multi-file package support
should really show up as its own patch, as it has the potential to cause
issues.