### PR TITLE
refactor: Pass in the semantic graph to completion instead of compiling from source

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -48,20 +48,20 @@ pub fn find_completions(
                 items.append(&mut stdlib_matches);
 
                 let mut user_matches =
-                    get_user_matches(info, contents, &pkg);
+                    get_user_matches(info, contents, pkg);
 
                 items.append(&mut user_matches);
             }
             CompletionType::Bad => {}
             CompletionType::CallProperty(_func) => {
                 return find_param_completions(
-                    None, &params, contents, &pkg,
+                    None, &params, contents, pkg,
                 )
             }
             CompletionType::Import => {
                 let infos = stdlib::get_package_infos();
 
-                let imports = get_imports(&pkg);
+                let imports = get_imports(pkg);
 
                 let mut items = vec![];
                 for info in infos {
@@ -302,7 +302,7 @@ fn property_key_str(p: &PropertyKey) -> &str {
 }
 
 fn get_imports(pkg: &flux::semantic::nodes::Package) -> Vec<Import> {
-    let walker = flux::semantic::walk::Node::Package(&pkg);
+    let walker = flux::semantic::walk::Node::Package(pkg);
     let mut visitor = ImportFinderVisitor::default();
 
     flux::semantic::walk::walk(&mut visitor, walker);
@@ -414,7 +414,7 @@ fn get_user_completables(
     pos: lsp::Position,
     pkg: &flux::semantic::nodes::Package,
 ) -> Vec<Arc<dyn Completable>> {
-    let walker = flux::semantic::walk::Node::Package(&pkg);
+    let walker = flux::semantic::walk::Node::Package(pkg);
     let mut visitor = CompletableFinderVisitor::new(pos);
 
     flux::semantic::walk::walk(&mut visitor, walker);
@@ -465,7 +465,7 @@ pub fn find_param_completions(
                 ));
 
                 let user_functions =
-                    get_user_functions(position, &sem_pkg);
+                    get_user_functions(position, sem_pkg);
                 items.extend(get_function_params(
                     ident.name.as_str(),
                     user_functions,
@@ -479,7 +479,7 @@ pub fn find_param_completions(
 
                     let object_functions = get_object_functions(
                         ident.name.as_str(),
-                        &sem_pkg,
+                        sem_pkg,
                     );
 
                     let key = property_key_str(&me.property);
@@ -540,7 +540,7 @@ fn get_specific_object(
     name: &str,
     pkg: &flux::semantic::nodes::Package,
 ) -> Vec<Arc<dyn Completable>> {
-    let walker = flux::semantic::walk::Node::Package(&pkg);
+    let walker = flux::semantic::walk::Node::Package(pkg);
     let mut visitor = CompletableObjectFinderVisitor::new(name);
 
     flux::semantic::walk::walk(&mut visitor, walker);
@@ -585,7 +585,7 @@ fn get_user_functions(
     pos: lsp::Position,
     pkg: &flux::semantic::nodes::Package,
 ) -> Vec<Function> {
-    let walker = flux::semantic::walk::Node::Package(&pkg);
+    let walker = flux::semantic::walk::Node::Package(pkg);
     let mut visitor = FunctionFinderVisitor::new(pos);
 
     flux::semantic::walk::walk(&mut visitor, walker);
@@ -597,7 +597,7 @@ fn get_object_functions(
     object: &str,
     pkg: &flux::semantic::nodes::Package,
 ) -> Vec<Function> {
-    let walker = flux::semantic::walk::Node::Package(&pkg);
+    let walker = flux::semantic::walk::Node::Package(pkg);
     let mut visitor = ObjectFunctionFinderVisitor::default();
 
     flux::semantic::walk::walk(&mut visitor, walker);
@@ -1115,7 +1115,7 @@ fn create_function_result(
                 package_name: Some("self".to_string()),
                 optional_args: get_argument_names(&fun.opt),
                 required_args: get_argument_names(&fun.req),
-                signature: stdlib::create_function_signature(&fun),
+                signature: stdlib::create_function_signature(fun),
             });
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -991,24 +991,21 @@ impl LanguageServer for LspServer {
                 }
             };
 
-        let analyzer_result = flux::new_semantic_analyzer(
+        let mut analyzer = match flux::new_semantic_analyzer(
             flux::semantic::AnalyzerConfig::default(),
-        );
-        if analyzer_result.is_err() {
-            return Ok(None);
-        }
-        let mut analyzer =
-            analyzer_result.expect("Previous check failed.");
+        ) {
+            Ok(analyzer) => analyzer,
+            Err(_) => return Ok(None),
+        };
 
-        let analyzed = analyzer.analyze_source(
+        let errors = match analyzer.analyze_source(
             "".into(),
             params.text_document.uri.clone().into(),
             &contents,
-        );
-        if analyzed.is_ok() {
-            return Ok(None);
-        }
-        let errors = analyzed.err().expect("Previous check failed.");
+        ) {
+            Ok(_) => return Ok(None),
+            Err(errors) => errors,
+        };
 
         let relevant: Vec<&flux::semantic::Error> = errors
             .error

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -153,6 +153,27 @@ pub fn find_stdlib_signatures(
         })
 }
 
+fn parse_semantic_graph(
+    key: &lsp::Url,
+    contents: &str,
+) -> Option<flux::semantic::nodes::Package> {
+    let mut analyzer = match flux::new_semantic_analyzer(
+        flux::semantic::AnalyzerConfig::default(),
+    ) {
+        Ok(a) => a,
+        Err(_) => return None,
+    };
+
+    match analyzer.analyze_source(
+        "".into(),
+        key.clone().into(),
+        &contents,
+    ) {
+        Ok((_, pkg)) => Some(pkg),
+        Err(err) => err.value.map(|(_, pkg)| pkg),
+    }
+}
+
 pub struct LspServer {
     client: Arc<Mutex<Option<Client>>>,
     store: store::Store,
@@ -866,6 +887,10 @@ impl LanguageServer for LspServer {
         let key = &params.text_document_position.text_document.uri;
 
         let contents = self.get_document(key)?;
+        let sem_pkg = match parse_semantic_graph(key, &contents) {
+            Some(sem_pkg) => sem_pkg,
+            None => return Ok(None),
+        };
 
         let items = if let Some(ctx) = &params.context {
             match (ctx.trigger_kind, &ctx.trigger_character) {
@@ -874,7 +899,7 @@ impl LanguageServer for LspServer {
                     Some(c),
                 ) => match c.as_str() {
                     "." => completion::find_dot_completions(
-                        params, &contents,
+                        params, &contents, &sem_pkg,
                     ),
                     ":" => {
                         // XXX: rockstar (29 Nov 2021) - This is where argument
@@ -890,19 +915,26 @@ impl LanguageServer for LspServer {
                         Some(c),
                         &params,
                         contents.as_str(),
+                        &sem_pkg,
                     ),
                     _ => completion::find_completions(
                         params,
                         contents.as_str(),
+                        &sem_pkg,
                     ),
                 },
                 _ => completion::find_completions(
                     params,
                     contents.as_str(),
+                    &sem_pkg,
                 ),
             }
         } else {
-            completion::find_completions(params, contents.as_str())
+            completion::find_completions(
+                params,
+                contents.as_str(),
+                &sem_pkg,
+            )
         };
 
         let response = lsp::CompletionResponse::List(items);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -167,7 +167,7 @@ fn parse_semantic_graph(
     match analyzer.analyze_source(
         "".into(),
         key.clone().into(),
-        &contents,
+        contents,
     ) {
         Ok((_, pkg)) => Some(pkg),
         Err(err) => err.value.map(|(_, pkg)| pkg),

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -79,9 +79,7 @@ async fn test_initialized() {
 async fn test_shutdown() {
     let server = create_server();
 
-    let result = server.shutdown().await.unwrap();
-
-    assert_eq!((), result)
+    server.shutdown().await.unwrap();
 }
 
 #[test]
@@ -99,7 +97,7 @@ async fn test_did_open() {
     server.did_open(params).await;
 
     let uri = lsp::Url::parse("file:///home/user/file.flux").unwrap();
-    let contents = server.store.get(&uri).unwrap().clone();
+    let contents = server.store.get(&uri).unwrap();
     assert_eq!("from(", contents);
 }
 
@@ -128,7 +126,7 @@ async fn test_did_change() {
     server.did_change(params).await;
 
     let uri = lsp::Url::parse("file:///home/user/file.flux").unwrap();
-    let contents = server.store.get(&uri).unwrap().clone();
+    let contents = server.store.get(&uri).unwrap();
     assert_eq!(r#"from(bucket: "bucket")"#, contents);
 }
 
@@ -168,7 +166,7 @@ async fn test_did_change_with_range() {
     server.did_change(params).await;
 
     let uri = lsp::Url::parse("file:///home/user/file.flux").unwrap();
-    let contents = server.store.get(&uri).unwrap().clone();
+    let contents = server.store.get(&uri).unwrap();
     assert_eq!(
         r#"from(bucket: "bucket")
 |>  first()"#,
@@ -215,7 +213,7 @@ async fn test_did_change_with_multiline_range() {
     server.did_change(params).await;
 
     let uri = lsp::Url::parse("file:///home/user/file.flux").unwrap();
-    let contents = server.store.get(&uri).unwrap().clone();
+    let contents = server.store.get(&uri).unwrap();
     assert_eq!(
         r#"from(bucket: "bucket")
 |>drop(columns: ["_start", "_stop"])
@@ -241,7 +239,7 @@ async fn test_did_save() {
     };
     server.did_save(params).await;
 
-    let contents = server.store.get(&uri).unwrap().clone();
+    let contents = server.store.get(&uri).unwrap();
     assert_eq!(r#"from(bucket: "test2")"#.to_string(), contents);
 }
 
@@ -480,7 +478,7 @@ errorCounts
                 character: 96,
             },
         },
-        flux::formatter::format(&fluxscript).unwrap(),
+        flux::formatter::format(fluxscript).unwrap(),
     );
     assert_eq!(vec![expected], result);
 }
@@ -529,7 +527,7 @@ errorCounts
     let result = server.formatting(params).await.unwrap().unwrap();
 
     let mut formatted_text =
-        flux::formatter::format(&fluxscript).unwrap();
+        flux::formatter::format(fluxscript).unwrap();
     formatted_text.push('\n');
     let expected = lsp::TextEdit::new(
         lsp::Range {
@@ -1487,7 +1485,7 @@ sql."#;
         .map(|x| x.into())
         .collect::<Vec<String>>();
 
-    match result.clone() {
+    match result {
         lsp::CompletionResponse::List(l) => {
             assert_eq!(
                 expected_labels,
@@ -1555,7 +1553,7 @@ errorCounts
     let result =
         server.completion(params.clone()).await.unwrap().unwrap();
 
-    let items = match result.clone() {
+    let items = match result {
         lsp::CompletionResponse::List(l) => l.items,
         _ => unreachable!(),
     };
@@ -1677,7 +1675,7 @@ task.
     let result =
         server.completion(params.clone()).await.unwrap().unwrap();
 
-    let items = match result.clone() {
+    let items = match result {
         lsp::CompletionResponse::List(l) => l.items,
         _ => unreachable!(),
     };
@@ -1741,7 +1739,7 @@ ab = 10
     let result =
         server.completion(params.clone()).await.unwrap().unwrap();
 
-    let items = match result.clone() {
+    let items = match result {
         lsp::CompletionResponse::List(l) => l.items,
         _ => unreachable!(),
     };
@@ -1883,7 +1881,7 @@ obj.func(
     let result =
         server.completion(params.clone()).await.unwrap().unwrap();
 
-    let items = match result.clone() {
+    let items = match result {
         lsp::CompletionResponse::List(l) => l.items,
         _ => unreachable!(),
     };
@@ -1932,7 +1930,7 @@ csv.from(
     let result =
         server.completion(params.clone()).await.unwrap().unwrap();
 
-    let items = match result.clone() {
+    let items = match result {
         lsp::CompletionResponse::List(l) => l.items,
         _ => unreachable!(),
     };
@@ -2008,7 +2006,7 @@ errorCounts
     let result =
         server.completion(params.clone()).await.unwrap().unwrap();
 
-    let items = match result.clone() {
+    let items = match result {
         lsp::CompletionResponse::List(l) => l.items,
         _ => unreachable!(),
     };

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -42,8 +42,7 @@ impl FunctionSignature {
     pub fn create_signature(&self) -> String {
         let args: String = self
             .arguments
-            .clone()
-            .into_iter()
+            .iter()
             .map(|x| format!("{}: ${}", x, x))
             .collect::<Vec<String>>()
             .join(" , ");
@@ -57,8 +56,7 @@ impl FunctionSignature {
         &self,
     ) -> Vec<lsp::ParameterInformation> {
         self.arguments
-            .clone()
-            .into_iter()
+            .iter()
             .map(|x| lsp::ParameterInformation {
                 label: lsp::ParameterLabel::Simple(format!("${}", x)),
                 documentation: None,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -281,7 +281,7 @@ from(bucket: "inbucket")
   |> filter(fn: (r) => r["_measurement"] == "activity")
   |> filter(fn: (r) => r["target"] == "crumbs")"#;
 
-        let parsed = parse(&script);
+        let parsed = parse(script);
 
         assert!(parsed.is_object());
     }
@@ -291,7 +291,7 @@ from(bucket: "inbucket")
     fn test_parse_invalid() {
         let script = r#"this isn't flux"#;
 
-        let parsed = parse(&script);
+        let parsed = parse(script);
 
         assert!(parsed.is_object());
     }
@@ -305,7 +305,7 @@ from(bucket: "inbucket")
 
         let script = r#"option task={name:"beetle",every:1h} from(bucket:"inbucket")
 |>range(start:-task.every)|>filter(fn:(r)=>r["_measurement"]=="activity")"#;
-        let parsed = parse(&script);
+        let parsed = parse(script);
 
         let formatted = format_from_js_file(parsed).unwrap();
 
@@ -315,7 +315,7 @@ from(bucket: "inbucket")
     #[wasm_bindgen_test]
     fn test_format_from_js_file_invalid() {
         let script = r#"from(bucket:this isn't flux"#;
-        let parsed = parse(&script);
+        let parsed = parse(script);
 
         if let Err(error) = format_from_js_file(parsed) {
             assert_eq!(


### PR DESCRIPTION
Removes some duplicated semantic graph parsing and removes the completion specific semantic graph parsing (I don't understand what they were going for with the `_removed` suffix :S ) . Also some other smaller refactorings so reviewing commit by commit may be helpful.