### PR TITLE
test: Correct the positions of some tests

### DIFF
--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1451,7 +1451,9 @@ async fn test_completion_resolve() {
 async fn test_package_completion() {
     let fluxscript = r#"import "sql"
 
-sql."#;
+sql.
+// ^
+"#;
     let server = create_server();
     open_file(&server, fluxscript.to_string()).await;
 
@@ -1461,10 +1463,7 @@ sql."#;
                 uri: lsp::Url::parse("file:///home/user/file.flux")
                     .unwrap(),
             },
-            position: lsp::Position {
-                line: 2,
-                character: 3,
-            },
+            position: position_of(fluxscript),
         },
         work_done_progress_params: lsp::WorkDoneProgressParams {
             work_done_token: None,
@@ -1481,6 +1480,7 @@ sql."#;
 
     let result =
         server.completion(params.clone()).await.unwrap().unwrap();
+
 
     let expected_labels: Vec<String> = vec!["to", "from"]
         .into_iter()

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1901,6 +1901,7 @@ async fn test_param_completion() {
     let fluxscript = r#"import "csv"
 
 csv.from(
+     // ^
         "#;
     let server = create_server();
     open_file(&server, fluxscript.to_string()).await;
@@ -1911,10 +1912,7 @@ csv.from(
                 uri: lsp::Url::parse("file:///home/user/file.flux")
                     .unwrap(),
             },
-            position: lsp::Position {
-                line: 2,
-                character: 8,
-            },
+            position: position_of(fluxscript),
         },
         work_done_progress_params: lsp::WorkDoneProgressParams {
             work_done_token: None,


### PR DESCRIPTION
These positions were actually pointing one character to the left of the current marker which does not seem correct to me as I would expect those positions to do completion on the `sql` identifier in the package test (not on the member access) and to complete on the member access and not the call expression in the parameter test. The current completion code seems to pass tests regardless but I noticed I were not getting the expression I was expecting when doing the position-to-node lookup in my rewrite.

The current completion code seems to have special cases to handle things either way but I will try to remove those in favor of being more precise about which node we are operating on.