### PR TITLE
fix: Complete function args in more contexts

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -17,7 +17,7 @@ use crate::shared::get_argument_names;
 use crate::shared::get_package_name;
 use crate::shared::Function;
 use crate::stdlib;
-use crate::visitors::ast::{CallFinderVisitor, NodeFinderVisitor};
+use crate::visitors::ast::NodeFinderVisitor;
 use crate::visitors::semantic::{
     FunctionFinderVisitor, Import, ImportFinderVisitor,
     ObjectFunctionFinderVisitor,
@@ -31,262 +31,11 @@ struct PackageResult {
     pub full_name: String,
 }
 
-pub fn find_completions(
-    params: lsp::CompletionParams,
-    contents: &str,
-    pkg: &flux::semantic::nodes::Package,
-) -> lsp::CompletionList {
-    let info = CompletionInfo::create(&params, contents, pkg);
-
-    let mut items: Vec<lsp::CompletionItem> = vec![];
-
-    if let Some(info) = info {
-        match info.completion_type {
-            CompletionType::Generic => {
-                items.extend(get_identifier_matches(
-                    info, contents, pkg,
-                ));
-            }
-            CompletionType::Bad => {}
-            CompletionType::CallProperty(_func) => {
-                return find_param_completions(
-                    None, &params, contents, pkg,
-                )
-            }
-            CompletionType::Import => {
-                let infos = stdlib::get_package_infos();
-
-                let imports = get_imports(pkg);
-
-                let mut items = vec![];
-                for info in infos {
-                    if !(&imports).iter().any(|x| x.path == info.name)
-                    {
-                        items.push(new_string_arg_completion(
-                            info.path.as_str(),
-                            get_trigger(&params),
-                        ));
-                    }
-                }
-
-                return lsp::CompletionList {
-                    is_incomplete: false,
-                    items,
-                };
-            }
-            CompletionType::ObjectMember(_obj) => {
-                return find_dot_completions(params, contents, pkg);
-            }
-            _ => {}
-        }
-    }
-
-    lsp::CompletionList {
-        is_incomplete: false,
-        items,
-    }
-}
-
-#[derive(Clone, Debug)]
-enum CompletionType {
-    Generic,
-    Logical(flux::ast::Operator),
-    CallProperty(String),
-    ObjectMember(String),
-    Import,
-    Bad,
-}
-
 #[derive(Clone, Debug)]
 struct CompletionInfo {
-    completion_type: CompletionType,
     ident: String,
     position: lsp::Position,
     imports: Vec<Import>,
-}
-
-impl CompletionInfo {
-    fn create(
-        params: &lsp::CompletionParams,
-        source: &str,
-        sem_pkg: &flux::semantic::nodes::Package,
-    ) -> Option<CompletionInfo> {
-        let uri = &params.text_document_position.text_document.uri;
-        let position = params.text_document_position.position;
-
-        let pkg: Package =
-            parse_string(uri.to_string(), source).into();
-        let walker = AstNode::File(&pkg.files[0]);
-        let mut visitor =
-            NodeFinderVisitor::new(move_back(position, 1));
-
-        walk(&mut visitor, walker);
-
-        if let Some(finder_node) = visitor.node {
-            if let Some(parent) = finder_node.parent {
-                match parent.node {
-                    AstNode::MemberExpr(me) => {
-                        if let Expression::Identifier(obj) =
-                            &me.object
-                        {
-                            return Some(CompletionInfo {
-                                completion_type:
-                                    CompletionType::ObjectMember(
-                                        obj.name.clone(),
-                                    ),
-                                ident: obj.name.clone(),
-                                position,
-                                imports: get_imports(sem_pkg),
-                            });
-                        }
-                    }
-                    AstNode::ImportDeclaration(_id) => {
-                        return Some(CompletionInfo {
-                            completion_type: CompletionType::Import,
-                            ident: "".to_string(),
-                            position,
-                            imports: get_imports(sem_pkg),
-                        });
-                    }
-                    AstNode::BinaryExpr(be) => match &be.left {
-                        Expression::Identifier(left) => {
-                            let name = &left.name;
-
-                            return Some(CompletionInfo {
-                                completion_type:
-                                    CompletionType::Logical(
-                                        be.operator.clone(),
-                                    ),
-                                ident: name.clone(),
-                                position,
-                                imports: get_imports(sem_pkg),
-                            });
-                        }
-                        Expression::Member(left) => {
-                            if let Expression::Identifier(ident) =
-                                &left.object
-                            {
-                                let key =
-                                    property_key_str(&left.property);
-
-                                let name =
-                                    format!("{}.{}", ident.name, key);
-
-                                return Some(CompletionInfo {
-                                    completion_type:
-                                        CompletionType::Logical(
-                                            be.operator.clone(),
-                                        ),
-                                    ident: name,
-                                    position,
-                                    imports: get_imports(sem_pkg),
-                                });
-                            }
-                        }
-                        _ => {}
-                    },
-                    _ => {}
-                }
-
-                if let Some(grandparent) = parent.parent {
-                    if let Some(greatgrandparent) = grandparent.parent
-                    {
-                        if let (
-                            AstNode::Property(prop),
-                            AstNode::ObjectExpr(_),
-                            AstNode::CallExpr(call),
-                        ) = (
-                            parent.node,
-                            grandparent.node,
-                            greatgrandparent.node,
-                        ) {
-                            let name = property_key_str(&prop.key);
-
-                            if let Expression::Identifier(func) =
-                                &call.callee
-                            {
-                                return Some(CompletionInfo {
-                                    completion_type:
-                                        CompletionType::CallProperty(
-                                            func.name.clone(),
-                                        ),
-                                    ident: name.to_owned(),
-                                    position,
-                                    imports: get_imports(sem_pkg),
-                                });
-                            }
-                        }
-                    }
-                }
-
-                match finder_node.node {
-                    AstNode::BinaryExpr(be) => {
-                        if let Expression::Identifier(left) = &be.left
-                        {
-                            let name = &left.name;
-
-                            return Some(CompletionInfo {
-                                completion_type:
-                                    CompletionType::Logical(
-                                        be.operator.clone(),
-                                    ),
-                                ident: name.clone(),
-                                position,
-                                imports: get_imports(sem_pkg),
-                            });
-                        }
-                    }
-                    AstNode::Identifier(ident) => {
-                        let name = ident.name.clone();
-                        return Some(CompletionInfo {
-                            completion_type: CompletionType::Generic,
-                            ident: name,
-                            position,
-                            imports: get_imports(sem_pkg),
-                        });
-                    }
-                    AstNode::BadExpr(expr) => {
-                        let name = expr.text.clone();
-                        return Some(CompletionInfo {
-                            completion_type: CompletionType::Bad,
-                            ident: name,
-                            position,
-                            imports: get_imports(sem_pkg),
-                        });
-                    }
-                    AstNode::MemberExpr(mbr) => {
-                        if let Expression::Identifier(ident) =
-                            &mbr.object
-                        {
-                            return Some(CompletionInfo {
-                                completion_type:
-                                    CompletionType::Generic,
-                                ident: ident.name.clone(),
-                                position,
-                                imports: get_imports(sem_pkg),
-                            });
-                        }
-                    }
-                    AstNode::CallExpr(c) => {
-                        if let Some(Expression::Identifier(ident)) =
-                            c.arguments.last()
-                        {
-                            return Some(CompletionInfo {
-                                completion_type:
-                                    CompletionType::Generic,
-                                ident: ident.name.clone(),
-                                position,
-                                imports: get_imports(sem_pkg),
-                            });
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        None
-    }
 }
 
 fn property_key_str(p: &PropertyKey) -> &str {
@@ -302,13 +51,6 @@ fn get_imports(pkg: &flux::semantic::nodes::Package) -> Vec<Import> {
 
     flux::semantic::walk::walk(&mut visitor, walker);
     visitor.imports
-}
-
-fn move_back(position: lsp::Position, count: u32) -> lsp::Position {
-    lsp::Position {
-        line: position.line,
-        character: position.character - count,
-    }
 }
 
 fn get_user_matches(
@@ -343,26 +85,6 @@ fn get_trigger(params: &lsp::CompletionParams) -> Option<&str> {
         context.trigger_character.as_deref()
     } else {
         None
-    }
-}
-
-pub fn find_dot_completions(
-    params: lsp::CompletionParams,
-    source: &str,
-    pkg: &flux::semantic::nodes::Package,
-) -> lsp::CompletionList {
-    let info = CompletionInfo::create(&params, source, pkg);
-
-    if let Some(info) = info {
-        return lsp::CompletionList {
-            is_incomplete: false,
-            items: get_dot_completions(info, pkg),
-        };
-    }
-
-    lsp::CompletionList {
-        is_incomplete: false,
-        items: vec![],
     }
 }
 
@@ -446,80 +168,6 @@ fn get_stdlib_matches(
     }
 
     matches
-}
-
-pub fn find_param_completions(
-    trigger: Option<&str>,
-    params: &lsp::CompletionParams,
-    source: &str,
-    sem_pkg: &flux::semantic::nodes::Package,
-) -> lsp::CompletionList {
-    let uri = &params.text_document_position.text_document.uri;
-    let position = params.text_document_position.position;
-
-    let pkg: Package = parse_string(uri.to_string(), source).into();
-    let walker = AstNode::File(&pkg.files[0]);
-    let mut visitor = CallFinderVisitor::new(move_back(position, 1));
-
-    walk(&mut visitor, walker);
-
-    let mut items: Vec<String> = vec![];
-
-    if let Some(AstNode::CallExpr(call)) = visitor.node {
-        let provided = get_provided_arguments(call);
-
-        match &call.callee {
-            Expression::Identifier(ident) => {
-                items.extend(get_function_params(
-                    ident.name.as_str(),
-                    stdlib::get_builtin_functions(),
-                    &provided,
-                ));
-
-                let user_functions =
-                    get_user_functions(position, sem_pkg);
-                items.extend(get_function_params(
-                    ident.name.as_str(),
-                    user_functions,
-                    &provided,
-                ));
-            }
-            Expression::Member(me) => {
-                if let Expression::Identifier(ident) = &me.object {
-                    let package_functions =
-                        stdlib::get_package_functions(&ident.name);
-
-                    let object_functions = get_object_functions(
-                        ident.name.as_str(),
-                        sem_pkg,
-                    );
-
-                    let key = property_key_str(&me.property);
-
-                    items.extend(get_function_params(
-                        key,
-                        package_functions,
-                        &provided,
-                    ));
-
-                    items.extend(get_function_params(
-                        key,
-                        object_functions,
-                        &provided,
-                    ));
-                }
-            }
-            _ => (),
-        }
-    }
-
-    lsp::CompletionList {
-        is_incomplete: false,
-        items: items
-            .into_iter()
-            .map(|x| new_param_completion(x, trigger))
-            .collect(),
-    }
 }
 
 fn get_specific_package_functions(
@@ -1512,7 +1160,7 @@ impl Completable for UserFunctionResult {
     }
 }
 
-pub fn find_completions_2(
+pub fn find_completions(
     params: lsp::CompletionParams,
     contents: &str,
     sem_pkg: &flux::semantic::nodes::Package,
@@ -1533,7 +1181,6 @@ pub fn find_completions_2(
             AstNode::Identifier(id) => {
                 items.extend(get_identifier_matches(
                     CompletionInfo {
-                        completion_type: CompletionType::Generic,
                         ident: id.name.clone(),
                         position,
                         imports: get_imports(sem_pkg),
@@ -1548,7 +1195,6 @@ pub fn find_completions_2(
                 {
                     items = get_dot_completions(
                         CompletionInfo {
-                            completion_type: CompletionType::Generic,
                             ident: ident.name.clone(),
                             position,
                             imports: get_imports(sem_pkg),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -892,45 +892,14 @@ impl LanguageServer for LspServer {
             None => return Ok(None),
         };
 
-        let items = if let Some(ctx) = &params.context {
-            match (ctx.trigger_kind, &ctx.trigger_character) {
-                (
-                    lsp::CompletionTriggerKind::TRIGGER_CHARACTER,
-                    Some(c),
-                ) => match c.as_str() {
-                    "." => completion::find_dot_completions(
-                        params, &contents, &sem_pkg,
-                    ),
-                    ":" => {
-                        // XXX: rockstar (29 Nov 2021) - This is where argument
-                        // completion will live, e.g. buckets, measurements and
-                        // tag keys/values. There are multiple issues open to support
-                        // this functionality open currently.
-                        lsp::CompletionList {
-                            is_incomplete: false,
-                            items: vec![],
-                        }
-                    }
-                    "(" | "," => completion::find_param_completions(
-                        Some(c),
-                        &params,
-                        contents.as_str(),
-                        &sem_pkg,
-                    ),
-                    _ => completion::find_completions(
-                        params,
-                        contents.as_str(),
-                        &sem_pkg,
-                    ),
-                },
-                _ => completion::find_completions(
-                    params,
-                    contents.as_str(),
-                    &sem_pkg,
-                ),
-            }
-        } else {
+        let items = if false {
             completion::find_completions(
+                params,
+                contents.as_str(),
+                &sem_pkg,
+            )
+        } else {
+            completion::find_completions_2(
                 params,
                 contents.as_str(),
                 &sem_pkg,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -892,19 +892,11 @@ impl LanguageServer for LspServer {
             None => return Ok(None),
         };
 
-        let items = if false {
-            completion::find_completions(
-                params,
-                contents.as_str(),
-                &sem_pkg,
-            )
-        } else {
-            completion::find_completions_2(
-                params,
-                contents.as_str(),
-                &sem_pkg,
-            )
-        };
+        let items = completion::find_completions(
+            params,
+            contents.as_str(),
+            &sem_pkg,
+        );
 
         let response = lsp::CompletionResponse::List(items);
         Ok(Some(response))

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2068,6 +2068,54 @@ csv.from(
 }
 
 #[test]
+async fn test_param_completion_2() {
+    let fluxscript = r#"import "csv"
+
+csv.from(
+"#;
+    let server = create_server();
+    open_file(&server, fluxscript.to_string()).await;
+
+    let params = lsp::CompletionParams {
+        text_document_position: lsp::TextDocumentPositionParams {
+            text_document: lsp::TextDocumentIdentifier {
+                uri: lsp::Url::parse("file:///home/user/file.flux")
+                    .unwrap(),
+            },
+            position: lsp::Position {
+                line: 3,
+                character: 0,
+            },
+        },
+        work_done_progress_params: lsp::WorkDoneProgressParams {
+            work_done_token: None,
+        },
+        partial_result_params: lsp::PartialResultParams {
+            partial_result_token: None,
+        },
+        context: Some(lsp::CompletionContext {
+            trigger_kind: lsp::CompletionTriggerKind::INVOKED,
+            trigger_character: None,
+        }),
+    };
+
+    let result =
+        server.completion(params.clone()).await.unwrap().unwrap();
+
+    let items = match result.clone() {
+        lsp::CompletionResponse::List(l) => l.items,
+        _ => unreachable!(),
+    };
+
+    let labels: Vec<&str> =
+        items.iter().map(|item| item.label.as_str()).collect();
+
+    let expected = vec!["csv", "file", "mode", "url"];
+
+    assert_eq!(expected, labels);
+}
+
+#[test]
 async fn test_options_completion() {
     let fluxscript = r#"import "strings"
 import "csv"

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1445,6 +1445,7 @@ async fn test_completion_resolve() {
 
     assert_eq!(params, result);
 }
+
 #[test]
 async fn test_package_completion() {
     let fluxscript = r#"import "sql"
@@ -1495,6 +1496,135 @@ sql.
                     .collect::<Vec<String>>()
             );
         }
+        _ => unreachable!(),
+    };
+}
+
+#[test]
+async fn test_import_completion() {
+    let fluxscript = r#"
+import "
+    // ^
+
+x = 1
+"#;
+    let server = create_server();
+    open_file(&server, fluxscript.to_string()).await;
+
+    let params = lsp::CompletionParams {
+        text_document_position: lsp::TextDocumentPositionParams {
+            text_document: lsp::TextDocumentIdentifier {
+                uri: lsp::Url::parse("file:///home/user/file.flux")
+                    .unwrap(),
+            },
+            position: position_of(fluxscript),
+        },
+        work_done_progress_params: lsp::WorkDoneProgressParams {
+            work_done_token: None,
+        },
+        partial_result_params: lsp::PartialResultParams {
+            partial_result_token: None,
+        },
+        context: Some(lsp::CompletionContext {
+            trigger_kind: lsp::CompletionTriggerKind::INVOKED,
+            trigger_character: None,
+        }),
+    };
+
+    let result =
+        server.completion(params.clone()).await.unwrap().unwrap();
+
+    match result.clone() {
+        lsp::CompletionResponse::List(l) => {
+            expect![[r#"
+                [
+                    "\"array\"",
+                    "\"contrib/RohanSreerama5/naiveBayesClassifier\"",
+                    "\"contrib/anaisdg/anomalydetection\"",
+                    "\"contrib/anaisdg/statsmodels\"",
+                    "\"contrib/bonitoo-io/alerta\"",
+                    "\"contrib/bonitoo-io/hex\"",
+                    "\"contrib/bonitoo-io/servicenow\"",
+                    "\"contrib/bonitoo-io/tickscript\"",
+                    "\"contrib/bonitoo-io/victorops\"",
+                    "\"contrib/bonitoo-io/zenoss\"",
+                    "\"contrib/chobbs/discord\"",
+                    "\"contrib/jsternberg/aggregate\"",
+                    "\"contrib/jsternberg/influxdb\"",
+                    "\"contrib/jsternberg/math\"",
+                    "\"contrib/jsternberg/rows\"",
+                    "\"contrib/rhajek/bigpanda\"",
+                    "\"contrib/sranka/opsgenie\"",
+                    "\"contrib/sranka/sensu\"",
+                    "\"contrib/sranka/teams\"",
+                    "\"contrib/sranka/telegram\"",
+                    "\"contrib/sranka/webexteams\"",
+                    "\"contrib/tomhollingworth/events\"",
+                    "\"csv\"",
+                    "\"date\"",
+                    "\"dict\"",
+                    "\"experimental\"",
+                    "\"experimental/aggregate\"",
+                    "\"experimental/array\"",
+                    "\"experimental/bigtable\"",
+                    "\"experimental/bitwise\"",
+                    "\"experimental/csv\"",
+                    "\"experimental/geo\"",
+                    "\"experimental/http\"",
+                    "\"experimental/http/requests\"",
+                    "\"experimental/influxdb\"",
+                    "\"experimental/iox\"",
+                    "\"experimental/json\"",
+                    "\"experimental/mqtt\"",
+                    "\"experimental/oee\"",
+                    "\"experimental/prometheus\"",
+                    "\"experimental/query\"",
+                    "\"experimental/record\"",
+                    "\"experimental/table\"",
+                    "\"experimental/usage\"",
+                    "\"generate\"",
+                    "\"http\"",
+                    "\"influxdata/influxdb\"",
+                    "\"influxdata/influxdb/monitor\"",
+                    "\"influxdata/influxdb/sample\"",
+                    "\"influxdata/influxdb/schema\"",
+                    "\"influxdata/influxdb/secrets\"",
+                    "\"influxdata/influxdb/tasks\"",
+                    "\"influxdata/influxdb/v1\"",
+                    "\"internal/boolean\"",
+                    "\"internal/debug\"",
+                    "\"internal/gen\"",
+                    "\"internal/influxql\"",
+                    "\"internal/location\"",
+                    "\"internal/promql\"",
+                    "\"internal/testutil\"",
+                    "\"interpolate\"",
+                    "\"json\"",
+                    "\"kafka\"",
+                    "\"math\"",
+                    "\"pagerduty\"",
+                    "\"planner\"",
+                    "\"profiler\"",
+                    "\"pushbullet\"",
+                    "\"regexp\"",
+                    "\"runtime\"",
+                    "\"sampledata\"",
+                    "\"slack\"",
+                    "\"socket\"",
+                    "\"sql\"",
+                    "\"strings\"",
+                    "\"system\"",
+                    "\"testing\"",
+                    "\"testing/expect\"",
+                    "\"timezone\"",
+                    "\"types\"",
+                    "\"universe\"",
+                ]
+            "#]].assert_debug_eq(
+                &l.items.iter().map(|x| &x.label).collect::<Vec<_>>(),
+            );
+        }
+
         _ => unreachable!(),
     };
 }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1641,6 +1641,7 @@ option task = {
 }
 
 task.
+ // ^
 
 // ab = 10
 "#;
@@ -1653,10 +1654,7 @@ task.
                 uri: lsp::Url::parse("file:///home/user/file.flux")
                     .unwrap(),
             },
-            position: lsp::Position {
-                line: 16,
-                character: 5,
-            },
+            position: position_of(fluxscript),
         },
         work_done_progress_params: lsp::WorkDoneProgressParams {
             work_done_token: None,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1533,7 +1533,7 @@ x = 1
     let result =
         server.completion(params.clone()).await.unwrap().unwrap();
 
-    match result.clone() {
+    match result {
         lsp::CompletionResponse::List(l) => {
             expect![[r#"
                 [
@@ -2102,7 +2102,7 @@ csv.from(
     let result =
         server.completion(params.clone()).await.unwrap().unwrap();
 
-    let items = match result.clone() {
+    let items = match result {
         lsp::CompletionResponse::List(l) => l.items,
         _ => unreachable!(),
     };
@@ -2148,7 +2148,7 @@ csv.from(mode: "raw",
     let result =
         server.completion(params.clone()).await.unwrap().unwrap();
 
-    let items = match result.clone() {
+    let items = match result {
         lsp::CompletionResponse::List(l) => l.items,
         _ => unreachable!(),
     };

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1479,6 +1479,7 @@ sql.
     let result =
         server.completion(params.clone()).await.unwrap().unwrap();
 
+
     let expected_labels: Vec<String> = vec!["to", "from"]
         .into_iter()
         .map(|x| x.into())

--- a/src/visitors/ast.rs
+++ b/src/visitors/ast.rs
@@ -54,10 +54,8 @@ impl<'a> NodeFinderVisitor<'a> {
 
 impl<'a> walk::Visitor<'a> for NodeFinderVisitor<'a> {
     fn visit(&mut self, node: walk::Node<'a>) -> bool {
-        if crate::lsp::position_in_range(
-            &self.position,
-            &node.base().clone().location.into(),
-        ) {
+        let range = lsp::Range::from(node.base().clone().location);
+        if crate::lsp::position_in_range(&self.position, &range) {
             let parent = self.node.clone();
             if let Some(parent) = parent {
                 self.node = Some(NodeFinderNode {

--- a/src/visitors/ast.rs
+++ b/src/visitors/ast.rs
@@ -1,36 +1,6 @@
 use flux::ast::walk;
 use lspower::lsp;
 
-#[derive(Clone)]
-pub struct CallFinderVisitor<'a> {
-    pub node: Option<walk::Node<'a>>,
-    pub position: lsp::Position,
-}
-
-impl<'a> CallFinderVisitor<'a> {
-    pub fn new(position: lsp::Position) -> Self {
-        CallFinderVisitor {
-            node: None,
-            position,
-        }
-    }
-}
-
-impl<'a> walk::Visitor<'a> for CallFinderVisitor<'a> {
-    fn visit(&mut self, node: walk::Node<'a>) -> bool {
-        if crate::lsp::position_in_range(
-            &self.position,
-            &node.base().clone().location.into(),
-        ) {
-            if let walk::Node::CallExpr(_) = node {
-                self.node = Some(node.clone())
-            }
-        }
-
-        true
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct NodeFinderNode<'a> {
     pub node: walk::Node<'a>,


### PR DESCRIPTION
The completion code is very complicated compared to what it actually does (or at least compared to what we test it for). This removes special casing around how the completion is triggered (trigger character vs invoked) and which node/position we determine that we need to run completion on. Thanks to this it fixes #392 .

Since this is a rewrite of part of the completion this may change or lose completion in some instances but it should be easier to add those back later rather than trying to mold the existing code into something better (and we would add tests as well then, so we know when behavior is changed).

