### PR TITLE
fix: add clippy rules to prevent print macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #![deny(
     clippy::expect_used,
     clippy::panic,
+    clippy::print_stderr,
+    clippy::print_stdout,
     clippy::unwrap_used,
     clippy::wildcard_imports
 )]


### PR DESCRIPTION
This patch adds clippy lint rules to prevent `println!` and `eprintln!`
calls. It doesn't truly catch all issues printing to `stdout`/`stderr`,
but it would have caught some earlier invocations of `println!` left in
after debugging.