### PR TITLE
chore: disable strict mode by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           command: cargo fmt --all -- --check
       - run:
           name: "run lint"
-          command: cargo clippy --locked --all -- -Dclippy::all
+          command: cargo clippy --locked --all-features --all -- -Dclippy::all
 
   test:
     docker:
@@ -20,7 +20,7 @@ jobs:
       - checkout
       - run:
           name: "run cargo tests"
-          command: cargo test --locked
+          command: cargo test --locked --all-features
 
   bench-test:
     docker:
@@ -50,7 +50,7 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - run: cargo build --locked --verbose
+      - run: cargo build --locked --verbose --all-features
 
   wasm-build:
     docker:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ opt-level = "z"
 lto = true
 
 [features]
-default = ["strict"]
+default = []
 strict = []
 wasm_next = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
-#![deny(
+#![warn(
     clippy::expect_used,
     clippy::panic,
     clippy::unwrap_used,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -13,7 +13,7 @@ use crate::LspServer;
 
 /// Initialize logging - this requires the "console_log" feature to function,
 /// as this library adds 180k to the wasm binary being shipped.
-#[allow(non_snake_case, dead_code)]
+#[allow(non_snake_case, dead_code, clippy::expect_used)]
 #[wasm_bindgen]
 pub fn initLog() {
     #[cfg(feature = "console_log")]


### PR DESCRIPTION
This patch removes strict mode by default. In general, I think having a
strict mode is good, and I think that CI should enforce something akin
to strict mode, but I realize now that there is plenty of reason for
that not to get in the way of tinkering during dev. I left it for so
long because go tends to have similar expectations, e.g. unused
variables won't compile, but I never liked that behavior and the man in
the mirror asserted the same things in rust.