### PR TITLE
fix: Complete function arguments when it is followed by statements

### DIFF
--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2145,6 +2145,7 @@ async fn test_param_completion_3() {
 
 csv.from(mode: "raw",
                    // ^
+x = 1
 "#;
     let server = create_server();
     open_file(&server, fluxscript.to_string()).await;


### PR DESCRIPTION
Updated a test to mostly make it more general. We get a quite weird parse here as `x` and `= 1`.
gets parsed as properties of the call expression but this at least fixes the completion for this case. (The parse itself will break completion done elsewhere however.

cc #392