### PR TITLE
fix: publish diagnostics on open

### DIFF
--- a/integration/lsp.test.ts
+++ b/integration/lsp.test.ts
@@ -113,6 +113,27 @@ describe('LSP Server', () => {
 
         expect(callback).toHaveBeenCalled();
     });
+
+    it('sends lists of diagnostics', async () => {
+        const diagnostics = [];
+        const callback = jest.fn((message) => {
+            const diagnosticMessage = JSON.parse(message);
+            diagnosticMessage.params.diagnostics.forEach(diagnostic => {
+                diagnostics.push(diagnostic);
+            });
+        });
+        server.onMessage(callback);
+        const runner = server.run();
+        await init(server);
+
+        const openRequest = '{"jsonrpc": "2.0", "id": 2, "method": "textDocument/didOpen", "params": { "textDocument": {"uri":"file:///main.flux","languageId":"flux","version":1,"text":"from(bucket: x)"}}}';
+        await server.send(openRequest)
+
+        await shutdown(server, runner);
+
+        expect(callback).toHaveBeenCalled();
+        expect(diagnostics.length).toBe(1);
+    });
 });
 describe('module', () => {
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3119,10 +3119,8 @@ async fn compute_diagnostics_multi_file() {
 |> filter(fn: (r) => r.anTag == v.a)"#;
     open_file(&server, fluxscript.into(), Some(&filename)).await;
 
-    let diagnostics = server.compute_diagnostics(
-        &lsp::Url::parse(&filename).unwrap(),
-        &fluxscript,
-    );
+    let diagnostics = server
+        .compute_diagnostics(&lsp::Url::parse(&filename).unwrap());
 
     assert_eq!(
         vec![lsp::Diagnostic {
@@ -3158,10 +3156,8 @@ async fn compute_diagnostics_multi_file() {
     )
     .await;
 
-    let diagnostics_again = server.compute_diagnostics(
-        &lsp::Url::parse(&filename).unwrap(),
-        &fluxscript,
-    );
+    let diagnostics_again = server
+        .compute_diagnostics(&lsp::Url::parse(&filename).unwrap());
 
     assert_eq!(0, diagnostics_again.len());
 }


### PR DESCRIPTION
This patch fixes an issue where diagnostics were attempted before the
file is saved in the store, so no files are found to create a package.
This probably had a number of follow-on bugs, but the first issue
noticed was that diagnostics were not showing up.

Additionally, the signature of `compute_diagnostics` was updated. It was
left the way it was before just for patch brevity, but that was probably
a mistake.

Closes #428