### PR TITLE
feat: shrink the wasm

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Cargo.lock binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,12 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -383,7 +389,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen",
 ]
 
@@ -403,7 +409,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -448,7 +454,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -458,7 +464,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -470,7 +476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -483,7 +489,7 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -525,7 +531,7 @@ version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8858831f7781322e539ea39e72449c46b059638250c14344fec8d0aa6e539c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "num_cpus",
  "parking_lot",
 ]
@@ -638,7 +644,6 @@ dependencies = [
  "flux-core",
  "getrandom",
  "once_cell",
- "serde_json",
  "thiserror",
  "walkdir",
 ]
@@ -703,6 +708,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+ "wee_alloc",
 ]
 
 [[package]]
@@ -831,7 +837,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "libc",
  "wasi",
@@ -925,7 +931,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1021,7 +1027,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "value-bag",
 ]
 
@@ -1064,6 +1070,12 @@ checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "memory_units"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "num-integer"
@@ -1146,7 +1158,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1225,7 +1237,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "log",
  "wepoll-ffi",
@@ -1787,7 +1799,7 @@ version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -1814,7 +1826,7 @@ version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -1881,6 +1893,18 @@ checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wee_alloc"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "memory_units",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "LSP support for the flux language"
 repository = "https://github.com/influxdata/flux-lsp"
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-Oz", "--enable-mutable-globals"]
+wasm-opt = ["-Oz"]
 
 [profile.release]
 opt-level = "z"
@@ -17,7 +17,6 @@ lto = true
 [features]
 default = []
 strict = []
-wasm_next = []
 
 [lib]
 name = "flux_lsp"
@@ -37,11 +36,11 @@ async-std = { version = "1.11.0", features = ["attributes"] }
 async-trait = "0.1.53"
 clap = { version = "3.1.8", features = ["derive"] }
 combinations = "0.1.0"
-console_error_panic_hook = "0.1.7"
+console_error_panic_hook = { version = "0.1.7", optional = true }
 console_log = { version = "0.2", optional = true }
 env_logger = "0.9"
 expect-test = "1.2.2"
-flux = { git = "https://github.com/influxdata/flux", tag = "v0.162.0", features = ["lsp"] }
+flux = { git = "https://github.com/influxdata/flux", tag = "v0.162.0", features = ["lsp"], default-features = false }
 futures = "0.3.21"
 js-sys = "0.3.56"
 line-col = "0.2.1"
@@ -56,6 +55,7 @@ url = "2.2.2"
 wasm-bindgen = { version = "0.2.79", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.29"
 web-sys = { version = "0.3.56", features = ["console"] }
+wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,4 +19,8 @@ mod wasm;
 #[macro_use]
 extern crate pretty_assertions;
 
+#[cfg(feature = "wee_alloc")]
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
 pub use server::LspServer;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -81,6 +81,7 @@ pub struct Lsp {
 
 impl Default for Lsp {
     fn default() -> Self {
+        #[cfg(feature = "console_log")]
         console_error_panic_hook::set_once();
 
         let (service, messages) =

--- a/wasm-build.sh
+++ b/wasm-build.sh
@@ -5,14 +5,14 @@ set -e
 BUILD_MODE=${BUILD_MODE-release}
 
 BUILD_FLAG=""
-BUILD_MODE_ARGS=""
+BUILD_MODE_ARGS="--features wee_alloc"
 case $BUILD_MODE in
     "release")
         BUILD_FLAG="--release"
         ;;
     "dev")
         BUILD_FLAG="--dev"
-        BUILD_MODE_ARGS="--features console_log"
+        BUILD_MODE_ARGS="${BUILD_MODE_ARGS},console_log,console_error_panic_hook"
         ;;
     *)
         echo "Invalid build mode: ${BUILD_MODE}"
@@ -39,6 +39,12 @@ wasm-pack build \
     -- \
     --locked \
     $BUILD_MODE_ARGS
+
+# Strip producers header and some other optional bits.
+wasm-strip pkg-node/flux-lsp-node_bg.wasm
+wasm-opt -Oz -o pkg-node/flux-lsp-node_bg.wasm pkg-node/flux-lsp-node_bg.wasm
+wasm-strip pkg-browser/flux-lsp-browser_bg.wasm
+wasm-opt -Oz -o pkg-browser/flux-lsp-browser_bg.wasm pkg-browser/flux-lsp-browser_bg.wasm
 
 cat pkg-node/package.json | sed s/@influxdata\\/flux-lsp\"/@influxdata\\/flux-lsp-node\"/g > pkg-node/package-new.json
 mv pkg-node/package-new.json pkg-node/package.json


### PR DESCRIPTION
This patch does a number of things, all in the name of shrinking the
final wasm binary size. The first three are introducing features, two to
change the logging to optional, and one to use a smaller allocator (by
10k).

Additionally, it introduces using some tools to shrink the binary
further by removing more sections that are unneeded. These are used in
`wasm-build.sh`.

Fixes #432