### PR TITLE
feat: add wasm tools to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM quay.io/influxdb/flux-build:latest
 
 USER root
 
-ENV NODE_VERSION="node_12.x"
-ENV DEBIAN_NAME="buster"
+ENV NODE_VERSION="node_16.x"
+ENV DEBIAN_NAME="bullseye"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
     echo "deb https://deb.nodesource.com/$NODE_VERSION $DEBIAN_NAME main" \
         > /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && apt-get install --no-install-recommends -y nodejs && \
+    apt-get update && apt-get install --no-install-recommends -y nodejs wabt binaryen && \
     apt-get clean  && rm -rf /var/lib/apt/lists/*
 
 # UNAME comes from the flux-build docker container


### PR DESCRIPTION
This patch adds `wabt` and `binaryen` to the docker image used to build
the wasm binaries. These two packages provide some wasm tools we'll use
in the future to shrink the wasm binary size.

Additionally, the debian version was updated (the stable debian is now
bullseye) and the node version was updated to 16, as 12 goes EOL on
Apr 30, 2022, and 16 is the version used in vsflux.