### PR TITLE
feat: separate final build artifact results into features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ jobs:
           command: cargo fmt --all -- --check
       - run:
           name: "run lint"
-          command: cargo clippy --locked --all-features --all -- -Dclippy::all
+          command: |
+            cargo clippy --locked -- -Dclippy::all
+            cargo clippy --no-default-features --features=wasm
 
   test:
     docker:
@@ -20,7 +22,9 @@ jobs:
       - checkout
       - run:
           name: "run cargo tests"
-          command: cargo test --locked --all-features
+          command: |
+            cargo test --locked
+            cargo test --no-default-features --features=wasm
 
   bench-test:
     docker:
@@ -50,7 +54,7 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - run: cargo build --locked --verbose --all-features
+      - run: cargo build --locked --verbose
 
   wasm-build:
     docker:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,6 @@ dependencies = [
 name = "flux-lsp"
 version = "0.8.12"
 dependencies = [
- "anyhow",
  "async-std",
  "async-trait",
  "clap 3.1.12",
@@ -706,13 +705,11 @@ dependencies = [
  "line-col",
  "log",
  "pretty_assertions",
- "serde",
  "serde_json",
- "serde_repr",
  "simplelog",
+ "tokio",
  "tower-lsp",
  "tower-service",
- "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -903,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6330e8a36bd8c859f3fa6d9382911fbb7147ec39807f63b923933a247240b9ba"
+checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
 
 [[package]]
 name = "humantime"
@@ -1208,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -1670,6 +1667,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f48b6d60512a392e34dbf7fd456249fd2de3c83669ab642e021903f4015185b"
+dependencies = [
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1741,8 @@ dependencies = [
  "memchr",
  "serde",
  "serde_json",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-lsp-macros",
 ]
@@ -1729,6 +1765,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
+name = "tracing"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,9 +1804,9 @@ checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,52 +15,52 @@ opt-level = "z"
 lto = true
 
 [features]
-default = []
+default = ["cmd"]
 strict = []
+cmd = ["clap", "simplelog", "tokio", "tower-service", "tower-lsp/runtime-tokio"]
+wasm = ["futures", "js-sys", "serde_json", "tower-lsp/runtime-agnostic", "tower-service", "wasm-bindgen", "wasm-bindgen-futures", "wee_alloc"]
 
 [lib]
-name = "flux_lsp"
 crate-type = ["cdylib", "rlib"]
-path = "src/lib.rs"
 
 [[bin]]
 name = "flux-lsp"
+required-features = ["cmd"]
 test = false
 bench = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.56"
-async-std = { version = "1.11.0", features = ["attributes"] }
+async-std = { version = "1.11.0", features = ["attributes"], optional = true }
 async-trait = "0.1.53"
-clap = { version = "3.1.9", features = ["derive"] }
+clap = { version = "3.1.9", features = ["derive"], optional = true }
 combinations = "0.1.0"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 console_log = { version = "0.2", optional = true }
-env_logger = "0.9"
-expect-test = "1.2.2"
 flux = { git = "https://github.com/influxdata/flux", tag = "v0.165.0", features = ["lsp"], default-features = false }
-futures = "0.3.21"
-js-sys = "0.3.57"
+futures = { version = "0.3.21", optional = true }
+js-sys = { version = "0.3.57", optional = true }
 line-col = "0.2.1"
 log = "0.4.16"
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.79"
-serde_repr = "0.1.7"
-simplelog = "0.12.0"
-tower-lsp = { version = "0.17.0", default-features = false, features = ["runtime-agnostic" ] }
-tower-service = { version = "0.3.1" }
-url = "2.2.2"
-wasm-bindgen = { version = "0.2.80", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.30"
-web-sys = { version = "0.3.57", features = ["console"] }
+serde_json = { version = "1.0.79", optional = true }
+simplelog = { version = "0.12.0", optional = true }
+tokio = { version = "1.17.0", features = ["io-std", "macros", "rt-multi-thread"], optional = true }
+tower-lsp = { version = "0.17.0", default-features = false, optional = true }
+tower-service = { version = "0.3.1", optional = true }
+wasm-bindgen = { version = "0.2.80", features = ["serde-serialize"], optional = true }
+wasm-bindgen-futures = { version = "0.4.30", optional = true }
+web-sys = { version = "0.3.57", features = ["console"], optional = true }
 wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
+async-std = { version = "1.11.0", features = ["attributes"] }
 criterion = "0.3"
+env_logger = "0.9"
+expect-test = "1.2.2"
 futures = "0.3.15"
 pretty_assertions = "1.2.1"
+serde_json = "1.0.79"
 wasm-bindgen-test = "0.3.30"
 
 [[bench]]

--- a/src/bin/flux-lsp.rs
+++ b/src/bin/flux-lsp.rs
@@ -14,7 +14,7 @@ struct Args {
     log_file: Option<String>,
 }
 
-#[async_std::main]
+#[tokio::main]
 async fn main() {
     let matches = Args::parse();
 
@@ -32,8 +32,8 @@ async fn main() {
     }
 
     log::debug!("Starting lsp client");
-    let stdin = async_std::io::stdin();
-    let stdout = async_std::io::stdout();
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
 
     let (service, messages) =
         LspService::new(|client| LspServer::new(Some(client)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod server;
 mod shared;
 mod stdlib;
 mod visitors;
+#[cfg(feature = "wasm")]
 mod wasm;
 
 #[cfg(test)]

--- a/wasm-build.sh
+++ b/wasm-build.sh
@@ -5,7 +5,7 @@ set -e
 BUILD_MODE=${BUILD_MODE-release}
 
 BUILD_FLAG=""
-BUILD_MODE_ARGS="--features wee_alloc"
+BUILD_MODE_ARGS="--no-default-features --features wasm"
 case $BUILD_MODE in
     "release")
         BUILD_FLAG="--release"


### PR DESCRIPTION
This patch separates the final build artifacts into two separate
features. The resulting changes to `Cargo.toml` reduced the final wasm
binary size by 350k, but the benefit to this work has been the explicit
separation between the two build artifacts and their needs.

The flux-lsp is really two separate products: a `flux-lsp` command-line
binary, and a wasm library consumed by a browser. Because of that, there
can be some really awkward interactions for how the source reads. This
work seems important to do now, before we start getting more complex on
the wasm side.