### PR TITLE
chore: remove pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,1 @@
-Closes #
 
-Describe your proposed changes here.
-
-<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->
-
-- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
-- [ ] Rebased/mergeable
-- [ ] Tests pass
-- [ ] Documentation updated or issue created (provide link to issue/pr)
-- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)


### PR DESCRIPTION
Every time I'm out in the field, I stumble into [this fence](https://en.wikipedia.org/wiki/Wikipedia:Chesterton%27s_fence).
I looked in the git history to see why it exists, and it was added by
default when the license was added. There has never been an outside
contributor to `flux-lsp` (all contributors were, at some point,
employees/contractors of InfluxData). The only time I encounter it is to
delete it, and I don't think it provides value that can, at this stage
in the maturity of the project, be conveyed better.

At this point, I feel comfortable understanding this fence, and feel its
removal is appropriate.