### PR TITLE
feat: change wasm export name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,8 @@ jobs:
       - checkout
       - run: |
           BUILD_MODE=release AR=llvm-ar ./wasm-build.sh
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > pkg-node/.npmrc
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > pkg-browser/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > target/pkg-node/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > target/pkg-browser/.npmrc
           ./publish.sh
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-/target
+target/
 **/*.rs.bk
-me.flux
 lsp.log
-pkg*
 .vscode
 .idea

--- a/integration/lsp.test.ts
+++ b/integration/lsp.test.ts
@@ -2,12 +2,12 @@ describe('LSP Server', () => {
     let server;
 
     beforeAll(async () => {
-        const { initLog } = await import('@influxdata/flux-lsp-node');
+        const { initLog } = await import('@influxdata/flux-node');
         initLog();
     });
 
     beforeEach(async () => {
-        const { Lsp } = await import('@influxdata/flux-lsp-node');
+        const { Lsp } = await import('@influxdata/flux-node');
         server = new Lsp();
     });
 
@@ -138,7 +138,7 @@ describe('LSP Server', () => {
 describe('module', () => {
 
     it('can parse Flux source' , async () => {
-        const { parse } = await import('@influxdata/flux-lsp-node');
+        const { parse } = await import('@influxdata/flux-node');
         const ast = parse('x = 1');
         // expect some basic parts of this ast
         expect(ast).toBeDefined();
@@ -149,7 +149,7 @@ describe('module', () => {
     })
 
     it('can format Flux source' , async () => {
-        const { parse, format_from_js_file } = await import('@influxdata/flux-lsp-node');
+        const { parse, format_from_js_file } = await import('@influxdata/flux-node');
         const ast = parse('x = 1');
         // Change AST
         ast.body[0].init.value = '2';

--- a/integration/package.json
+++ b/integration/package.json
@@ -279,7 +279,7 @@
   "scripts": {
     "build-wasm-browser": "",
     "build-wasm": "cd .. && BUILD_MODE=dev ./wasm-build.sh",
-    "install-pkg": "npm run build-wasm && npm install --no-save ../pkg-node",
+    "install-pkg": "npm run build-wasm && npm install --no-save ../target/pkg-node",
     "client": "npm run install-pkg && node an-lsp-client.js",
     "test": "npm run install-pkg && jest"
   },


### PR DESCRIPTION
This patch changes the final wasm export packages from `flux-lsp-*` to
just `flux-*`, as it will soon carry with it more general tools for
working with flux itself.

Additionally, it simplifies some of the build process itself.

Fixes #436