### PR TITLE
fix: use RwLock instead of Mutex

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -304,6 +304,7 @@ from(bucket: "inbucket")
     #[wasm_bindgen_test]
     fn test_format_from_js_file() {
         let expected = r#"option task = {name: "beetle", every: 1h}
+
 from(bucket: "inbucket")
     |> range(start: -task.every)
     |> filter(fn: (r) => r["_measurement"] == "activity")"#;


### PR DESCRIPTION
`RwLock` is like `Mutex` except that it allows multiple read references
but still only one write reference maximum. Most lsp operations only
need a read reference, so while I don't think there are _currently_
performance bottlenecks for a `Mutex`, `RwLock` does send a different
message in its use, which is more applicable in this case.