### PR TITLE
chore: small nits and changes

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1192,8 +1192,7 @@ pub fn find_completions(
                     sem_pkg,
                 ));
             }
-            AstNode::MemberExpr(member) => {
-                // TODO Handle completion on member accesses on non-identifiers
+            AstNode::MemberExpr(member) => 
                 if let Expression::Identifier(ident) = &member.object
                 {
                     items = get_dot_completions(

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1192,7 +1192,7 @@ pub fn find_completions(
                     sem_pkg,
                 ));
             }
-            AstNode::MemberExpr(member) => 
+            AstNode::MemberExpr(member) => {
                 if let Expression::Identifier(ident) = &member.object
                 {
                     items = get_dot_completions(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -770,7 +770,7 @@ impl LanguageServer for LspServer {
                                         .parameter(
                                             ident.name.as_str(),
                                         )
-                                        .map(|value| value.clone())
+                                        .cloned()
                                 }
                                 _ => None,
                             }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -241,7 +241,7 @@ impl LanguageServer for LspServer {
                 code_lens_provider: None,
                 color_provider: None,
                 completion_provider: Some(lsp::CompletionOptions {
-                    resolve_provider: Some(true),
+                    resolve_provider: None,
                     trigger_characters: Some(vec![
                         ".".to_string(),
                         ":".to_string(),
@@ -799,16 +799,6 @@ impl LanguageServer for LspServer {
             }
         }
         Ok(None)
-    }
-
-    // XXX: rockstar (9 Aug 2021) - This implementation exists here *solely* for
-    // compatibility with the previous server. This behavior is identical to it,
-    // although very clearly kinda useless.
-    async fn completion_resolve(
-        &self,
-        params: lsp::CompletionItem,
-    ) -> RpcResult<lsp::CompletionItem> {
-        Ok(params)
     }
 
     async fn completion(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -765,8 +765,6 @@ impl LanguageServer for LspServer {
                             let func = path.get(path.len() - 3)?;
                             match func {
                                 walk::Node::FunctionExpr(func) => {
-
-                                    // TODO Use MonoType::parameter directly
                                     let field = ident.name.as_str();
                                     match &func.typ {
                                         MonoType::Fun(f) => f.req.get(field).or_else(|| f.opt.get(field)).or_else(|| {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -18,6 +18,8 @@ use crate::{
     completion, shared::FunctionSignature, stdlib, visitors::semantic,
 };
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// Convert a flux::semantic::walk::Node to a lsp::Location
 /// https://microsoft.github.io/language-server-protocol/specification#location
 fn node_to_location(
@@ -327,7 +329,7 @@ impl LanguageServer for LspServer {
             },
             server_info: Some(lsp::ServerInfo {
                 name: "flux-lsp".to_string(),
-                version: Some("2.0".to_string()),
+                version: Some(VERSION.into()),
             }),
         })
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,8 +6,7 @@ use std::collections::HashMap;
 
 use flux::semantic::nodes::ErrorKind as SemanticNodeErrorKind;
 use flux::semantic::{
-    nodes::FunctionParameter, nodes::Symbol, types::MonoType, walk,
-    ErrorKind,
+    nodes::FunctionParameter, nodes::Symbol, walk, ErrorKind,
 };
 use tower_lsp::{
     jsonrpc::Result as RpcResult, lsp_types as lsp, Client,
@@ -767,25 +766,18 @@ impl LanguageServer for LspServer {
                             let func = path.get(path.len() - 3)?;
                             match func {
                                 walk::Node::FunctionExpr(func) => {
-                                    let field = ident.name.as_str();
-                                    match &func.typ {
-                                        MonoType::Fun(f) => f.req.get(field).or_else(|| f.opt.get(field)).or_else(|| {
-                                            f.pipe
-                                                .as_ref()
-                                                .and_then(|pipe| if pipe.k == field { Some(&pipe.v) } else { None })
-                                        })
-
-                                                .cloned()
-                                        ,
-                                        _ => None,
-                                    }
+                                    func.typ
+                                        .parameter(
+                                            ident.name.as_str(),
+                                        )
+                                        .map(|value| value.clone())
                                 }
-                                _ => None
+                                _ => None,
                             }
                         }
                         _ => None,
                     }
-                },
+                }
                 _ => None,
             });
             if let Some(typ) = hover_type {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -431,8 +431,6 @@ impl LanguageServer for LspServer {
                         &ident.name,
                         "builtin",
                     ));
-                    // XXX: rockstar (13 Jul 2021) - Add support for user defined
-                    // signatures.
                 } else {
                     log::debug!("signature_help on non-member and non-identifier");
                 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -439,10 +439,6 @@ impl LanguageServer for LspServer {
             }
         }
 
-        // XXX: rockstar (12 Jul 2021) - `active_parameter` and `active_signature`
-        // are currently unsupported, as they were unsupported in the previous
-        // version of the server. They should be implemented, as it presents a
-        // much better user interface.
         let response = if signatures.is_empty() {
             None
         } else {

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -21,7 +21,13 @@ fn url_to_key_val(url: &lsp::Url) -> (String, String) {
     (parent, filename.into())
 }
 
-fn get_analyzer() -> Result<flux::semantic::Analyzer<'static, &'static flux::semantic::import::Packages>, LspError> {
+fn get_analyzer() -> Result<
+    flux::semantic::Analyzer<
+        'static,
+        &'static flux::semantic::import::Packages,
+    >,
+    LspError,
+> {
     match flux::new_semantic_analyzer(
         flux::semantic::AnalyzerConfig {
             // Explicitly disable the AST and Semantic checks.
@@ -33,10 +39,7 @@ fn get_analyzer() -> Result<flux::semantic::Analyzer<'static, &'static flux::sem
     ) {
         Ok(analyzer) => Ok(analyzer),
         Err(err) => {
-            return Err(LspError::InternalError(format!(
-                "{}",
-                err
-            )))
+            return Err(LspError::InternalError(format!("{}", err)))
         }
     }
 }
@@ -158,7 +161,10 @@ impl Store {
         }
     }
 
-    fn get_ast_package(&self, url: &lsp::Url) -> Result<flux::ast::Package, LspError> {
+    fn get_ast_package(
+        &self,
+        url: &lsp::Url,
+    ) -> Result<flux::ast::Package, LspError> {
         let (key, val) = url_to_key_val(url);
         let files = self.get_files(key)?;
 
@@ -214,13 +220,15 @@ impl Store {
         match analyzer.analyze_ast(&ast_pkg).map_err(|mut err| {
             let (key, _val) = url_to_key_val(url);
             match self.get_files(key) {
-                Ok(files) => err.error.source = Some(
-                    files
-                        .into_iter()
-                        .map(|file| file.1)
-                        .collect::<Vec<String>>()
-                        .join("\n"),
-                ),
+                Ok(files) => {
+                    err.error.source = Some(
+                        files
+                            .into_iter()
+                            .map(|file| file.1)
+                            .collect::<Vec<String>>()
+                            .join("\n"),
+                    )
+                }
                 Err(_) => (),
             }
             err
@@ -253,7 +261,7 @@ impl Store {
             }
         };
 
-        let mut analyzer = match get_analyzer(){
+        let mut analyzer = match get_analyzer() {
             Ok(analyzer) => analyzer,
             Err(err) => {
                 log::error!("{:?}", err);
@@ -263,13 +271,15 @@ impl Store {
         match analyzer.analyze_ast(&ast_pkg).map_err(|mut err| {
             let (key, _val) = url_to_key_val(url);
             match self.get_files(key) {
-                Ok(files) => err.error.source = Some(
-                    files
-                        .into_iter()
-                        .map(|file| file.1)
-                        .collect::<Vec<String>>()
-                        .join("\n"),
-                ),
+                Ok(files) => {
+                    err.error.source = Some(
+                        files
+                            .into_iter()
+                            .map(|file| file.1)
+                            .collect::<Vec<String>>()
+                            .join("\n"),
+                    )
+                }
                 Err(_) => (),
             }
             err

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1758,13 +1758,6 @@ errorCounts
     );
 }
 
-// TODO: sean (10 Aug 2021) - This test fails unless the line reading
-// `ab = 10` in the flux script is commented out. The error is valid,
-// but the lsp should be able to turn it into a diagnostic notification
-// and continue to provide completion suggestions.
-//
-// An issue has been created for this:
-// https://github.com/influxdata/flux-lsp/issues/290
 #[test]
 async fn test_option_object_members_completion() {
     let fluxscript = r#"import "strings"
@@ -1786,7 +1779,7 @@ option task = {
 task.
  // ^
 
-// ab = 10
+ab = 10
 "#;
     let server = create_server();
     open_file(&server, fluxscript.to_string(), None).await;

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3138,9 +3138,6 @@ async fn compute_diagnostics_multi_file() {
         diagnostics
     );
 
-    // Open the adjacent file with the identifier in it.
-    // This has to have a filename that is alphabetically before the previous
-    // one; see the XXX comment in store.rs.
     open_file(
         &server,
         r#"v = {a: "b"}"#.to_string(),

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1442,23 +1442,6 @@ x = 1
 }
 
 #[test]
-async fn test_completion_resolve() {
-    let fluxscript = r#"import "strings"#;
-    let server = create_server();
-    open_file(&server, fluxscript.to_string(), None).await;
-
-    let params = lsp::CompletionItem::new_simple(
-        "label".to_string(),
-        "detail".to_string(),
-    );
-
-    let result =
-        server.completion_resolve(params.clone()).await.unwrap();
-
-    assert_eq!(params, result);
-}
-
-#[test]
 async fn test_package_completion() {
     let fluxscript = r#"import "sql"
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -81,7 +81,7 @@ async fn test_initialized() {
     let server_info = result.server_info.unwrap();
 
     assert_eq!(server_info.name, "flux-lsp".to_string());
-    assert_eq!(server_info.version, Some("2.0".to_string()));
+    assert_eq!(server_info.version, Some(env!("CARGO_PKG_VERSION").into()));
 }
 
 #[test]

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -81,7 +81,10 @@ async fn test_initialized() {
     let server_info = result.server_info.unwrap();
 
     assert_eq!(server_info.name, "flux-lsp".to_string());
-    assert_eq!(server_info.version, Some(env!("CARGO_PKG_VERSION").into()));
+    assert_eq!(
+        server_info.version,
+        Some(env!("CARGO_PKG_VERSION").into())
+    );
 }
 
 #[test]
@@ -311,7 +314,6 @@ async fn test_signature_help() {
     let fluxscript = r#"from(
                           // ^"#;
     open_file(&server, fluxscript.into(), None).await;
-
 
     let params = lsp::SignatureHelpParams {
         context: None,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -308,12 +308,11 @@ async fn test_signature_help_not_opened() {
 #[test]
 async fn test_signature_help() {
     let server = create_server();
-    open_file(&server, "from(".to_string(), None).await;
+    let fluxscript = r#"from(
+                          // ^"#;
+    open_file(&server, fluxscript.into(), None).await;
 
-    // XXX: rockstar (13 Jul 2021) - In the lsp protocol, Position arguments
-    // are indexed from 1, e.g. there is no line number 0. This references
-    // (0, 5) for compatibility with the previous implementation, but should
-    // be updated to (1, 5) at some point.
+
     let params = lsp::SignatureHelpParams {
         context: None,
         text_document_position_params:
@@ -322,7 +321,7 @@ async fn test_signature_help() {
                     lsp::Url::parse("file:///home/user/file.flux")
                         .unwrap(),
                 ),
-                lsp::Position::new(0, 5),
+                position_of(fluxscript),
             ),
         work_done_progress_params: lsp::WorkDoneProgressParams {
             work_done_token: None,

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -146,7 +146,6 @@ pub fn get_package_infos() -> Vec<PackageInfo> {
     result
 }
 
-// TODO Use Record/MonoType::fields from flux
 fn record_fields(
     this: &Record,
 ) -> impl Iterator<Item = &flux::semantic::types::Property> {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,8 +1,4 @@
 #![allow(clippy::panic)]
-// XXX: rockstar (15 Mar 2022) - rustwasm generates a spurious () at the end of
-// the generated code. This was fixed in mainline, but has not yet had a release.
-// See https://github.com/rustwasm/wasm-bindgen/issues/2774
-#![allow(clippy::unused_unit)]
 
 use std::mem;
 


### PR DESCRIPTION
This all started as I was digging into fixing another bug. As I was diving
through the code, I started realizing that there were a lot of things captured
in comments that should be issues, and other things that no longer applied, and
it just kind of unrolled into a bunch of nits. `XXX` and `TODO` comments were
either verified to no longer be needed or converted into an issue.

While I was there, I then added the version information from initialization,
which is what I originally needed a branch for, so I could verify that we were,
indeed, running the version of flux-lsp that I needed.

Each individual commit should provide all the context needed. Apologies for
such a wildly out-of-context patch. It just sort of...happened.