### PR TITLE
fix: only show diagnostics relating to the the trigger file

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -217,6 +217,19 @@ impl LspServer {
             Some(errors) => errors
                 .errors
                 .iter()
+                .filter(|error| {
+                    // We will never have two files with the same name in a package, so we can
+                    // key off filename to determine whether the error exists in this file or
+                    // elsewhere in the package.
+                    if let Some(file) = &error.location.file {
+                        if let Some(segments) = key.path_segments() {
+                            if let Some(filename) = segments.last() {
+                                return file == filename;
+                            }
+                        }
+                    }
+                    false
+                })
                 .map(|e| lsp::Diagnostic {
                     range: e.location.clone().into(),
                     severity: Some(lsp::DiagnosticSeverity::ERROR),

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3136,8 +3136,9 @@ async fn compute_diagnostics_multi_file() {
     assert_eq!(0, diagnostics_again.len());
 }
 
+// Only emit diagnostics related to that specific file.
 #[test]
-async fn compute_diagnostics_multi_file_error_in_another_file() {
+async fn compute_diagnostics_only_on_problem_file() {
     let server = create_server();
 
     let filename: String = "file:///path/to/script.flux".into();
@@ -3145,6 +3146,7 @@ async fn compute_diagnostics_multi_file_error_in_another_file() {
 |> range(start: -100d)
 |> filter(fn: (r) => r.anTag == v.a)"#;
     open_file(&server, fluxscript.into(), Some(&filename)).await;
+    // This file, in the same package, contains an error.
     open_file(
         &server,
         r#"v = a"#.to_string(),
@@ -3155,5 +3157,5 @@ async fn compute_diagnostics_multi_file_error_in_another_file() {
     let diagnostics_again = server
         .compute_diagnostics(&lsp::Url::parse(&filename).unwrap());
 
-    assert_eq!(0, diagnostics_again.len());
+    assert!(diagnostics_again.is_empty());
 }


### PR DESCRIPTION
Prior to this patch, there was a bug when, should an error exist
in another file in the package, that diagnostic was reported on _all_
files in the package. This patch fixes that issue to only report errors
on the trigger file, e.g. the file that sent the
`didOpen`/`didChange`/`didSave` event.

Fixes #456