### PR TITLE
fix: downgrade back to lspower

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "async-codec-lite"
-version = "0.0.1"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4402a0bd7db04e239d06a40aa7ab442729ea22ab73ef242de3094761580d53"
+checksum = "932ad436d9570582ac23e13163f598c647c1af1220f102e83488ed47d50d7f05"
 dependencies = [
  "anyhow",
  "bytes",
@@ -536,13 +536,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.3.3"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391b56fbd302e585b7a9494fb70e40949567b1cf9003a8e4a6041a1687c26573"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown 0.12.1",
- "lock_api",
+ "num_cpus",
 ]
 
 [[package]]
@@ -674,7 +673,7 @@ dependencies = [
  "fnv",
  "libflate",
  "log",
- "lsp-types",
+ "lsp-types 0.93.0",
  "maplit",
  "pretty",
  "regex",
@@ -705,11 +704,11 @@ dependencies = [
  "js-sys",
  "line-col",
  "log",
+ "lspower",
  "pretty_assertions",
  "serde_json",
  "simplelog",
  "tokio",
- "tower-lsp",
  "tower-service",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -876,12 +875,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
-name = "hashbrown"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
-
-[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,7 +928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1025,16 +1018,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e69cdf6b85b5c8dce514f694089a2cf8b1a702f6cd28607bcb3cf296c9778db"
 
 [[package]]
-name = "lock_api"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1025,19 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
  "value-bag",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.91.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2368312c59425dd133cb9a327afee65be0a633a8ce471d248e2202a48f8f68ae"
+dependencies = [
+ "bitflags",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
 ]
 
 [[package]]
@@ -1055,6 +1051,44 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "lspower"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2242d4cb4071c7b9ae53001c8c658402b55bb8c3669a70d3ce9565f1144b30"
+dependencies = [
+ "anyhow",
+ "async-codec-lite",
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "httparse",
+ "log",
+ "lsp-types 0.91.1",
+ "lspower-macros",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "twoway",
+]
+
+[[package]]
+name = "lspower-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca1d48da0e4a6100b4afd52fae99f36d47964a209624021280ad9ffdd410e83d"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1166,26 +1200,6 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-
-[[package]]
-name = "pin-project"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1666,71 +1680,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.2"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
-
-[[package]]
-name = "tower-lsp"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e094780b4447366c59f79acfd65b1375ecaa84e61dddbde1421aa506334024"
-dependencies = [
- "async-codec-lite",
- "async-trait",
- "auto_impl",
- "bytes",
- "dashmap",
- "futures",
- "httparse",
  "log",
- "lsp-types",
- "memchr",
- "serde",
- "serde_json",
+ "pin-project-lite",
  "tokio",
- "tokio-util",
- "tower",
- "tower-lsp-macros",
-]
-
-[[package]]
-name = "tower-lsp-macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebd99eec668d0a450c177acbc4d05e0d0d13b1f8d3db13cd706c52cbec4ac04"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1740,35 +1699,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
-name = "tracing"
-version = "0.1.34"
+name = "twoway"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+checksum = "c57ffb460d7c24cd6eda43694110189030a3d1dfe418416d9468fd1c1d290b47"
 dependencies = [
- "cfg-if 1.0.0",
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
-dependencies = [
- "lazy_static",
+ "memchr",
+ "unchecked-index",
 ]
 
 [[package]]
@@ -1776,6 +1713,12 @@ name = "typed-arena"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
+
+[[package]]
+name = "unchecked-index"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ lto = true
 [features]
 default = ["cmd"]
 strict = []
-cmd = ["clap", "simplelog", "tokio", "tower-service", "tower-lsp/runtime-tokio"]
-wasm = ["futures", "js-sys", "serde_json", "tower-lsp/runtime-agnostic", "tower-service", "wasm-bindgen", "wasm-bindgen-futures", "wee_alloc"]
+cmd = ["clap", "simplelog", "tokio", "tower-service", "lspower/runtime-tokio"]
+wasm = ["futures", "js-sys", "serde_json", "lspower/runtime-agnostic", "tower-service", "wasm-bindgen", "wasm-bindgen-futures", "wee_alloc"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -43,10 +43,10 @@ futures = { version = "0.3.21", optional = true }
 js-sys = { version = "0.3.57", optional = true }
 line-col = "0.2.1"
 log = "0.4.16"
+lspower = { version = "1.5.0", default-features = false, optional = true }
 serde_json = { version = "1.0.79", optional = true }
 simplelog = { version = "0.12.0", optional = true }
 tokio = { version = "1.17.0", features = ["io-std", "macros", "rt-multi-thread"], optional = true }
-tower-lsp = { version = "0.17.0", default-features = false, optional = true }
 tower-service = { version = "0.3.1", optional = true }
 wasm-bindgen = { version = "0.2.80", features = ["serde-serialize"], optional = true }
 wasm-bindgen-futures = { version = "0.4.30", optional = true }

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -3,7 +3,7 @@ use criterion::{
     black_box, criterion_group, criterion_main, Criterion,
 };
 use flux_lsp::LspServer;
-use tower_lsp::{lsp_types as lsp, LanguageServer};
+use lspower::{lsp, LanguageServer};
 
 fn create_server() -> LspServer {
     LspServer::new(None)

--- a/integration/lsp.test.ts
+++ b/integration/lsp.test.ts
@@ -98,7 +98,7 @@ describe('LSP Server', () => {
         await shutdown(server, runner);
     });
 
-    it.skip('sends diagnostics', async () => {
+    it('sends diagnostics', async () => {
         const callback = jest.fn((message) => {
             console.log('callback', message);
         });
@@ -114,7 +114,7 @@ describe('LSP Server', () => {
         expect(callback).toHaveBeenCalled();
     });
 
-    it.skip('sends lists of diagnostics', async () => {
+    it('sends lists of diagnostics', async () => {
         const diagnostics = [];
         const callback = jest.fn((message) => {
             const diagnosticMessage = JSON.parse(message);

--- a/src/bin/flux-lsp.rs
+++ b/src/bin/flux-lsp.rs
@@ -2,8 +2,8 @@
 use std::fs::OpenOptions;
 
 use clap::Parser;
+use lspower::{LspService, Server};
 use simplelog::{CombinedLogger, Config, LevelFilter, WriteLogger};
-use tower_lsp::{LspService, Server};
 
 use flux_lsp::LspServer;
 
@@ -37,5 +37,8 @@ async fn main() {
 
     let (service, messages) =
         LspService::new(|client| LspServer::new(Some(client)));
-    Server::new(stdin, stdout, messages).serve(service).await;
+    Server::new(stdin, stdout)
+        .interleave(messages)
+        .serve(service)
+        .await;
 }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -11,7 +11,7 @@ use flux::semantic::types::{
 };
 use flux::semantic::walk::Visitor as SemanticVisitor;
 use flux::{imports, prelude};
-use tower_lsp::lsp_types as lsp;
+use lspower::lsp;
 
 use crate::shared::Function;
 use crate::shared::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(feature = "strict", deny(warnings))]
+#![cfg_attr(
+    feature = "strict",
+    deny(warnings, clippy::print_stdout, clippy::print_stderr)
+)]
 #![warn(
     clippy::expect_used,
     clippy::panic,

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,5 +1,5 @@
 /// A collection of tools for working with lsp types.
-use tower_lsp::lsp_types as lsp;
+use lspower::lsp;
 
 /// Return true if two Range structs overlap.
 pub fn ranges_overlap(a: &lsp::Range, b: &lsp::Range) -> bool {
@@ -16,7 +16,7 @@ pub fn position_in_range(
 
 #[cfg(test)]
 mod test {
-    use tower_lsp::lsp_types as lsp;
+    use lspower::lsp;
 
     use super::*;
 

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 
-use tower_lsp::lsp_types as lsp;
+use lspower::lsp;
 
 use super::types::LspError;
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashMap};
 
 use async_std::test;
 use expect_test::expect;
-use tower_lsp::{lsp_types as lsp, LanguageServer};
+use lspower::{lsp, LanguageServer};
 
 use super::*;
 

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -1,3 +1,5 @@
+use lspower::jsonrpc::{Error, ErrorCode};
+
 #[derive(Debug)]
 pub enum LspError {
     InternalError(String),
@@ -5,30 +7,24 @@ pub enum LspError {
     FileNotFound(String),
 }
 
-impl From<LspError> for tower_lsp::jsonrpc::Error {
+impl From<LspError> for Error {
     fn from(error: LspError) -> Self {
         match error {
-            LspError::InternalError(error) => {
-                tower_lsp::jsonrpc::Error {
-                    code:
-                        tower_lsp::jsonrpc::ErrorCode::InternalError,
-                    message: error,
-                    data: None,
-                }
-            }
-            LspError::LockNotAcquired => tower_lsp::jsonrpc::Error {
-                code: tower_lsp::jsonrpc::ErrorCode::InternalError,
+            LspError::InternalError(error) => Error {
+                code: ErrorCode::InternalError,
+                message: error,
+                data: None,
+            },
+            LspError::LockNotAcquired => Error {
+                code: ErrorCode::InternalError,
                 message: "Could not acquire lock".into(),
                 data: None,
             },
-            LspError::FileNotFound(filename) => {
-                tower_lsp::jsonrpc::Error {
-                    code:
-                        tower_lsp::jsonrpc::ErrorCode::InvalidParams,
-                    message: format!("File not fiend: {}", filename),
-                    data: None,
-                }
-            }
+            LspError::FileNotFound(filename) => Error {
+                code: ErrorCode::InvalidParams,
+                message: format!("File not fiend: {}", filename),
+                data: None,
+            },
         }
     }
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,4 +1,4 @@
-use tower_lsp::lsp_types as lsp;
+use lspower::lsp;
 
 use flux::semantic::types::MonoType;
 

--- a/src/visitors/semantic/completion.rs
+++ b/src/visitors/semantic/completion.rs
@@ -2,7 +2,7 @@ use flux::ast::SourceLocation;
 use flux::semantic::nodes::Expression;
 use flux::semantic::types::MonoType;
 use flux::semantic::walk::{Node, Visitor};
-use tower_lsp::lsp_types as lsp;
+use lspower::lsp;
 
 use crate::shared::Function;
 

--- a/src/visitors/semantic/functions.rs
+++ b/src/visitors/semantic/functions.rs
@@ -4,7 +4,7 @@ use flux::ast::SourceLocation;
 use flux::semantic::nodes::Expression;
 use flux::semantic::types::MonoType;
 use flux::semantic::walk::{Node, Visitor};
-use tower_lsp::lsp_types as lsp;
+use lspower::lsp;
 
 use crate::shared::FunctionInfo;
 

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -4,7 +4,7 @@ use flux::semantic::{
     nodes::{Expression, Symbol},
     walk::{self, Node, Visitor},
 };
-use tower_lsp::lsp_types as lsp;
+use lspower::lsp;
 
 mod completion;
 mod symbols;
@@ -219,7 +219,18 @@ pub struct PackageNodeFinderVisitor {
 impl<'a> Visitor<'a> for PackageNodeFinderVisitor {
     fn visit(&mut self, node: Node<'a>) -> bool {
         if let Node::PackageClause(n) = node {
-            self.location = Some(n.loc.clone().into());
+            // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
+            // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
+            self.location = Some(lsp::Range {
+                start: lsp::Position {
+                    line: n.loc.start.line - 1,
+                    character: n.loc.start.column - 1,
+                },
+                end: lsp::Position {
+                    line: n.loc.end.line - 1,
+                    character: n.loc.end.column - 1,
+                },
+            });
             return false;
         }
         true

--- a/src/visitors/semantic/symbols.rs
+++ b/src/visitors/semantic/symbols.rs
@@ -2,7 +2,7 @@
 
 use flux::semantic::nodes::{self, Expression};
 use flux::semantic::walk::{Node, Visitor};
-use tower_lsp::lsp_types as lsp;
+use lspower::lsp;
 
 fn parse_variable_assignment(
     uri: lsp::Url,


### PR DESCRIPTION
There's a showstopper issue related to `tower-lsp` and our `onMessage`
handler code in the wasm export. This patch reverses that update so that
we aren't blocked with continuing feature work while we figure out what
we're missing there.