### PR TITLE
feat: add linting infrastructure and provide hints about contrib/experimental

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,98 @@
+/// Diagnostics for flux code
+///
+/// These diagnostics can range from informational lints to warnings and errors.
+use lspower::lsp;
+
+use flux::semantic::nodes::Package;
+
+use super::visitors::semantic::ExperimentalDiagnosticVisitor;
+
+/// Provide info about the nature of experimental.
+///
+/// While we want to encourage people to use the experimental package, we should
+/// ensure they understand and are okay with the unstable nature of experimental.
+/// The function can change or disappear at a moment's notice. If there isn't active
+/// monitoring on the successful nature of queries using experimental, they may break
+/// silently and cause headaches for consumers.
+pub(crate) fn experimental_lint(
+    pkg: &Package,
+) -> Vec<lsp::Diagnostic> {
+    let walker = flux::semantic::walk::Node::Package(pkg);
+    let mut visitor = ExperimentalDiagnosticVisitor::default();
+
+    flux::semantic::walk::walk(&mut visitor, walker);
+
+    visitor.diagnostics
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn get_package(source: &str) -> flux::semantic::nodes::Package {
+        let ast_pkg = flux::parser::parse_string("".into(), &source);
+        let mut analyzer = flux::new_semantic_analyzer(
+            flux::semantic::AnalyzerConfig::default(),
+        )
+        .unwrap();
+        let (_, pkg) = analyzer.analyze_ast(&ast_pkg.into()).unwrap();
+        pkg
+    }
+
+    #[test]
+    fn experimental_lint_check() {
+        let fluxscript = r#"import "experimental"
+        
+from(bucket: "my-bucket")
+    |> range(start: -100d)
+    |> filter(fn: (r) => r.value == "b")
+    |> experimental.to(bucket: "out-bucket", org: "abc123", host: "https://myhost.example.com", token: "123abc")
+"#;
+        let package = get_package(&fluxscript);
+
+        let diagnostics = experimental_lint(&package);
+
+        assert_eq!(vec![lsp::Diagnostic {
+            range: lsp::Range {
+                start: lsp::Position {
+                    line: 5, character: 7,
+                },
+                end : lsp::Position {
+                    line: 5, character: 112,
+                },
+            },
+            severity: Some(lsp::DiagnosticSeverity::HINT),
+            message: "experimental features can change often or be deleted/moved. Use with caution.".into(),
+            ..lsp::Diagnostic::default()
+        }], diagnostics);
+    }
+
+    #[test]
+    fn experimental_array_lint() {
+        let fluxscript = r#"import "experimental/array"
+
+array.concat(
+    arr: [1,2],
+    v: [3,4],
+)
+"#;
+        let package = get_package(&fluxscript);
+
+        let diagnostics = experimental_lint(&package);
+
+        assert_eq!(vec![lsp::Diagnostic {
+            range: lsp::Range {
+                start: lsp::Position {
+                    line: 2, character: 0,
+                },
+                end : lsp::Position {
+                    line: 5, character: 1,
+                },
+            },
+            severity: Some(lsp::DiagnosticSeverity::HINT),
+            message: "experimental features can change often or be deleted/moved. Use with caution.".into(),
+            ..lsp::Diagnostic::default()
+        }], diagnostics);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
     clippy::wildcard_imports
 )]
 mod completion;
+mod diagnostics;
 mod lsp;
 mod server;
 mod shared;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -199,7 +199,10 @@ impl LspServer {
     pub fn new(client: Option<Client>) -> Self {
         Self {
             client: Arc::new(Mutex::new(client)),
-            diagnostics: vec![super::diagnostics::experimental_lint],
+            diagnostics: vec![
+                super::diagnostics::experimental_lint,
+                super::diagnostics::contrib_lint,
+            ],
             store: store::Store::default(),
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -253,13 +253,17 @@ impl LspServer {
                 // Note: it is important, if no diagnostics exist, that we return an empty
                 // diagnostic list, as that will signal to the client that the diagnostics
                 // have been cleared.
-                let package =
-                    self.store.get_semantic_package(key).unwrap();
-                self.diagnostics
-                    .iter()
-                    .map(|func| func(&package))
-                    .flatten()
-                    .collect::<Vec<lsp::Diagnostic>>()
+                if let Ok(package) =
+                    self.store.get_semantic_package(key)
+                {
+                    return self
+                        .diagnostics
+                        .iter()
+                        .flat_map(|func| func(&package))
+                        .collect::<Vec<lsp::Diagnostic>>();
+                } else {
+                    return vec![];
+                }
             }
             Some(errors) => errors
                 .errors

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3153,3 +3153,22 @@ async fn compute_diagnostics_only_on_problem_file() {
 
     assert!(diagnostics_again.is_empty());
 }
+
+#[test]
+async fn compute_diagnostics_non_errors() {
+    let server = create_server();
+
+    let filename: String = "file:///path/to/script.flux".into();
+    let fluxscript = r#"import "experimental"
+        
+from(bucket: "my-bucket")
+|> range(start: -100d)
+|> filter(fn: (r) => r.value == "b")
+|> experimental.to(bucket: "out-bucket", org: "abc123", host: "https://myhost.example.com", token: "123abc")"#;
+    open_file(&server, fluxscript.into(), Some(&filename)).await;
+
+    let diagnostics_again = server
+        .compute_diagnostics(&lsp::Url::parse(&filename).unwrap());
+
+    assert!(!diagnostics_again.is_empty());
+}

--- a/src/visitors/semantic/lint.rs
+++ b/src/visitors/semantic/lint.rs
@@ -57,11 +57,11 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                             self.diagnostics.push(lsp::Diagnostic {
                                 range: lsp::Range {
                                     start: lsp::Position {
-                                        line: expr.loc.start.line -1,
-                                        character: expr.loc.start.column -1,
+                                        line: expr.loc.start.line - 1,
+                                        character: expr.loc.start.column - 1,
                                     },
                                     end: lsp::Position {
-                                        line: expr.loc.end.line-1,
+                                        line: expr.loc.end.line - 1,
                                         character: expr.loc.end.column - 1,
                                     },
                                 },
@@ -87,6 +87,106 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                                     },
                                     severity: Some(lsp::DiagnosticSeverity::HINT),
                                     message: "experimental features can change often or be deleted/moved. Use with caution.".into(),
+                                    ..lsp::Diagnostic::default()
+                                });
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            _ => {},
+        }
+        true
+    }
+}
+
+pub struct ContribDiagnosticVisitor {
+    namespaces: Vec<String>,
+    pub diagnostics: Vec<lsp::Diagnostic>,
+}
+
+impl Default for ContribDiagnosticVisitor {
+    fn default() -> Self {
+        Self {
+            diagnostics: vec![],
+            namespaces: vec![],
+        }
+    }
+}
+
+impl<'a> flux::semantic::walk::Visitor<'a>
+    for ContribDiagnosticVisitor
+{
+    fn visit(&mut self, node: WalkNode<'a>) -> bool {
+        if let WalkNode::Package(pkg) = node {
+            // Is there an experimental import in this package? If not,
+            // don't keep going. There's nothing to check here.
+            let mut imports_from_contrib = false;
+            pkg.files.iter().for_each(|file| {
+                file.imports.iter().for_each(|import| {
+                    if import.path.value.starts_with("contrib") {
+                        imports_from_contrib = true;
+
+                        if let Some(alias) = &import.alias {
+                            self.namespaces
+                                .push(format!("{}", alias.name));
+                        } else {
+                            let split: Vec<&str> = import
+                                .path
+                                .value
+                                .split("/")
+                                .collect();
+                            if split.len() > 1 {
+                                self.namespaces.push(
+                                    split.last().unwrap().to_string(),
+                                );
+                            }
+                        }
+                    }
+                })
+            });
+            return imports_from_contrib;
+        }
+
+        match node {
+            WalkNode::CallExpr(expr) => {
+                match &expr.callee {
+                    flux::semantic::nodes::Expression::Identifier(id) => {
+                        if self.namespaces.contains(&format!("{}", id.name)) {
+                            self.diagnostics.push(lsp::Diagnostic {
+                                range: lsp::Range {
+                                    start: lsp::Position {
+                                        line: expr.loc.start.line -1,
+                                        character: expr.loc.start.column -1,
+                                    },
+                                    end: lsp::Position {
+                                        line: expr.loc.end.line-1,
+                                        character: expr.loc.end.column - 1,
+                                    },
+                                },
+                                severity: Some(lsp::DiagnosticSeverity::HINT),
+                                message: "contrib packages are user-contributed, and do not carry with them the same compatibility guarantees as the standard library. Use with caution.".into(),
+                                ..lsp::Diagnostic::default()
+                            });
+                        }
+                    }
+                    flux::semantic::nodes::Expression::Member(member) => {
+                        if let flux::semantic::nodes::Expression::Identifier(id) = &member.object {
+                            if self.namespaces.contains(&id.name.to_string()) {
+                                self.diagnostics.push(lsp::Diagnostic {
+                                    range: lsp::Range {
+                                        start: lsp::Position {
+                                            line: expr.loc.start.line - 1,
+                                            character: expr.loc.start.column - 1,
+                                        },
+                                        end: lsp::Position {
+                                            line: expr.loc.end.line - 1,
+                                            character: expr.loc.end.column - 1,
+                                        },
+                                    },
+                                    severity: Some(lsp::DiagnosticSeverity::HINT),
+                                    message: "contrib packages are user-contributed, and do not carry with them the same compatibility guarantees as the standard library. Use with caution.".into(),
                                     ..lsp::Diagnostic::default()
                                 });
                             }

--- a/src/visitors/semantic/lint.rs
+++ b/src/visitors/semantic/lint.rs
@@ -1,0 +1,102 @@
+use flux::semantic::walk::Node as WalkNode;
+use lspower::lsp;
+
+pub struct ExperimentalDiagnosticVisitor {
+    namespaces: Vec<String>,
+    pub diagnostics: Vec<lsp::Diagnostic>,
+}
+
+impl Default for ExperimentalDiagnosticVisitor {
+    fn default() -> Self {
+        Self {
+            diagnostics: vec![],
+            namespaces: vec!["experimental".into()],
+        }
+    }
+}
+
+impl<'a> flux::semantic::walk::Visitor<'a>
+    for ExperimentalDiagnosticVisitor
+{
+    fn visit(&mut self, node: WalkNode<'a>) -> bool {
+        if let WalkNode::Package(pkg) = node {
+            // Is there an experimental import in this package? If not,
+            // don't keep going. There's nothing to check here.
+            let mut imports_experimental = false;
+            pkg.files.iter().for_each(|file| {
+                file.imports.iter().for_each(|import| {
+                    if import.path.value.starts_with("experimental") {
+                        imports_experimental = true;
+
+                        if let Some(alias) = &import.alias {
+                            self.namespaces
+                                .push(format!("{}", alias.name));
+                        } else {
+                            let split: Vec<&str> = import
+                                .path
+                                .value
+                                .split("/")
+                                .collect();
+                            if split.len() > 1 {
+                                self.namespaces.push(
+                                    split.last().unwrap().to_string(),
+                                );
+                            }
+                        }
+                    }
+                })
+            });
+            return imports_experimental;
+        }
+
+        match node {
+            WalkNode::CallExpr(expr) => {
+                match &expr.callee {
+                    flux::semantic::nodes::Expression::Identifier(id) => {
+                        if self.namespaces.contains(&format!("{}", id.name)) {
+                            self.diagnostics.push(lsp::Diagnostic {
+                                range: lsp::Range {
+                                    start: lsp::Position {
+                                        line: expr.loc.start.line -1,
+                                        character: expr.loc.start.column -1,
+                                    },
+                                    end: lsp::Position {
+                                        line: expr.loc.end.line-1,
+                                        character: expr.loc.end.column - 1,
+                                    },
+                                },
+                                severity: Some(lsp::DiagnosticSeverity::HINT),
+                                message: "experimental features can change often or be deleted/moved. Use with caution.".into(),
+                                ..lsp::Diagnostic::default()
+                            });
+                        }
+                    }
+                    flux::semantic::nodes::Expression::Member(member) => {
+                        if let flux::semantic::nodes::Expression::Identifier(id) = &member.object {
+                            if self.namespaces.contains(&format!("{}", id.name)) {
+                                self.diagnostics.push(lsp::Diagnostic {
+                                    range: lsp::Range {
+                                        start: lsp::Position {
+                                            line: expr.loc.start.line -1,
+                                            character: expr.loc.start.column -1,
+                                        },
+                                        end: lsp::Position {
+                                            line: expr.loc.end.line-1,
+                                            character: expr.loc.end.column - 1,
+                                        },
+                                    },
+                                    severity: Some(lsp::DiagnosticSeverity::HINT),
+                                    message: "experimental features can change often or be deleted/moved. Use with caution.".into(),
+                                    ..lsp::Diagnostic::default()
+                                });
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            _ => {},
+        }
+        true
+    }
+}

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -14,7 +14,9 @@ mod symbols;
 pub use completion::{
     FunctionFinderVisitor, ObjectFunctionFinderVisitor,
 };
-pub use lint::ExperimentalDiagnosticVisitor;
+pub use lint::{
+    ContribDiagnosticVisitor, ExperimentalDiagnosticVisitor,
+};
 pub use symbols::SymbolsVisitor;
 
 fn contains_position(node: Node<'_>, pos: lsp::Position) -> bool {

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -7,13 +7,14 @@ use flux::semantic::{
 use lspower::lsp;
 
 mod completion;
-mod symbols;
-
 mod functions;
+mod lint;
+mod symbols;
 
 pub use completion::{
     FunctionFinderVisitor, ObjectFunctionFinderVisitor,
 };
+pub use lint::ExperimentalDiagnosticVisitor;
 pub use symbols::SymbolsVisitor;
 
 fn contains_position(node: Node<'_>, pos: lsp::Position) -> bool {


### PR DESCRIPTION
This patch adds some new linting architecture into the diagnostic mechanisms of
the lsp. It also brings with it two small lints, both showing information about
using `contrib` and `experimental`.

Fixes #461