### PR TITLE
fix: panic when onMessage is called after run

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -108,6 +108,8 @@ impl Lsp {
     pub fn onMessage(&mut self, func: js_sys::Function) {
         if let Some(processor) = &mut self.processor {
             processor.on_message(func)
+        } else {
+            panic!("Attempted to add a message handler after running the server. Please attach message handlers before calling `run`.");
         }
     }
 


### PR DESCRIPTION
When calling `run`, the server is consumed and control is, effectively,
lost. When trying to attach an `onMessage` handler after `run`, the
handler can't attach; the `Lsp.processor` is `None` at that point. This
patch causes the wasm to panic explicitly when `onMessage` is called on
a running server.

Fixes #462