### PR TITLE
refactor: Make adding new semantic tokens less brittle

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -364,15 +364,7 @@ impl LanguageServer for LspServer {
                         work_done_progress: None
                     },
                     legend: lsp::SemanticTokensLegend {
-                        // STOP! Are you adding more token types? Add them
-                        // at the end of this vector, and make sure to add
-                        // a corresponding constant for the token type. For
-                        // more information, see https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#semanticTokensLegend
-                        token_types: vec![
-                            lsp::SemanticTokenType::KEYWORD,
-                            lsp::SemanticTokenType::NUMBER,
-                            lsp::SemanticTokenType::STRING,
-                        ],
+                        token_types: crate::visitors::ast::SemanticToken::LSP_MAPPING.to_owned(),
                         token_modifiers: vec![],
                     },
                     range: None,

--- a/src/visitors/ast.rs
+++ b/src/visitors/ast.rs
@@ -73,9 +73,39 @@ impl From<&flux::ast::Package> for PackageInfo {
     }
 }
 
-pub(crate) const SEMANTIC_TOKEN_KEYWORD: u32 = 0;
-pub(crate) const SEMANTIC_TOKEN_NUMBER: u32 = 1;
-pub(crate) const SEMANTIC_TOKEN_STRING: u32 = 2;
+macro_rules! semantic_tokens {
+    ($($name: ident => $lsp_name: ident),* $(,)?) => {
+        // C-like enumerations can be casted to 0,1,2 etc in order which is exactly what the
+        // LSP protocal needs for the mapping
+        #[derive(Debug)]
+        #[allow(non_camel_case_types)]
+        pub(crate) enum SemanticToken {
+            $(
+            $name,
+            )*
+        }
+
+        impl SemanticToken {
+            pub(crate) const LSP_MAPPING: &'static [lsp::SemanticTokenType] = &[
+                $(
+                lsp::SemanticTokenType::$lsp_name,
+                )*
+            ];
+        }
+
+        $(
+        pub(crate) const $name: u32 = SemanticToken::$name as u32;
+        )*
+    }
+}
+
+// Constructs an integer <=> string mapping according in accordance to
+// https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#semanticTokensLegend
+semantic_tokens! {
+    SEMANTIC_TOKEN_KEYWORD => KEYWORD,
+    SEMANTIC_TOKEN_NUMBER => NUMBER,
+    SEMANTIC_TOKEN_STRING => STRING,
+}
 
 #[derive(Clone, Default)]
 pub struct SemanticTokenVisitor {


### PR DESCRIPTION
I were looking into some weirdness in the syntax highlighting which lead me to looking at the semantic tokens implementation where I noticed this comment. So I made a small refactor to remove the need for it.

(Turns out neovim doesn't actually support semantic tokens yet anyway so the problem was in the normal syntax file. I am not sure semantic tokens are actually enabled on the server side either? It might need define `full: true` in the configuration?)