### PR TITLE
feat: publish warnings for use of `v`, `params`, and `tasks`

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -327,7 +327,6 @@ impl LspServer {
                         .collect()
                 }
             };
-        println!("{:#?}", diagnostics);
         diagnostics.into_iter().for_each(|(filename, diagnostic)| {
             // XXX: rockstar (5 June 2022) - Can this _ever_ be None? Is a blind unwrap safe?
             if let Some(filename) = filename {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -200,8 +200,9 @@ impl LspServer {
         Self {
             client: Arc::new(Mutex::new(client)),
             diagnostics: vec![
-                super::diagnostics::experimental_lint,
                 super::diagnostics::contrib_lint,
+                super::diagnostics::experimental_lint,
+                super::diagnostics::no_influxdb_identifiers,
             ],
             store: store::Store::default(),
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -23,7 +23,8 @@ use self::types::LspError;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-type Diagnostic = fn(&SemanticPackage) -> Vec<lsp::Diagnostic>;
+type Diagnostic =
+    fn(&SemanticPackage) -> Vec<(Option<String>, lsp::Diagnostic)>;
 
 /// Convert a flux::semantic::walk::Node to a lsp::Location
 /// https://microsoft.github.io/language-server-protocol/specification#location
@@ -231,58 +232,80 @@ impl LspServer {
         }
     }
 
-    // Publish any diagnostics to the client
+    /// Publish any diagnostics to the client
+    ///
+    /// This
     async fn publish_diagnostics(&self, key: &lsp::Url) {
         // If we have a client back to the editor report any diagnostics found in the document
         if let Some(client) = &self.get_client() {
-            let diagnostics = self.compute_diagnostics(key);
-            client
-                .publish_diagnostics(key.clone(), diagnostics, None)
-                .await;
+            for (key, diagnostics) in
+                self.compute_diagnostics(key).into_iter()
+            {
+                client
+                    .publish_diagnostics(key, diagnostics, None)
+                    .await;
+            }
         }
     }
 
     fn compute_diagnostics(
         &self,
         key: &lsp::Url,
-    ) -> Vec<lsp::Diagnostic> {
-        match self.store.get_package_errors(key) {
-            None => {
-                // If there are no semantic package errors, we can check for other
-                // diagnostics.
-                //
-                // Note: it is important, if no diagnostics exist, that we return an empty
-                // diagnostic list, as that will signal to the client that the diagnostics
-                // have been cleared.
-                if let Ok(package) =
-                    self.store.get_semantic_package(key)
-                {
-                    return self
+    ) -> HashMap<lsp::Url, Vec<lsp::Diagnostic>> {
+        let mut diagnostic_map: HashMap<
+            lsp::Url,
+            Vec<lsp::Diagnostic>,
+        > = self
+            .store
+            .get_package_urls(key)
+            .into_iter()
+            .map(|url| (url, Vec::new()))
+            .collect();
+
+        let diagnostics: Vec<(Option<String>, lsp::Diagnostic)> =
+            match self.store.get_package_errors(key) {
+                None => {
+                    // If there are no semantic package errors, we can check for other
+                    // diagnostics.
+                    //
+                    // Note: it is important, if no diagnostics exist, that we return an empty
+                    // diagnostic list, as that will signal to the client that the diagnostics
+                    // have been cleared.
+                    if let Ok(package) =
+                        self.store.get_semantic_package(key)
+                    {
+                        self
                         .diagnostics
                         .iter()
                         .flat_map(|func| func(&package))
-                        .collect::<Vec<lsp::Diagnostic>>();
-                } else {
-                    return vec![];
-                }
-            }
-            Some(errors) => errors
-                .errors
-                .iter()
-                .filter(|error| {
-                    // We will never have two files with the same name in a package, so we can
-                    // key off filename to determine whether the error exists in this file or
-                    // elsewhere in the package.
-                    if let Some(file) = &error.location.file {
-                        if let Some(segments) = key.path_segments() {
-                            if let Some(filename) = segments.last() {
-                                return file == filename;
-                            }
-                        }
+                        .collect::<Vec<(Option<String>, lsp::Diagnostic)>>()
+                    } else {
+                        vec![]
                     }
-                    false
-                })
-                .map(|e| lsp::Diagnostic {
+                }
+                Some(errors) => {
+                    errors
+                        .errors
+                        .iter()
+                        .filter(|error| {
+                            // We will never have two files with the same name in a package, so we can
+                            // key off filename to determine whether the error exists in this file or
+                            // elsewhere in the package.
+                            if let Some(file) = &error.location.file {
+                                if let Some(segments) =
+                                    key.path_segments()
+                                {
+                                    if let Some(filename) =
+                                        segments.last()
+                                    {
+                                        return file == filename;
+                                    }
+                                }
+                            }
+                            false
+                        })
+                        .map(|e| {
+                            (e.location.file.clone(), lsp::Diagnostic {
                     // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
                     // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
                     range: lsp::Range {
@@ -300,8 +323,26 @@ impl LspServer {
                     message: e.error.to_string(),
                     ..lsp::Diagnostic::default()
                 })
-                .collect(),
-        }
+                        })
+                        .collect()
+                }
+            };
+        println!("{:#?}", diagnostics);
+        diagnostics.into_iter().for_each(|(filename, diagnostic)| {
+            // XXX: rockstar (5 June 2022) - Can this _ever_ be None? Is a blind unwrap safe?
+            if let Some(filename) = filename {
+                diagnostic_map
+                    .iter_mut()
+                    .filter(|(url, _)| {
+                        url.to_string().ends_with(&filename)
+                    })
+                    .for_each(|(_, diagnostics)| {
+                        diagnostics.push(diagnostic.clone())
+                    });
+            }
+        });
+
+        diagnostic_map
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -233,8 +233,6 @@ impl LspServer {
     }
 
     /// Publish any diagnostics to the client
-    ///
-    /// This
     async fn publish_diagnostics(&self, key: &lsp::Url) {
         // If we have a client back to the editor report any diagnostics found in the document
         if let Some(client) = &self.get_client() {
@@ -248,6 +246,11 @@ impl LspServer {
         }
     }
 
+    /// Compute diagnostics for a package
+    ///
+    /// This function will compute all diagnostics for the same package simultaneously. This
+    /// includes files that don't have any diagnostic messages (an empty list is generated),
+    /// as this is the way the server will signal that previous diagnostic messages have cleared.
     fn compute_diagnostics(
         &self,
         key: &lsp::Url,

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -123,6 +123,27 @@ impl Store {
         }
     }
 
+    pub fn get_package_urls(&self, url: &lsp::Url) -> Vec<lsp::Url> {
+        let (key, _) = url_to_key_val(url);
+        match self.backend.read() {
+            Ok(store) => match store.get(&key) {
+                None => vec![],
+                Some(files) => files
+                    .keys()
+                    .map(|file| {
+                        #[allow(clippy::unwrap_used)]
+                        lsp::Url::parse(&format!(
+                            "file://{}/{}",
+                            key, file
+                        ))
+                        .unwrap()
+                    })
+                    .collect(),
+            },
+            Err(_) => vec![],
+        }
+    }
+
     fn get_files(
         &self,
         path: String,

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -123,6 +123,7 @@ impl Store {
         }
     }
 
+    /// Get urls for all files in a specified file's package.
     pub fn get_package_urls(&self, url: &lsp::Url) -> Vec<lsp::Url> {
         let (key, _) = url_to_key_val(url);
         match self.backend.read() {

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -327,6 +327,58 @@ mod test {
     }
 
     #[test]
+    fn get_package_urls_single_file() {
+        let store = Store::default();
+        let url = lsp::Url::parse("file:///a/b/c").unwrap();
+        store.put(&url, "");
+
+        let urls = store.get_package_urls(&url);
+
+        assert_eq!(vec![url,], urls);
+    }
+
+    #[test]
+    fn get_package_urls_twe_files_two_packages() {
+        let store = Store::default();
+        let url = lsp::Url::parse("file:///a/b/c").unwrap();
+        store.put(&url, "");
+        store.put(&lsp::Url::parse("file:///a/c/c").unwrap(), "");
+
+        let urls = store.get_package_urls(&url);
+
+        assert_eq!(vec![url,], urls);
+    }
+
+    #[test]
+    fn get_package_urls_two_files_one_package() {
+        let store = Store::default();
+        let url = lsp::Url::parse("file:///a/b/c").unwrap();
+        let url2 = lsp::Url::parse("file:///a/b/d").unwrap();
+        store.put(&url, "");
+        store.put(&url2, "");
+
+        let mut urls = store.get_package_urls(&url);
+        urls.sort();
+
+        assert_eq!(vec![url, url2], urls);
+    }
+
+    #[test]
+    fn get_package_urls_three_files_two_packages() {
+        let store = Store::default();
+        let url = lsp::Url::parse("file:///a/b/c").unwrap();
+        let url2 = lsp::Url::parse("file:///a/b/d").unwrap();
+        store.put(&url, "");
+        store.put(&url2, "");
+        store.put(&lsp::Url::parse("file:///a/c/c").unwrap(), "");
+
+        let mut urls = store.get_package_urls(&url);
+        urls.sort();
+
+        assert_eq!(vec![url, url2], urls);
+    }
+
+    #[test]
     fn remove() {
         let store = Store::default();
         let url = lsp::Url::parse("file:///a/b/c").unwrap();

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3094,26 +3094,29 @@ async fn compute_diagnostics_multi_file() {
         .compute_diagnostics(&lsp::Url::parse(&filename).unwrap());
 
     assert_eq!(
-        vec![lsp::Diagnostic {
-            code: None,
-            code_description: None,
-            data: None,
-            message: "undefined identifier v".into(),
-            range: lsp::Range {
-                start: lsp::Position {
-                    line: 2,
-                    character: 32
+        HashMap::from([(
+            lsp::Url::parse("file:///path/to/script.flux").unwrap(),
+            vec![lsp::Diagnostic {
+                code: None,
+                code_description: None,
+                data: None,
+                message: "undefined identifier v".into(),
+                range: lsp::Range {
+                    start: lsp::Position {
+                        line: 2,
+                        character: 32
+                    },
+                    end: lsp::Position {
+                        line: 2,
+                        character: 33
+                    },
                 },
-                end: lsp::Position {
-                    line: 2,
-                    character: 33
-                },
-            },
-            related_information: None,
-            severity: Some(lsp::DiagnosticSeverity::ERROR),
-            source: Some("flux".into()),
-            tags: None,
-        }],
+                related_information: None,
+                severity: Some(lsp::DiagnosticSeverity::ERROR),
+                source: Some("flux".into()),
+                tags: None,
+            }]
+        ),]),
         diagnostics
     );
 
@@ -3127,32 +3130,26 @@ async fn compute_diagnostics_multi_file() {
     let diagnostics_again = server
         .compute_diagnostics(&lsp::Url::parse(&filename).unwrap());
 
-    let expected: Vec<lsp::Diagnostic> = vec![];
+    let expected: HashMap<lsp::Url, Vec<lsp::Diagnostic>> = HashMap::from([
+        (lsp::Url::parse("file:///path/to/script.flux").unwrap(), vec![]),
+        (lsp::Url::parse("file:///path/to/an_vars.flux").unwrap(), vec![lsp::Diagnostic {
+            range: lsp::Range {
+                start: lsp::Position {
+                    line: 0, character: 0,
+                },
+                end: lsp::Position {
+                    line: 0, character: 1,
+                }
+            },
+            severity: Some(lsp::DiagnosticSeverity::WARNING),
+            message: "Avoid using `v` as an identifier name. In some InfluxDB contexts, it may be provided at runtime.".to_string(),
+            ..lsp::Diagnostic::default()
+        }]),
+    ]);
+
+    // We are interested in the error from the original file being fixed, not in
+    // the lints introduced by the new file.
     assert_eq!(expected, diagnostics_again);
-}
-
-// Only emit diagnostics related to that specific file.
-#[test]
-async fn compute_diagnostics_only_on_problem_file() {
-    let server = create_server();
-
-    let filename: String = "file:///path/to/script.flux".into();
-    let fluxscript = r#"from(bucket: "my-bucket")
-|> range(start: -100d)
-|> filter(fn: (r) => r.anTag == v.a)"#;
-    open_file(&server, fluxscript.into(), Some(&filename)).await;
-    // This file, in the same package, contains an error.
-    open_file(
-        &server,
-        r#"v = a"#.to_string(),
-        Some("file:///path/to/an_vars.flux"),
-    )
-    .await;
-
-    let diagnostics_again = server
-        .compute_diagnostics(&lsp::Url::parse(&filename).unwrap());
-
-    assert!(diagnostics_again.is_empty());
 }
 
 #[test]

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3127,7 +3127,8 @@ async fn compute_diagnostics_multi_file() {
     let diagnostics_again = server
         .compute_diagnostics(&lsp::Url::parse(&filename).unwrap());
 
-    assert_eq!(0, diagnostics_again.len());
+    let expected: Vec<lsp::Diagnostic> = vec![];
+    assert_eq!(expected, diagnostics_again);
 }
 
 // Only emit diagnostics related to that specific file.

--- a/src/visitors/semantic/lint.rs
+++ b/src/visitors/semantic/lint.rs
@@ -73,7 +73,6 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                     flux::semantic::nodes::Expression::Member(member) => {
                         if let flux::semantic::nodes::Expression::Identifier(id) = &member.object {
                             if self.namespaces.contains(&format!("{}", id.name)) {
-                                println!("{:?}\n", member.loc);
                                 self.diagnostics.push((expr.loc.file.clone(), lsp::Diagnostic {
                                     range: lsp::Range {
                                         start: lsp::Position {

--- a/src/visitors/semantic/lint.rs
+++ b/src/visitors/semantic/lint.rs
@@ -3,7 +3,7 @@ use lspower::lsp;
 
 pub struct ExperimentalDiagnosticVisitor {
     namespaces: Vec<String>,
-    pub diagnostics: Vec<lsp::Diagnostic>,
+    pub diagnostics: Vec<(Option<String>, lsp::Diagnostic)>,
 }
 
 impl Default for ExperimentalDiagnosticVisitor {
@@ -53,7 +53,7 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                 match &expr.callee {
                     flux::semantic::nodes::Expression::Identifier(id) => {
                         if self.namespaces.contains(&format!("{}", id.name)) {
-                            self.diagnostics.push(lsp::Diagnostic {
+                            self.diagnostics.push((expr.loc.file.clone(), lsp::Diagnostic {
                                 range: lsp::Range {
                                     start: lsp::Position {
                                         line: expr.loc.start.line - 1,
@@ -67,13 +67,14 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                                 severity: Some(lsp::DiagnosticSeverity::HINT),
                                 message: "experimental features can change often or be deleted/moved. Use with caution.".into(),
                                 ..lsp::Diagnostic::default()
-                            });
+                            }));
                         }
                     }
                     flux::semantic::nodes::Expression::Member(member) => {
                         if let flux::semantic::nodes::Expression::Identifier(id) = &member.object {
                             if self.namespaces.contains(&format!("{}", id.name)) {
-                                self.diagnostics.push(lsp::Diagnostic {
+                                println!("{:?}\n", member.loc);
+                                self.diagnostics.push((expr.loc.file.clone(), lsp::Diagnostic {
                                     range: lsp::Range {
                                         start: lsp::Position {
                                             line: expr.loc.start.line -1,
@@ -87,7 +88,7 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                                     severity: Some(lsp::DiagnosticSeverity::HINT),
                                     message: "experimental features can change often or be deleted/moved. Use with caution.".into(),
                                     ..lsp::Diagnostic::default()
-                                });
+                                }));
                             }
                         }
                     }
@@ -102,7 +103,7 @@ impl<'a> flux::semantic::walk::Visitor<'a>
 #[derive(Default)]
 pub struct ContribDiagnosticVisitor {
     namespaces: Vec<String>,
-    pub diagnostics: Vec<lsp::Diagnostic>,
+    pub diagnostics: Vec<(Option<String>, lsp::Diagnostic)>,
 }
 
 impl<'a> flux::semantic::walk::Visitor<'a>
@@ -145,7 +146,7 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                 match &expr.callee {
                     flux::semantic::nodes::Expression::Identifier(id) => {
                         if self.namespaces.contains(&format!("{}", id.name)) {
-                            self.diagnostics.push(lsp::Diagnostic {
+                            self.diagnostics.push((id.loc.file.clone(), lsp::Diagnostic {
                                 range: lsp::Range {
                                     start: lsp::Position {
                                         line: expr.loc.start.line -1,
@@ -159,13 +160,13 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                                 severity: Some(lsp::DiagnosticSeverity::HINT),
                                 message: "contrib packages are user-contributed, and do not carry with them the same compatibility guarantees as the standard library. Use with caution.".into(),
                                 ..lsp::Diagnostic::default()
-                            });
+                            }));
                         }
                     }
                     flux::semantic::nodes::Expression::Member(member) => {
                         if let flux::semantic::nodes::Expression::Identifier(id) = &member.object {
                             if self.namespaces.contains(&id.name.to_string()) {
-                                self.diagnostics.push(lsp::Diagnostic {
+                                self.diagnostics.push((id.loc.file.clone(), lsp::Diagnostic {
                                     range: lsp::Range {
                                         start: lsp::Position {
                                             line: expr.loc.start.line - 1,
@@ -179,7 +180,7 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                                     severity: Some(lsp::DiagnosticSeverity::HINT),
                                     message: "contrib packages are user-contributed, and do not carry with them the same compatibility guarantees as the standard library. Use with caution.".into(),
                                     ..lsp::Diagnostic::default()
-                                });
+                                }));
                             }
                         }
                     }
@@ -194,7 +195,7 @@ impl<'a> flux::semantic::walk::Visitor<'a>
 
 pub struct InfluxDBIdentifierDiagnosticVisitor {
     names: Vec<String>,
-    pub diagnostics: Vec<lsp::Diagnostic>,
+    pub diagnostics: Vec<(Option<String>, lsp::Diagnostic)>,
 }
 
 impl Default for InfluxDBIdentifierDiagnosticVisitor {
@@ -212,7 +213,7 @@ impl<'a> flux::semantic::walk::Visitor<'a>
     fn visit(&mut self, node: WalkNode<'a>) -> bool {
         if let WalkNode::VariableAssgn(assign) = node {
             if self.names.contains(&assign.id.name.to_string()) {
-                self.diagnostics.push(lsp::Diagnostic {
+                self.diagnostics.push((assign.loc.file.clone(), lsp::Diagnostic {
                     range: lsp::Range {
                         start: lsp::Position {
                             line: assign.id.loc.start.line - 1,
@@ -226,7 +227,7 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                     severity: Some(lsp::DiagnosticSeverity::WARNING),
                     message: format!("Avoid using `{}` as an identifier name. In some InfluxDB contexts, it may be provided at runtime.", assign.id.name),
                     ..lsp::Diagnostic::default()
-                });
+                }));
             }
         }
         true

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -16,6 +16,7 @@ pub use completion::{
 };
 pub use lint::{
     ContribDiagnosticVisitor, ExperimentalDiagnosticVisitor,
+    InfluxDBIdentifierDiagnosticVisitor,
 };
 pub use symbols::SymbolsVisitor;
 


### PR DESCRIPTION
This patch introduces new lints for assigning variables to `v`, `params` and
`tasks`. We want to discourage users from using these three names as variable
(regardless of scope), because the InfluxDB ecosystem may specify these at
runtime and break the script. When influxdata/flux#4834 is addressed, we will
still want these lints, though we'll likely then downgrade them to "hints"
as opposed to the "warning" levels they are now (they can potentially break
your script in non-obvious ways currently).

As part of this work, we needed to (properly) address an issue we previously
handled in the diagnostics where an error from a file would show as an error in
another file from the same package. While the errors were handled properly, a
test broke that showed that the lints were reporting incorrectly. The way to
properly address this issue was to publish diagnostics for every file in the
package any time any file in the package triggered a diagnostic event, e.g.
`textDocument/didOpen`, `textDocument/didSave`. The upside is that if a error
is showing in one file of the package, but the fix is made in another file, we
don't need a change event in the file showing the error to see the error
cleared.

It _might_ help to look at the two individual commits of this PR, as they both
contain related changes.

Fixes #477