### PR TITLE
feat: add ability to inject a tag value filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,7 @@ dependencies = [
  "log",
  "lspower",
  "pretty_assertions",
+ "serde",
  "serde_json",
  "simplelog",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = true
 default = ["cmd"]
 strict = []
 cmd = ["clap", "simplelog", "tokio", "tower-service", "lspower/runtime-tokio"]
-wasm = ["futures", "js-sys", "serde_json", "lspower/runtime-agnostic", "tower-service", "wasm-bindgen", "wasm-bindgen-futures", "wee_alloc"]
+wasm = ["futures", "js-sys", "lspower/runtime-agnostic", "tower-service", "wasm-bindgen", "wasm-bindgen-futures", "wee_alloc"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -44,7 +44,8 @@ js-sys = { version = "0.3.57", optional = true }
 line-col = "0.2.1"
 log = "0.4.16"
 lspower = { version = "1.5.0", default-features = false, optional = true }
-serde_json = { version = "1.0.79", optional = true }
+serde = { version = "1.0.137", features = ["derive"] }
+serde_json = "1.0.79"
 simplelog = { version = "0.12.0", optional = true }
 tokio = { version = "1.17.0", features = ["io-std", "macros", "rt-multi-thread"], optional = true }
 tower-service = { version = "0.3.1", optional = true }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,5 @@
 mod store;
+mod transform;
 mod types;
 
 use std::borrow::Cow;
@@ -12,6 +13,7 @@ use flux::semantic::{walk, ErrorKind};
 use lspower::{
     jsonrpc::Result as RpcResult, lsp, Client, LanguageServer,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::{completion, stdlib, visitors::semantic};
 
@@ -152,6 +154,36 @@ pub fn find_stdlib_signatures(
             acc.extend(x);
             acc
         })
+}
+
+enum LspServerCommand {
+    InjectTagValueFilter,
+}
+
+impl TryFrom<String> for LspServerCommand {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "injectTagValueFilter" => {
+                Ok(LspServerCommand::InjectTagValueFilter)
+            }
+            _ => Err(format!(
+                "Received unknown value for LspServerCommand: {}",
+                value
+            )),
+        }
+    }
+}
+
+impl From<LspServerCommand> for String {
+    fn from(value: LspServerCommand) -> Self {
+        match value {
+            LspServerCommand::InjectTagValueFilter => {
+                "injectTagValueFilter".into()
+            }
+        }
+    }
 }
 
 pub struct LspServer {
@@ -310,7 +342,12 @@ impl LanguageServer for LspServer {
                 document_symbol_provider: Some(lsp::OneOf::Left(
                     true,
                 )),
-                execute_command_provider: None,
+                execute_command_provider: Some(lsp::ExecuteCommandOptions {
+                    commands: vec![LspServerCommand::InjectTagValueFilter.into()],
+                    work_done_progress_options: lsp::WorkDoneProgressOptions {
+                        work_done_progress: None,
+                    }
+                }),
                 experimental: None,
                 folding_range_provider: Some(
                     lsp::FoldingRangeProviderCapability::Simple(true),
@@ -1051,6 +1088,120 @@ impl LanguageServer for LspServer {
 
         return Ok(Some(actions));
     }
+
+    async fn execute_command(
+        &self,
+        params: lsp::ExecuteCommandParams,
+    ) -> RpcResult<Option<serde_json::Value>> {
+        if params.arguments.len() != 1
+            || !params.arguments[0].is_object()
+        {
+            // We only want a single argument, which is an object itself. This means that
+            // positional arguments are not supported. We only want kwargs.
+            return Err(
+                LspError::InvalidArguments(params.arguments).into()
+            );
+        }
+        match LspServerCommand::try_from(params.command.clone()) {
+            Ok(LspServerCommand::InjectTagValueFilter) => {
+                let command_params: InjectTagValueFilterParams =
+                    match serde_json::value::from_value(
+                        params.arguments[0].clone(),
+                    ) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            return Err(LspError::InternalError(
+                                format!("{:?}", err),
+                            )
+                            .into())
+                        }
+                    };
+                let file = self.store.get_ast_file(
+                    &command_params.text_document.uri,
+                )?;
+                let transformed =
+                    match transform::inject_tag_value_filter(
+                        &file,
+                        command_params.name,
+                        command_params.value,
+                    ) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            return Err(LspError::InternalError(
+                                format!("{:?}", err),
+                            )
+                            .into())
+                        }
+                    };
+
+                let new_text =
+                    match flux::formatter::convert_to_string(
+                        &transformed,
+                    ) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            return Err(LspError::InternalError(
+                                format!("{:?}", err),
+                            )
+                            .into())
+                        }
+                    };
+                let last_pos =
+                    line_col::LineColLookup::new(&new_text)
+                        .get(new_text.len());
+                let edit = lsp::WorkspaceEdit {
+                    changes: Some(HashMap::from([(
+                        command_params.text_document.uri.clone(),
+                        vec![lsp::TextEdit {
+                            new_text: new_text.clone(),
+                            range: lsp::Range {
+                                start: lsp::Position::default(),
+                                end: lsp::Position {
+                                    line: last_pos.0 as u32,
+                                    character: last_pos.1 as u32,
+                                },
+                            },
+                        }],
+                    )])),
+                    document_changes: None,
+                    change_annotations: None,
+                };
+                if let Some(client) = self.get_client() {
+                    match client.apply_edit(edit, None).await {
+                        Ok(response) => {
+                            if response.applied {
+                                self.store.put(
+                                    &command_params.text_document.uri,
+                                    &new_text,
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            return Err(LspError::InternalError(
+                                format!("{:?}", err),
+                            )
+                            .into())
+                        }
+                    };
+                }
+                Ok(None)
+            }
+            Err(_err) => {
+                return Err(
+                    LspError::InvalidCommand(params.command).into()
+                )
+            }
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InjectTagValueFilterParams {
+    text_document: lsp::TextDocumentIdentifier,
+    bucket: Option<String>,
+    name: String,
+    value: String,
 }
 
 // Url::to_file_path doesn't exist in wasm-unknown-unknown, for kinda

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -149,6 +149,23 @@ impl Store {
         }
     }
 
+    pub fn get_ast_file(
+        &self,
+        url: &lsp::Url,
+    ) -> Result<flux::ast::File, LspError> {
+        let (_, filename) = url_to_key_val(url);
+        let source = match self.get(url) {
+            Ok(value) => value,
+            Err(_err) => {
+                return Err(LspError::FileNotFound(filename))
+            }
+        };
+
+        let file: flux::ast::File =
+            flux::parser::parse_string(filename, &source);
+        Ok(file)
+    }
+
     fn get_ast_package(
         &self,
         url: &lsp::Url,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3172,3 +3172,41 @@ from(bucket: "my-bucket")
 
     assert!(!diagnostics_again.is_empty());
 }
+
+// All commands require key/value pairs as params, not positional
+/// arguments.
+#[test]
+async fn execute_command_too_many_args() {
+    let server = create_server();
+    let params = lsp::ExecuteCommandParams {
+        command: "notActuallyAValidCommand".into(),
+        arguments: vec![
+            serde_json::value::to_value("arg1").unwrap(),
+            serde_json::value::to_value("arg2").unwrap(),
+        ],
+        work_done_progress_params: lsp::WorkDoneProgressParams {
+            work_done_token: None,
+        },
+    };
+
+    let result = server.execute_command(params).await;
+
+    assert!(result.is_err());
+}
+
+// Attempting to execute a command that doesn't exist results in an Err response.
+#[test]
+async fn execute_command_unknown_command() {
+    let server = create_server();
+    let params = lsp::ExecuteCommandParams {
+        command: "notActuallyAValidCommand".into(),
+        arguments: vec![serde_json::json!({"foo": "bar"})],
+        work_done_progress_params: lsp::WorkDoneProgressParams {
+            work_done_token: None,
+        },
+    };
+
+    let result = server.execute_command(params).await;
+
+    assert!(result.is_err());
+}

--- a/src/server/transform.rs
+++ b/src/server/transform.rs
@@ -1,0 +1,151 @@
+/// Flux transformations
+///
+/// The code here is not for visiting or analyzing flux, but for transforming AST
+/// (and only AST).
+use flux::ast;
+
+/// Create a function used as then `fn` parameter of `filter`
+///
+/// This will return the ast equivalent of `(r) => r.{field} == "{value}"`.
+fn make_flux_filter_function(
+    field: String,
+    value: String,
+) -> ast::Expression {
+    ast::Expression::Function(Box::new(ast::FunctionExpr {
+        arrow: vec![],
+        base: ast::BaseNode::default(),
+        body: ast::FunctionBody::Expr(ast::Expression::Binary(
+            Box::new(ast::BinaryExpr {
+                base: ast::BaseNode::default(),
+                left: ast::Expression::Member(Box::new(
+                    ast::MemberExpr {
+                        base: ast::BaseNode::default(),
+                        lbrack: vec![],
+                        rbrack: vec![],
+                        object: ast::Expression::Identifier(
+                            ast::Identifier {
+                                base: ast::BaseNode::default(),
+                                name: "r".into(),
+                            },
+                        ),
+                        property: ast::PropertyKey::Identifier(
+                            ast::Identifier {
+                                base: ast::BaseNode::default(),
+                                name: field,
+                            },
+                        ),
+                    },
+                )),
+                right: ast::Expression::StringLit(ast::StringLit {
+                    base: ast::BaseNode::default(),
+                    value,
+                }),
+                operator: ast::Operator::EqualOperator,
+            }),
+        )),
+        lparen: vec![],
+        rparen: vec![],
+        params: vec![ast::Property {
+            base: ast::BaseNode::default(),
+            key: ast::PropertyKey::Identifier(ast::Identifier {
+                base: ast::BaseNode::default(),
+                name: "r".into(),
+            }),
+            comma: vec![],
+            separator: vec![],
+            value: None,
+        }],
+    }))
+}
+
+pub(crate) fn inject_tag_value_filter(
+    file: &ast::File,
+    name: String,
+    value: String,
+) -> Result<ast::File, ()> {
+    if let Some(statement) = file
+        .body
+        .iter()
+        .filter(|node| {
+            if let ast::Statement::Expr(_stmt) = node {
+                return true;
+            }
+            false
+        })
+        .last()
+    {
+        let mut new_ast = file.clone();
+        new_ast.body.retain(|x| x != statement);
+
+        let call: &ast::Expression =
+            if let ast::Statement::Expr(expr) = statement {
+                &expr.expression
+            } else {
+                return Err(());
+            };
+
+        new_ast.body.push(ast::Statement::Expr(
+            Box::new(ast::ExprStmt {
+                base: ast::BaseNode::default(),
+                expression: ast::Expression::PipeExpr(Box::new(ast::PipeExpr {
+                    argument: call.clone(),
+                    base: ast::BaseNode::default(),
+                    call: ast::CallExpr {
+                        arguments: vec![ast::Expression::Object(Box::new(ast::ObjectExpr {
+                            base: ast::BaseNode::default(),
+                            properties: vec![
+                                ast::Property {
+                                    base: ast::BaseNode::default(),
+                                    key: ast::PropertyKey::Identifier(ast::Identifier {
+                                        base: ast::BaseNode::default(),
+                                        name: "fn".into(),
+                                    }),
+                                    value: Some(make_flux_filter_function(name, value)),
+                                    comma: vec![],
+                                    separator: vec![],
+                                }
+                            ],
+                            lbrace: vec![],
+                            rbrace: vec![],
+                            with: None,
+                        }))],
+                        base: ast::BaseNode::default(),
+                        callee: ast::Expression::Identifier(ast::Identifier {
+                            base: ast::BaseNode::default(),
+                            name: "filter".into(),
+                        }),
+                        lparen: vec![],
+                        rparen: vec![],
+                    }
+                }))
+            })
+        ));
+        return Ok(new_ast);
+    }
+    Err(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_inject_tag_value_filter() {
+        let fluxscript = r#"from(bucket: "my-bucket")"#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+
+        let transformed = inject_tag_value_filter(
+            &ast,
+            "myTag".into(),
+            "myTagValue".into(),
+        )
+        .unwrap();
+
+        let expected = r#"from(bucket: "my-bucket") |> filter(fn: (r) => r.myTag == "myTagValue")"#;
+        assert_eq!(
+            expected,
+            flux::formatter::convert_to_string(&transformed).unwrap()
+        );
+    }
+}

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -5,6 +5,8 @@ pub enum LspError {
     InternalError(String),
     LockNotAcquired,
     FileNotFound(String),
+    InvalidArguments(Vec<serde_json::value::Value>),
+    InvalidCommand(String),
 }
 
 impl From<LspError> for Error {
@@ -23,6 +25,22 @@ impl From<LspError> for Error {
             LspError::FileNotFound(filename) => Error {
                 code: ErrorCode::InvalidParams,
                 message: format!("File not fiend: {}", filename),
+                data: None,
+            },
+            LspError::InvalidArguments(value) => Error {
+                code: ErrorCode::InvalidParams,
+                message: format!(
+                    "Invalid parameters supplied: {:?}",
+                    value
+                ),
+                data: None,
+            },
+            LspError::InvalidCommand(command) => Error {
+                code: ErrorCode::InvalidParams,
+                message: format!(
+                    "Unknown command execution: {}",
+                    command
+                ),
                 data: None,
             },
         }


### PR DESCRIPTION
This patch adds in the initial work to inject a tag value filter to
a query.

Fixes #485