### PR TITLE
feat: Accept unstable flux feature flags through the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.154.0"
-source = "git+https://github.com/influxdata/flux?tag=v0.170.0#167cfbf4677fd7e9a5de1913254e2b3436aedc81"
+source = "git+https://github.com/influxdata/flux?tag=v0.171.0#f8817e020abb631e7e4216684bb342246d829deb"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "flux-core"
 version = "0.154.0"
-source = "git+https://github.com/influxdata/flux?tag=v0.170.0#167cfbf4677fd7e9a5de1913254e2b3436aedc81"
+source = "git+https://github.com/influxdata/flux?tag=v0.171.0#f8817e020abb631e7e4216684bb342246d829deb"
 dependencies = [
  "anyhow",
  "chrono",
@@ -673,7 +673,7 @@ dependencies = [
  "fnv",
  "libflate",
  "log",
- "lsp-types 0.93.0",
+ "lsp-types 0.92.1",
  "maplit",
  "pretty",
  "regex",
@@ -1043,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.93.0"
+version = "0.92.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c74e2173b2b31f8655d33724b4b45ac13f439386f66290f539c22b144c2212"
+checksum = "c79d4897790e8fd2550afa6d6125821edb5716e60e0e285046e070f0f6a06e0e"
 dependencies = [
  "bitflags",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ clap = { version = "3.1.9", features = ["derive"], optional = true }
 combinations = "0.1.0"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 console_log = { version = "0.2", optional = true }
-flux = { git = "https://github.com/influxdata/flux", tag = "v0.170.0", features = ["lsp"], default-features = false }
+flux = { git = "https://github.com/influxdata/flux", tag = "v0.171.0", features = ["lsp"], default-features = false }
 futures = { version = "0.3.21", optional = true }
 js-sys = { version = "0.3.57", optional = true }
 line-col = "0.2.1"

--- a/src/bin/flux-lsp.rs
+++ b/src/bin/flux-lsp.rs
@@ -30,6 +30,11 @@ struct Args {
         help = "Path to unix socket when channel is \"unix\" (defaults to /tmp/flux-lsp-sock.unix)"
     )]
     path: Option<String>,
+    #[clap(
+        long,
+        help = "Which features to enable in the flux compiler"
+    )]
+    flux_features: Vec<flux::semantic::Feature>,
 }
 
 #[tokio::main]
@@ -49,8 +54,14 @@ async fn main() {
         .unwrap();
     }
 
-    let (service, messages) =
-        LspService::new(|client| LspServer::new(Some(client)));
+    let (service, messages) = LspService::new(|client| {
+        LspServer::with_config(
+            Some(client),
+            flux_lsp::Config {
+                flux_features: matches.flux_features,
+            },
+        )
+    });
 
     let channel =
         matches.channel.unwrap_or_else(|| "stdio".to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,4 @@ extern crate pretty_assertions;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
-pub use server::LspServer;
+pub use server::{Config, LspServer};

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -292,6 +292,7 @@ impl LspServer {
                 }
                 Some(errors) => {
                     errors
+                        .diagnostics
                         .errors
                         .iter()
                         .filter(|error| {
@@ -1042,6 +1043,7 @@ impl LanguageServer for LspServer {
 
         let relevant: Vec<&flux::semantic::Error> = errors
             .error
+            .diagnostics
             .errors
             .iter()
             .filter(|error| {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -32,17 +32,23 @@ fn node_to_location(
 ) -> lsp::Location {
     lsp::Location {
         uri,
-        // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
-        // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
-        range: lsp::Range {
-            start: lsp::Position {
-                line: node.loc().start.line - 1,
-                character: node.loc().start.column - 1,
-            },
-            end: lsp::Position {
-                line: node.loc().end.line - 1,
-                character: node.loc().end.column - 1,
-            },
+        range: flux_location_to_lsp(node.loc()),
+    }
+}
+
+fn flux_location_to_lsp(
+    loc: &flux::ast::SourceLocation,
+) -> lsp::Range {
+    // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
+    // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
+    lsp::Range {
+        start: lsp::Position {
+            line: loc.start.line - 1,
+            character: loc.start.column - 1,
+        },
+        end: lsp::Position {
+            line: loc.end.line - 1,
+            character: loc.end.column - 1,
         },
     }
 }
@@ -316,16 +322,7 @@ impl LspServer {
                             (e.location.file.clone(), lsp::Diagnostic {
                     // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
                     // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
-                    range: lsp::Range {
-                        start: lsp::Position {
-                            line: e.location.start.line - 1,
-                            character: e.location.start.column - 1,
-                        },
-                        end: lsp::Position {
-                            line: e.location.end.line - 1,
-                            character: e.location.end.column - 1,
-                        },
-                    },
+                    range: flux_location_to_lsp(&e.location),
                     severity: Some(lsp::DiagnosticSeverity::ERROR),
                     source: Some("flux".to_string()),
                     message: e.error.to_string(),
@@ -1049,19 +1046,7 @@ impl LanguageServer for LspServer {
             .filter(|error| {
                 crate::lsp::ranges_overlap(
                     &params.range,
-                    // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
-                    // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
-                    &lsp::Range {
-                        start: lsp::Position {
-                            line: error.location.start.line - 1,
-                            character: error.location.start.column
-                                - 1,
-                        },
-                        end: lsp::Position {
-                            line: error.location.end.line - 1,
-                            character: error.location.end.column - 1,
-                        },
-                    },
+                    &flux_location_to_lsp(&error.location),
                 )
             })
             .collect();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -301,11 +301,29 @@ impl LspServer {
                         .diagnostics
                         .errors
                         .iter()
-                        .filter(|error| {
+                        .map(|error| {
+                            (
+                                &error.location,
+                                error.error.to_string(),
+                                lsp::DiagnosticSeverity::ERROR,
+                            )
+                        })
+                        .chain(
+                            errors.diagnostics.warnings.iter().map(
+                                |warning| {
+                                    (
+                                        &warning.location,
+                                        warning.error.to_string(),
+                                        lsp::DiagnosticSeverity::WARNING,
+                                    )
+                                },
+                            ),
+                        )
+                        .filter(|(location, _, _)| {
                             // We will never have two files with the same name in a package, so we can
                             // key off filename to determine whether the error exists in this file or
                             // elsewhere in the package.
-                            if let Some(file) = &error.location.file {
+                            if let Some(file) = &location.file {
                                 if let Some(segments) =
                                     key.path_segments()
                                 {
@@ -318,21 +336,19 @@ impl LspServer {
                             }
                             false
                         })
-                        .map(|e| {
+                        .map(|(location, error, severity)| {
                             let diagnostic = lsp::Diagnostic {
-                                // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
-                                // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
                                 range: flux_location_to_lsp(
-                                    &e.location,
+                                    &location,
                                 ),
                                 severity: Some(
-                                    lsp::DiagnosticSeverity::ERROR,
+                                    severity
                                 ),
                                 source: Some("flux".to_string()),
-                                message: e.error.to_string(),
+                                message: error,
                                 ..lsp::Diagnostic::default()
                             };
-                            (e.location.file.clone(), diagnostic)
+                            (location.file.clone(), diagnostic)
                         })
                         .collect()
                 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -339,7 +339,7 @@ impl LspServer {
                         .map(|(location, error, severity)| {
                             let diagnostic = lsp::Diagnostic {
                                 range: flux_location_to_lsp(
-                                    &location,
+                                    location,
                                 ),
                                 severity: Some(
                                     severity

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -319,15 +319,20 @@ impl LspServer {
                             false
                         })
                         .map(|e| {
-                            (e.location.file.clone(), lsp::Diagnostic {
-                    // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
-                    // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
-                    range: flux_location_to_lsp(&e.location),
-                    severity: Some(lsp::DiagnosticSeverity::ERROR),
-                    source: Some("flux".to_string()),
-                    message: e.error.to_string(),
-                    ..lsp::Diagnostic::default()
-                })
+                            let diagnostic = lsp::Diagnostic {
+                                // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
+                                // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
+                                range: flux_location_to_lsp(
+                                    &e.location,
+                                ),
+                                severity: Some(
+                                    lsp::DiagnosticSeverity::ERROR,
+                                ),
+                                source: Some("flux".to_string()),
+                                message: e.error.to_string(),
+                                ..lsp::Diagnostic::default()
+                            };
+                            (e.location.file.clone(), diagnostic)
                         })
                         .collect()
                 }


### PR DESCRIPTION
Were trying to test label polymorphism in the LSP which means enabling the `labelPolymorphism`
feature. So I added an option to pass in feature flags when using the CLI.

Needs a new release of flux before merge.