### PR TITLE
chore: Update flux to 0.171.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "flux"
 version = "0.154.0"
-source = "git+https://github.com/influxdata/flux?tag=v0.170.0#167cfbf4677fd7e9a5de1913254e2b3436aedc81"
+source = "git+https://github.com/influxdata/flux?tag=v0.171.0#f8817e020abb631e7e4216684bb342246d829deb"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "flux-core"
 version = "0.154.0"
-source = "git+https://github.com/influxdata/flux?tag=v0.170.0#167cfbf4677fd7e9a5de1913254e2b3436aedc81"
+source = "git+https://github.com/influxdata/flux?tag=v0.171.0#f8817e020abb631e7e4216684bb342246d829deb"
 dependencies = [
  "anyhow",
  "chrono",
@@ -673,7 +673,7 @@ dependencies = [
  "fnv",
  "libflate",
  "log",
- "lsp-types 0.93.0",
+ "lsp-types 0.92.1",
  "maplit",
  "pretty",
  "regex",
@@ -1043,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.93.0"
+version = "0.92.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c74e2173b2b31f8655d33724b4b45ac13f439386f66290f539c22b144c2212"
+checksum = "c79d4897790e8fd2550afa6d6125821edb5716e60e0e285046e070f0f6a06e0e"
 dependencies = [
  "bitflags",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ clap = { version = "3.1.9", features = ["derive"], optional = true }
 combinations = "0.1.0"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 console_log = { version = "0.2", optional = true }
-flux = { git = "https://github.com/influxdata/flux", tag = "v0.170.0", features = ["lsp"], default-features = false }
+flux = { git = "https://github.com/influxdata/flux", tag = "v0.171.0", features = ["lsp"], default-features = false }
 futures = { version = "0.3.21", optional = true }
 js-sys = { version = "0.3.57", optional = true }
 line-col = "0.2.1"

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -332,7 +332,7 @@ impl LspServer {
                         .map(|(location, error, severity)| {
                             let diagnostic = lsp::Diagnostic {
                                 range: flux_location_to_lsp(
-                                    &location,
+                                    location,
                                 ),
                                 severity: Some(
                                     severity

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -285,6 +285,7 @@ impl LspServer {
                 }
                 Some(errors) => {
                     errors
+                        .diagnostics
                         .errors
                         .iter()
                         .filter(|error| {
@@ -1035,6 +1036,7 @@ impl LanguageServer for LspServer {
 
         let relevant: Vec<&flux::semantic::Error> = errors
             .error
+            .diagnostics
             .errors
             .iter()
             .filter(|error| {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -312,15 +312,20 @@ impl LspServer {
                             false
                         })
                         .map(|e| {
-                            (e.location.file.clone(), lsp::Diagnostic {
-                    // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
-                    // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
-                    range: flux_location_to_lsp(&e.location),
-                    severity: Some(lsp::DiagnosticSeverity::ERROR),
-                    source: Some("flux".to_string()),
-                    message: e.error.to_string(),
-                    ..lsp::Diagnostic::default()
-                })
+                            let diagnostic = lsp::Diagnostic {
+                                // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
+                                // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
+                                range: flux_location_to_lsp(
+                                    &e.location,
+                                ),
+                                severity: Some(
+                                    lsp::DiagnosticSeverity::ERROR,
+                                ),
+                                source: Some("flux".to_string()),
+                                message: e.error.to_string(),
+                                ..lsp::Diagnostic::default()
+                            };
+                            (e.location.file.clone(), diagnostic)
                         })
                         .collect()
                 }


### PR DESCRIPTION
Also includes warnings a warning to diagnostic conversion now to flux can emit warnings. However the only warning that exists right now is behind a feature flag so it isn't exposed just yet (see https://github.com/influxdata/flux-lsp/pull/487 for a start). Refactors a bit to try and make rustfmt not give up on the parts of the code I modified. 