### PR TITLE
feat: add support for injecting a tag key filter

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -158,6 +158,7 @@ pub fn find_stdlib_signatures(
 }
 
 enum LspServerCommand {
+    InjectTagFilter,
     InjectTagValueFilter,
 }
 
@@ -166,6 +167,9 @@ impl TryFrom<String> for LspServerCommand {
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         match value.as_str() {
+            "injectTagFilter" => {
+                Ok(LspServerCommand::InjectTagFilter)
+            }
             "injectTagValueFilter" => {
                 Ok(LspServerCommand::InjectTagValueFilter)
             }
@@ -180,9 +184,12 @@ impl TryFrom<String> for LspServerCommand {
 impl From<LspServerCommand> for String {
     fn from(value: LspServerCommand) -> Self {
         match value {
+            LspServerCommand::InjectTagFilter => {
+                "injectTagFilter".into()
+            },
             LspServerCommand::InjectTagValueFilter => {
                 "injectTagValueFilter".into()
-            }
+            },
         }
     }
 }
@@ -387,7 +394,7 @@ impl LanguageServer for LspServer {
                     true,
                 )),
                 execute_command_provider: Some(lsp::ExecuteCommandOptions {
-                    commands: vec![LspServerCommand::InjectTagValueFilter.into()],
+                    commands: vec![LspServerCommand::InjectTagFilter.into(), LspServerCommand::InjectTagValueFilter.into()],
                     work_done_progress_options: lsp::WorkDoneProgressOptions {
                         work_done_progress: None,
                     }
@@ -1147,6 +1154,88 @@ impl LanguageServer for LspServer {
             );
         }
         match LspServerCommand::try_from(params.command.clone()) {
+            Ok(LspServerCommand::InjectTagFilter) => {
+                let command_params: InjectTagFilterParams =
+                    match serde_json::value::from_value(
+                        params.arguments[0].clone(),
+                    ) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            return Err(LspError::InternalError(
+                                format!("{:?}", err),
+                            )
+                            .into())
+                        }
+                    };
+                let file = self.store.get_ast_file(
+                    &command_params.text_document.uri,
+                )?;
+                let transformed =
+                    match transform::inject_tag_filter(
+                        &file,
+                        command_params.name,
+                    ) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            return Err(LspError::InternalError(
+                                format!("{:?}", err),
+                            )
+                            .into())
+                        }
+                    };
+
+                let new_text =
+                    match flux::formatter::convert_to_string(
+                        &transformed,
+                    ) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            return Err(LspError::InternalError(
+                                format!("{:?}", err),
+                            )
+                            .into())
+                        }
+                    };
+                let last_pos =
+                    line_col::LineColLookup::new(&new_text)
+                        .get(new_text.len());
+                let edit = lsp::WorkspaceEdit {
+                    changes: Some(HashMap::from([(
+                        command_params.text_document.uri.clone(),
+                        vec![lsp::TextEdit {
+                            new_text: new_text.clone(),
+                            range: lsp::Range {
+                                start: lsp::Position::default(),
+                                end: lsp::Position {
+                                    line: last_pos.0 as u32,
+                                    character: last_pos.1 as u32,
+                                },
+                            },
+                        }],
+                    )])),
+                    document_changes: None,
+                    change_annotations: None,
+                };
+                if let Some(client) = self.get_client() {
+                    match client.apply_edit(edit, None).await {
+                        Ok(response) => {
+                            if response.applied {
+                                self.store.put(
+                                    &command_params.text_document.uri,
+                                    &new_text,
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            return Err(LspError::InternalError(
+                                format!("{:?}", err),
+                            )
+                            .into())
+                        }
+                    };
+                }
+                Ok(None)
+            }
             Ok(LspServerCommand::InjectTagValueFilter) => {
                 let command_params: InjectTagValueFilterParams =
                     match serde_json::value::from_value(
@@ -1237,6 +1326,14 @@ impl LanguageServer for LspServer {
             }
         }
     }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InjectTagFilterParams {
+    text_document: lsp::TextDocumentIdentifier,
+    bucket: Option<String>,
+    name: String,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -186,10 +186,10 @@ impl From<LspServerCommand> for String {
         match value {
             LspServerCommand::InjectTagFilter => {
                 "injectTagFilter".into()
-            },
+            }
             LspServerCommand::InjectTagValueFilter => {
                 "injectTagValueFilter".into()
-            },
+            }
         }
     }
 }
@@ -1170,19 +1170,19 @@ impl LanguageServer for LspServer {
                 let file = self.store.get_ast_file(
                     &command_params.text_document.uri,
                 )?;
-                let transformed =
-                    match transform::inject_tag_filter(
-                        &file,
-                        command_params.name,
-                    ) {
-                        Ok(value) => value,
-                        Err(err) => {
-                            return Err(LspError::InternalError(
-                                format!("{:?}", err),
-                            )
-                            .into())
-                        }
-                    };
+                let transformed = match transform::inject_tag_filter(
+                    &file,
+                    command_params.name,
+                ) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        return Err(LspError::InternalError(format!(
+                            "{:?}",
+                            err
+                        ))
+                        .into())
+                    }
+                };
 
                 let new_text =
                     match flux::formatter::convert_to_string(

--- a/src/server/transform.rs
+++ b/src/server/transform.rs
@@ -60,30 +60,30 @@ fn make_flux_filter_function(
 
 pub(crate) fn inject_tag_filter(
     file: &ast::File,
-    name: String
+    name: String,
 ) -> Result<ast::File, ()> {
     if let Some(statement) = file
-    .body
-    .iter()
-    .filter(|node| {
-        if let ast::Statement::Expr(_stmt) = node {
-            return true;
-        }
-        false
-    })
-    .last()
-{
-    let mut new_ast = file.clone();
-    new_ast.body.retain(|x| x != statement);
+        .body
+        .iter()
+        .filter(|node| {
+            if let ast::Statement::Expr(_stmt) = node {
+                return true;
+            }
+            false
+        })
+        .last()
+    {
+        let mut new_ast = file.clone();
+        new_ast.body.retain(|x| x != statement);
 
-    let call: &ast::Expression =
-        if let ast::Statement::Expr(expr) = statement {
-            &expr.expression
-        } else {
-            return Err(());
-        };
+        let call: &ast::Expression =
+            if let ast::Statement::Expr(expr) = statement {
+                &expr.expression
+            } else {
+                return Err(());
+            };
 
-    new_ast.body.push(ast::Statement::Expr(
+        new_ast.body.push(ast::Statement::Expr(
         Box::new(ast::ExprStmt {
             base: ast::BaseNode::default(),
             expression: ast::Expression::PipeExpr(Box::new(ast::PipeExpr {
@@ -151,9 +151,9 @@ pub(crate) fn inject_tag_filter(
             }))
         })
     ));
-    return Ok(new_ast);
-}
-Err(())
+        return Ok(new_ast);
+    }
+    Err(())
 }
 
 pub(crate) fn inject_tag_value_filter(
@@ -233,10 +233,14 @@ mod tests {
         let fluxscript = r#"from(bucket: "my-bucket")"#;
         let ast = flux::parser::parse_string("".into(), &fluxscript);
 
-        let transformed = inject_tag_filter(&ast, "cpu".into()).unwrap();
+        let transformed =
+            inject_tag_filter(&ast, "cpu".into()).unwrap();
 
         let expected = r#"from(bucket: "my-bucket") |> filter(fn: (r) => exists r.cpu)"#;
-        assert_eq!(expected, flux::formatter::convert_to_string(&transformed).unwrap());
+        assert_eq!(
+            expected,
+            flux::formatter::convert_to_string(&transformed).unwrap()
+        );
     }
 
     #[test]

--- a/src/server/transform.rs
+++ b/src/server/transform.rs
@@ -58,6 +58,104 @@ fn make_flux_filter_function(
     }))
 }
 
+pub(crate) fn inject_tag_filter(
+    file: &ast::File,
+    name: String
+) -> Result<ast::File, ()> {
+    if let Some(statement) = file
+    .body
+    .iter()
+    .filter(|node| {
+        if let ast::Statement::Expr(_stmt) = node {
+            return true;
+        }
+        false
+    })
+    .last()
+{
+    let mut new_ast = file.clone();
+    new_ast.body.retain(|x| x != statement);
+
+    let call: &ast::Expression =
+        if let ast::Statement::Expr(expr) = statement {
+            &expr.expression
+        } else {
+            return Err(());
+        };
+
+    new_ast.body.push(ast::Statement::Expr(
+        Box::new(ast::ExprStmt {
+            base: ast::BaseNode::default(),
+            expression: ast::Expression::PipeExpr(Box::new(ast::PipeExpr {
+                argument: call.clone(),
+                base: ast::BaseNode::default(),
+                call: ast::CallExpr {
+                    arguments: vec![ast::Expression::Object(Box::new(ast::ObjectExpr {
+                        base: ast::BaseNode::default(),
+                        properties: vec![
+                            ast::Property {
+                                base: ast::BaseNode::default(),
+                                key: ast::PropertyKey::Identifier(ast::Identifier {
+                                    base: ast::BaseNode::default(),
+                                    name: "fn".into(),
+                                }),
+                                value: Some(ast::Expression::Function(Box::new(ast::FunctionExpr{
+                                    arrow: vec![],
+                                    base: ast::BaseNode::default(),
+                                    body: ast::FunctionBody::Expr(ast::Expression::Unary(Box::new(ast::UnaryExpr{
+                                        base: ast::BaseNode::default(),
+                                        argument: ast::Expression::Member(Box::new(ast::MemberExpr {
+                                            base: ast::BaseNode::default(),
+                                            lbrack: vec![],
+                                            rbrack: vec![],
+                                            object: ast::Expression::Identifier(ast::Identifier {
+                                                base: ast::BaseNode::default(),
+                                                name: "r".into(),
+                                            }),
+                                            property: ast::PropertyKey::Identifier(ast::Identifier {
+                                                base: ast::BaseNode::default(),
+                                                name,
+                                            }),
+                                        })),
+                                        operator: ast::Operator::ExistsOperator,
+                                    }))),
+                                    lparen: vec![],
+                                    rparen: vec![],
+                                    params: vec![ast::Property {
+                                        base: ast::BaseNode::default(),
+                                        key: ast::PropertyKey::Identifier(ast::Identifier {
+                                            base: ast::BaseNode::default(),
+                                            name: "r".into(),
+                                        }),
+                                        comma: vec![],
+                                        separator: vec![],
+                                        value: None,
+                                    }],
+                                }))),
+                                comma: vec![],
+                                separator: vec![],
+                            }
+                        ],
+                        lbrace: vec![],
+                        rbrace: vec![],
+                        with: None,
+                    }))],
+                    base: ast::BaseNode::default(),
+                    callee: ast::Expression::Identifier(ast::Identifier {
+                        base: ast::BaseNode::default(),
+                        name: "filter".into(),
+                    }),
+                    lparen: vec![],
+                    rparen: vec![],
+                }
+            }))
+        })
+    ));
+    return Ok(new_ast);
+}
+Err(())
+}
+
 pub(crate) fn inject_tag_value_filter(
     file: &ast::File,
     name: String,
@@ -129,6 +227,17 @@ pub(crate) fn inject_tag_value_filter(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_inject_tag_key() {
+        let fluxscript = r#"from(bucket: "my-bucket")"#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+
+        let transformed = inject_tag_filter(&ast, "cpu".into()).unwrap();
+
+        let expected = r#"from(bucket: "my-bucket") |> filter(fn: (r) => exists r.cpu)"#;
+        assert_eq!(expected, flux::formatter::convert_to_string(&transformed).unwrap());
+    }
 
     #[test]
     fn test_inject_tag_value_filter() {


### PR DESCRIPTION
This patch adds support for injecting a `filter` call to narrow a query
by the existence of a tag. For instance, you could turn the following:

    from(bucket: "myBucket")

...into...

    from(bucket: "myBucket")
      |> filter(fn: (r) => exists r.myTag)

Fixes #484