### PR TITLE
feat: find or create the `from` call

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,9 @@
 [net]
 git-fetch-with-cli = true
+
+[target.'cfg(feature = "cargo-clippy")']
+rustflags = [
+  "-Dclippy::print_stdout",
+  "-Dclippy::print_stderr",
+  "-Dclippy::dbg_macro",
+]

--- a/src/bin/flux-lsp.rs
+++ b/src/bin/flux-lsp.rs
@@ -104,6 +104,7 @@ async fn main() {
                 .serve(service)
                 .await;
         }
+        #[allow(clippy::print_stderr)]
         _ => {
             eprintln!(
                 "Unsupported communication channel: {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
-#![cfg_attr(
-    feature = "strict",
-    deny(warnings, clippy::print_stdout, clippy::print_stderr)
-)]
+#![cfg_attr(feature = "strict", deny(warnings))]
 #![warn(
     clippy::expect_used,
     clippy::panic,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1195,6 +1195,7 @@ impl LanguageServer for LspServer {
                 let transformed = match transform::inject_tag_filter(
                     &file,
                     command_params.name,
+                    command_params.bucket,
                 ) {
                     Ok(value) => value,
                     Err(err) => {
@@ -1279,6 +1280,7 @@ impl LanguageServer for LspServer {
                         &file,
                         command_params.name,
                         command_params.value,
+                        command_params.bucket,
                     ) {
                         Ok(value) => value,
                         Err(err) => {
@@ -1360,6 +1362,7 @@ impl LanguageServer for LspServer {
                 let transformed = match transform::inject_field_filter(
                     &file,
                     command_params.name,
+                    command_params.bucket,
                 ) {
                     Ok(value) => value,
                     Err(err) => {
@@ -1443,6 +1446,7 @@ impl LanguageServer for LspServer {
                     match transform::inject_measurement_filter(
                         &file,
                         command_params.name,
+                        command_params.bucket,
                     ) {
                         Ok(value) => value,
                         Err(err) => {
@@ -1518,7 +1522,7 @@ impl LanguageServer for LspServer {
 #[serde(rename_all = "camelCase")]
 struct InjectTagFilterParams {
     text_document: lsp::TextDocumentIdentifier,
-    bucket: Option<String>,
+    bucket: String,
     name: String,
 }
 
@@ -1526,7 +1530,7 @@ struct InjectTagFilterParams {
 #[serde(rename_all = "camelCase")]
 struct InjectTagValueFilterParams {
     text_document: lsp::TextDocumentIdentifier,
-    bucket: Option<String>,
+    bucket: String,
     name: String,
     value: String,
 }
@@ -1535,7 +1539,7 @@ struct InjectTagValueFilterParams {
 #[serde(rename_all = "camelCase")]
 struct InjectFieldFilterParams {
     text_document: lsp::TextDocumentIdentifier,
-    bucket: Option<String>,
+    bucket: String,
     name: String,
 }
 
@@ -1543,7 +1547,7 @@ struct InjectFieldFilterParams {
 #[serde(rename_all = "camelCase")]
 struct InjectMeasurementFilterParams {
     text_document: lsp::TextDocumentIdentifier,
-    bucket: Option<String>,
+    bucket: String,
     name: String,
 }
 

--- a/src/server/transform.rs
+++ b/src/server/transform.rs
@@ -3,6 +3,130 @@
 /// The code here is not for visiting or analyzing flux, but for transforming AST
 /// (and only AST).
 use flux::ast;
+use flux::ast::walk;
+
+fn make_from_function(bucket: String) -> ast::Statement {
+    ast::Statement::Expr(Box::new(ast::ExprStmt {
+        base: ast::BaseNode::default(),
+        expression: ast::Expression::Call(Box::new(ast::CallExpr {
+            base: ast::BaseNode::default(),
+            callee: ast::Expression::Identifier(ast::Identifier {
+                base: ast::BaseNode::default(),
+                name: "from".into(),
+            }),
+            arguments: vec![ast::Expression::Object(Box::new(
+                ast::ObjectExpr {
+                    base: ast::BaseNode::default(),
+                    lbrace: vec![],
+                    with: None,
+                    properties: vec![flux::ast::Property {
+                        base: ast::BaseNode::default(),
+                        key: ast::PropertyKey::Identifier(
+                            ast::Identifier {
+                                base: ast::BaseNode::default(),
+                                name: "bucket".into(),
+                            },
+                        ),
+                        separator: vec![],
+                        value: Some(ast::Expression::StringLit(
+                            ast::StringLit {
+                                base: ast::BaseNode::default(),
+                                value: bucket,
+                            },
+                        )),
+                        comma: vec![],
+                    }],
+                    rbrace: vec![],
+                },
+            ))],
+            lparen: vec![],
+            rparen: vec![],
+        })),
+    }))
+}
+
+#[derive(Default)]
+struct FromBucketVisitor {
+    bucket: Option<String>,
+}
+
+impl<'a> walk::Visitor<'a> for FromBucketVisitor {
+    fn visit(&mut self, node: walk::Node<'a>) -> bool {
+        match node {
+            walk::Node::CallExpr(call) => {
+                if let ast::Expression::Identifier(identifier) =
+                    &call.callee
+                {
+                    if identifier.name == "from" {
+                        call.arguments.iter().for_each(|argument| {
+                            if let ast::Expression::Object(obj) = argument {
+                                obj.properties.iter().for_each(|property| {
+                                    if let ast::PropertyKey::Identifier(key) = &property.key {
+                                        if key.name == "bucket" {
+                                            if let Some(ast::Expression::StringLit(value)) = &property.value {
+                                                self.bucket = Some(value.value.clone());
+                                            }
+                                        }
+                                    }
+                                })
+                            }
+                        });
+                        false
+                    } else {
+                        true
+                    }
+                } else {
+                    true
+                }
+            }
+            _ => true,
+        }
+    }
+}
+
+/// Find the correct `from` expression in a query ast
+///
+/// The logic follows this: we _only_ ever want to look at the last expression
+/// in a query ast. Is it a `from` expression? Does it match the specified bucket?
+/// If that expression is found, pull that expression out of the query and return
+/// it. Otherwise, create a new `from() |> range()` expression and return it.
+///
+/// Why only the last one? Unless we're adding information about cursor position, we
+/// have to make a choice on where the insertion needs to be. That choice is explicitly
+/// "at the end of the file."
+fn find_the_from(
+    file: &mut ast::File,
+    bucket: String,
+) -> ast::Statement {
+    // XXX: rockstar (13 Jun 2022) - This still has an issue where the last call in the
+    // pipe is a yield. Appending to that statement will change the result.
+    let last_statement = file.body.pop();
+    match last_statement {
+        Some(last_statement) => {
+            if let ast::Statement::Expr(statement) =
+                last_statement.clone()
+            {
+                let walker = walk::Node::ExprStmt(statement.as_ref());
+                let mut visitor = FromBucketVisitor::default();
+
+                ast::walk::walk(&mut visitor, walker);
+
+                if let Some(name) = visitor.bucket {
+                    if name == bucket {
+                        return ast::Statement::Expr(statement);
+                    }
+                }
+
+                file.body.push(last_statement);
+                make_from_function(bucket)
+            } else {
+                file.body.push(last_statement);
+                make_from_function(bucket)
+            }
+        }
+        None => make_from_function(bucket),
+    }
+}
 
 /// Create a function used as then `fn` parameter of `filter`
 ///
@@ -61,33 +185,23 @@ fn make_flux_filter_function(
 pub(crate) fn inject_tag_filter(
     file: &ast::File,
     name: String,
+    bucket: String,
 ) -> Result<ast::File, ()> {
-    if let Some(statement) = file
-        .body
-        .iter()
-        .filter(|node| {
-            if let ast::Statement::Expr(_stmt) = node {
-                return true;
-            }
-            false
-        })
-        .last()
+    let mut ast = file.clone();
+
+    let call: ast::Expression = if let ast::Statement::Expr(expr) =
+        find_the_from(&mut ast, bucket)
     {
-        let mut new_ast = file.clone();
-        new_ast.body.retain(|x| x != statement);
+        expr.expression
+    } else {
+        return Err(());
+    };
 
-        let call: &ast::Expression =
-            if let ast::Statement::Expr(expr) = statement {
-                &expr.expression
-            } else {
-                return Err(());
-            };
-
-        new_ast.body.push(ast::Statement::Expr(
+    ast.body.push(ast::Statement::Expr(
         Box::new(ast::ExprStmt {
             base: ast::BaseNode::default(),
             expression: ast::Expression::PipeExpr(Box::new(ast::PipeExpr {
-                argument: call.clone(),
+                argument: call,
                 base: ast::BaseNode::default(),
                 call: ast::CallExpr {
                     arguments: vec![ast::Expression::Object(Box::new(ast::ObjectExpr {
@@ -151,208 +265,200 @@ pub(crate) fn inject_tag_filter(
             }))
         })
     ));
-        return Ok(new_ast);
-    }
-    Err(())
+
+    Ok(ast)
 }
 
 pub(crate) fn inject_field_filter(
     file: &ast::File,
     name: String,
+    bucket: String,
 ) -> Result<ast::File, ()> {
-    if let Some(statement) = file
-        .body
-        .iter()
-        .filter(|node| {
-            if let ast::Statement::Expr(_stmt) = node {
-                return true;
-            }
-            false
-        })
-        .last()
+    let mut ast = file.clone();
+
+    let call: ast::Expression = if let ast::Statement::Expr(expr) =
+        find_the_from(&mut ast, bucket)
     {
-        let mut new_ast = file.clone();
-        new_ast.body.retain(|x| x != statement);
+        expr.expression
+    } else {
+        return Err(());
+    };
 
-        let call: &ast::Expression =
-            if let ast::Statement::Expr(expr) = statement {
-                &expr.expression
-            } else {
-                return Err(());
-            };
-
-        new_ast.body.push(ast::Statement::Expr(
-        Box::new(ast::ExprStmt {
-            base: ast::BaseNode::default(),
-            expression: ast::Expression::PipeExpr(Box::new(ast::PipeExpr {
-                argument: call.clone(),
+    ast.body.push(ast::Statement::Expr(Box::new(ast::ExprStmt {
+        base: ast::BaseNode::default(),
+        expression: ast::Expression::PipeExpr(Box::new(
+            ast::PipeExpr {
+                argument: call,
                 base: ast::BaseNode::default(),
                 call: ast::CallExpr {
-                    arguments: vec![ast::Expression::Object(Box::new(ast::ObjectExpr {
-                        base: ast::BaseNode::default(),
-                        properties: vec![
-                            ast::Property {
+                    arguments: vec![ast::Expression::Object(
+                        Box::new(ast::ObjectExpr {
+                            base: ast::BaseNode::default(),
+                            properties: vec![ast::Property {
                                 base: ast::BaseNode::default(),
-                                key: ast::PropertyKey::Identifier(ast::Identifier {
-                                    base: ast::BaseNode::default(),
-                                    name: "fn".into(),
-                                }),
-                                value: Some(make_flux_filter_function("_field".into(), name)),
+                                key: ast::PropertyKey::Identifier(
+                                    ast::Identifier {
+                                        base: ast::BaseNode::default(
+                                        ),
+                                        name: "fn".into(),
+                                    },
+                                ),
+                                value: Some(
+                                    make_flux_filter_function(
+                                        "_field".into(),
+                                        name,
+                                    ),
+                                ),
                                 comma: vec![],
                                 separator: vec![],
-                            }
-                        ],
-                        lbrace: vec![],
-                        rbrace: vec![],
-                        with: None,
-                    }))],
+                            }],
+                            lbrace: vec![],
+                            rbrace: vec![],
+                            with: None,
+                        }),
+                    )],
                     base: ast::BaseNode::default(),
-                    callee: ast::Expression::Identifier(ast::Identifier {
-                        base: ast::BaseNode::default(),
-                        name: "filter".into(),
-                    }),
+                    callee: ast::Expression::Identifier(
+                        ast::Identifier {
+                            base: ast::BaseNode::default(),
+                            name: "filter".into(),
+                        },
+                    ),
                     lparen: vec![],
                     rparen: vec![],
-                }
-            }))
-        })
-    ));
-        return Ok(new_ast);
-    }
-    Err(())
+                },
+            },
+        )),
+    })));
+    Ok(ast)
 }
 
 pub(crate) fn inject_tag_value_filter(
     file: &ast::File,
     name: String,
     value: String,
+    bucket: String,
 ) -> Result<ast::File, ()> {
-    if let Some(statement) = file
-        .body
-        .iter()
-        .filter(|node| {
-            if let ast::Statement::Expr(_stmt) = node {
-                return true;
-            }
-            false
-        })
-        .last()
+    let mut ast = file.clone();
+
+    let call: ast::Expression = if let ast::Statement::Expr(expr) =
+        find_the_from(&mut ast, bucket)
     {
-        let mut new_ast = file.clone();
-        new_ast.body.retain(|x| x != statement);
+        expr.expression
+    } else {
+        return Err(());
+    };
 
-        let call: &ast::Expression =
-            if let ast::Statement::Expr(expr) = statement {
-                &expr.expression
-            } else {
-                return Err(());
-            };
-
-        new_ast.body.push(ast::Statement::Expr(
-            Box::new(ast::ExprStmt {
+    ast.body.push(ast::Statement::Expr(Box::new(ast::ExprStmt {
+        base: ast::BaseNode::default(),
+        expression: ast::Expression::PipeExpr(Box::new(
+            ast::PipeExpr {
+                argument: call,
                 base: ast::BaseNode::default(),
-                expression: ast::Expression::PipeExpr(Box::new(ast::PipeExpr {
-                    argument: call.clone(),
-                    base: ast::BaseNode::default(),
-                    call: ast::CallExpr {
-                        arguments: vec![ast::Expression::Object(Box::new(ast::ObjectExpr {
+                call: ast::CallExpr {
+                    arguments: vec![ast::Expression::Object(
+                        Box::new(ast::ObjectExpr {
                             base: ast::BaseNode::default(),
-                            properties: vec![
-                                ast::Property {
-                                    base: ast::BaseNode::default(),
-                                    key: ast::PropertyKey::Identifier(ast::Identifier {
-                                        base: ast::BaseNode::default(),
+                            properties: vec![ast::Property {
+                                base: ast::BaseNode::default(),
+                                key: ast::PropertyKey::Identifier(
+                                    ast::Identifier {
+                                        base: ast::BaseNode::default(
+                                        ),
                                         name: "fn".into(),
-                                    }),
-                                    value: Some(make_flux_filter_function(name, value)),
-                                    comma: vec![],
-                                    separator: vec![],
-                                }
-                            ],
+                                    },
+                                ),
+                                value: Some(
+                                    make_flux_filter_function(
+                                        name, value,
+                                    ),
+                                ),
+                                comma: vec![],
+                                separator: vec![],
+                            }],
                             lbrace: vec![],
                             rbrace: vec![],
                             with: None,
-                        }))],
-                        base: ast::BaseNode::default(),
-                        callee: ast::Expression::Identifier(ast::Identifier {
+                        }),
+                    )],
+                    base: ast::BaseNode::default(),
+                    callee: ast::Expression::Identifier(
+                        ast::Identifier {
                             base: ast::BaseNode::default(),
                             name: "filter".into(),
-                        }),
-                        lparen: vec![],
-                        rparen: vec![],
-                    }
-                }))
-            })
-        ));
-        return Ok(new_ast);
-    }
-    Err(())
+                        },
+                    ),
+                    lparen: vec![],
+                    rparen: vec![],
+                },
+            },
+        )),
+    })));
+    Ok(ast)
 }
 
 pub(crate) fn inject_measurement_filter(
     file: &ast::File,
     name: String,
+    bucket: String,
 ) -> Result<ast::File, ()> {
-    if let Some(statement) = file
-        .body
-        .iter()
-        .filter(|node| {
-            if let ast::Statement::Expr(_stmt) = node {
-                return true;
-            }
-            false
-        })
-        .last()
+    let mut ast = file.clone();
+
+    let call: ast::Expression = if let ast::Statement::Expr(expr) =
+        find_the_from(&mut ast, bucket)
     {
-        let mut new_ast = file.clone();
-        new_ast.body.retain(|x| x != statement);
+        expr.expression
+    } else {
+        return Err(());
+    };
 
-        let call: &ast::Expression =
-            if let ast::Statement::Expr(expr) = statement {
-                &expr.expression
-            } else {
-                return Err(());
-            };
-
-        new_ast.body.push(ast::Statement::Expr(
-        Box::new(ast::ExprStmt {
-            base: ast::BaseNode::default(),
-            expression: ast::Expression::PipeExpr(Box::new(ast::PipeExpr {
-                argument: call.clone(),
+    ast.body.push(ast::Statement::Expr(Box::new(ast::ExprStmt {
+        base: ast::BaseNode::default(),
+        expression: ast::Expression::PipeExpr(Box::new(
+            ast::PipeExpr {
+                argument: call,
                 base: ast::BaseNode::default(),
                 call: ast::CallExpr {
-                    arguments: vec![ast::Expression::Object(Box::new(ast::ObjectExpr {
-                        base: ast::BaseNode::default(),
-                        properties: vec![
-                            ast::Property {
+                    arguments: vec![ast::Expression::Object(
+                        Box::new(ast::ObjectExpr {
+                            base: ast::BaseNode::default(),
+                            properties: vec![ast::Property {
                                 base: ast::BaseNode::default(),
-                                key: ast::PropertyKey::Identifier(ast::Identifier {
-                                    base: ast::BaseNode::default(),
-                                    name: "fn".into(),
-                                }),
-                                value: Some(make_flux_filter_function("_measurement".into(), name)),
+                                key: ast::PropertyKey::Identifier(
+                                    ast::Identifier {
+                                        base: ast::BaseNode::default(
+                                        ),
+                                        name: "fn".into(),
+                                    },
+                                ),
+                                value: Some(
+                                    make_flux_filter_function(
+                                        "_measurement".into(),
+                                        name,
+                                    ),
+                                ),
                                 comma: vec![],
                                 separator: vec![],
-                            }
-                        ],
-                        lbrace: vec![],
-                        rbrace: vec![],
-                        with: None,
-                    }))],
+                            }],
+                            lbrace: vec![],
+                            rbrace: vec![],
+                            with: None,
+                        }),
+                    )],
                     base: ast::BaseNode::default(),
-                    callee: ast::Expression::Identifier(ast::Identifier {
-                        base: ast::BaseNode::default(),
-                        name: "filter".into(),
-                    }),
+                    callee: ast::Expression::Identifier(
+                        ast::Identifier {
+                            base: ast::BaseNode::default(),
+                            name: "filter".into(),
+                        },
+                    ),
                     lparen: vec![],
                     rparen: vec![],
-                }
-            }))
-        })
-    ));
-        return Ok(new_ast);
-    }
-    Err(())
+                },
+            },
+        )),
+    })));
+    Ok(ast)
 }
 
 #[cfg(test)]
@@ -360,13 +466,149 @@ pub(crate) fn inject_measurement_filter(
 mod tests {
     use super::*;
 
+    // When the last statement isn't a `from` call, return a new `from` call.
+    #[test]
+    fn test_find_the_from_last_statement_not_from() {
+        let fluxscript = r#"from(bucket: "my-bucket")
+        
+a = 0"#;
+        let mut ast =
+            flux::parser::parse_string("".into(), &fluxscript);
+
+        let from = find_the_from(&mut ast, "my-bucket".into());
+
+        assert_eq!(
+            from.base().location,
+            ast::SourceLocation {
+                start: ast::Position { line: 0, column: 0 },
+                end: ast::Position { line: 0, column: 0 },
+                file: None,
+                source: None
+            }
+        );
+        assert_eq!(2, ast.body.len());
+    }
+
+    // When the query is empty, return a new `from` call.
+    #[test]
+    fn test_find_the_from_empty_query() {
+        let fluxscript = r#""#;
+        let mut ast =
+            flux::parser::parse_string("".into(), &fluxscript);
+
+        let from = find_the_from(&mut ast, "my-bucket".into());
+
+        assert_eq!(
+            from.base().location,
+            ast::SourceLocation {
+                start: ast::Position { line: 0, column: 0 },
+                end: ast::Position { line: 0, column: 0 },
+                file: None,
+                source: None
+            }
+        );
+        assert_eq!(0, ast.body.len());
+    }
+
+    // When the last `from` call isn't the right bucket, return a new `from` call.
+    #[test]
+    fn test_find_the_from_not_existing_from() {
+        let fluxscript = r#"from(bucket: "my-bucket")"#;
+        let mut ast =
+            flux::parser::parse_string("".into(), &fluxscript);
+
+        let from = find_the_from(&mut ast, "my-new-bucket".into());
+
+        assert_eq!(
+            from.base().location,
+            ast::SourceLocation {
+                start: ast::Position { line: 0, column: 0 },
+                end: ast::Position { line: 0, column: 0 },
+                file: None,
+                source: None
+            }
+        );
+        assert_eq!(1, ast.body.len());
+    }
+
+    // When the last `from` call is the correct bucket, return that call.
+    #[test]
+    fn test_find_the_from_from_found() {
+        let fluxscript = r#"from(bucket: "my-bucket")"#;
+        let mut ast =
+            flux::parser::parse_string("".into(), &fluxscript);
+
+        let from = find_the_from(&mut ast, "my-bucket".into());
+
+        assert_eq!(
+            from.base().location,
+            ast::SourceLocation {
+                start: ast::Position { line: 1, column: 1 },
+                end: ast::Position {
+                    line: 1,
+                    column: 26
+                },
+                file: None,
+                source: Some(r#"from(bucket: "my-bucket")"#.into())
+            }
+        );
+        assert_eq!(0, ast.body.len());
+    }
+
+    // When the expected `from` is nested in a pipe expr, walk down
+    // into it to find it.
+    #[test]
+    fn test_find_the_from_from_with_pipe_expr() {
+        let fluxscript = r#"from(bucket: "my-bucket")
+  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)"#;
+        let mut ast =
+            flux::parser::parse_string("".into(), &fluxscript);
+
+        let from = find_the_from(&mut ast, "my-bucket".into());
+
+        assert_eq!(
+            from.base().location,
+            ast::SourceLocation {
+                start: ast::Position { line: 1, column: 1 },
+                end: ast::Position {
+                    line: 2,
+                    column: 59
+                },
+                file: None,
+                source: Some(
+                    r#"from(bucket: "my-bucket")
+  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)"#
+                        .into()
+                )
+            }
+        );
+        assert_eq!(0, ast.body.len());
+    }
+
     #[test]
     fn test_inject_tag_key() {
         let fluxscript = r#"from(bucket: "my-bucket")"#;
         let ast = flux::parser::parse_string("".into(), &fluxscript);
 
         let transformed =
-            inject_tag_filter(&ast, "cpu".into()).unwrap();
+            inject_tag_filter(&ast, "cpu".into(), "my-bucket".into())
+                .unwrap();
+
+        let expected = r#"from(bucket: "my-bucket") |> filter(fn: (r) => exists r.cpu)"#;
+        assert_eq!(
+            expected,
+            flux::formatter::convert_to_string(&transformed).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_inject_tag_key_no_from() {
+        let fluxscript = r#""#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+
+        let transformed =
+            inject_tag_filter(&ast, "cpu".into(), "my-bucket".into())
+                .unwrap();
 
         let expected = r#"from(bucket: "my-bucket") |> filter(fn: (r) => exists r.cpu)"#;
         assert_eq!(
@@ -384,6 +626,27 @@ mod tests {
             &ast,
             "myTag".into(),
             "myTagValue".into(),
+            "my-bucket".into(),
+        )
+        .unwrap();
+
+        let expected = r#"from(bucket: "my-bucket") |> filter(fn: (r) => r.myTag == "myTagValue")"#;
+        assert_eq!(
+            expected,
+            flux::formatter::convert_to_string(&transformed).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_inject_tag_value_filter_no_from() {
+        let fluxscript = r#""#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+
+        let transformed = inject_tag_value_filter(
+            &ast,
+            "myTag".into(),
+            "myTagValue".into(),
+            "my-bucket".into(),
         )
         .unwrap();
 
@@ -399,8 +662,12 @@ mod tests {
         let fluxscript = r#"from(bucket: "my-bucket")"#;
         let ast = flux::parser::parse_string("".into(), &fluxscript);
 
-        let transformed =
-            inject_field_filter(&ast, "myField".into()).unwrap();
+        let transformed = inject_field_filter(
+            &ast,
+            "myField".into(),
+            "my-bucket".into(),
+        )
+        .unwrap();
 
         let expected = r#"from(bucket: "my-bucket") |> filter(fn: (r) => r._field == "myField")"#;
         assert_eq!(
@@ -414,9 +681,12 @@ mod tests {
         let fluxscript = r#"from(bucket: "my-bucket")"#;
         let ast = flux::parser::parse_string("".into(), &fluxscript);
 
-        let transformed =
-            inject_measurement_filter(&ast, "myMeasurement".into())
-                .unwrap();
+        let transformed = inject_measurement_filter(
+            &ast,
+            "myMeasurement".into(),
+            "my-bucket".into(),
+        )
+        .unwrap();
 
         let expected = r#"from(bucket: "my-bucket") |> filter(fn: (r) => r._measurement == "myMeasurement")"#;
         assert_eq!(


### PR DESCRIPTION
This patch adds support for finding or creating the `from` call when
injecting filter functions. It does not add the `range` pipe expression,
as we're at a turning point where we need to find a better way to
express new AST nodes and transformations. Otherwise, the patch might be
prohibitively large at this time.

Additionally, fix the lint rules for `clippy::print_stdout` and
`clippy::print_stderr`. Since they were macros, they were being
evaluated too late to be caught. They are now specified as compiler
flags.