### PR TITLE
feat: Display the type constraints when hovering over something

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -874,7 +874,7 @@ impl LanguageServer for LspServer {
         );
         if let Some(node) = visitor.node {
             let path = &visitor.path;
-            let hover_type = node.type_of().or_else(|| match node {
+            let hover_type = node.type_of().map(|t| t.to_string()).or_else(|| match node {
                 walk::Node::Identifier(ident) => {
                     // We hovered over an identifier without an attached type, try to figure
                     // it out from its context
@@ -882,18 +882,18 @@ impl LanguageServer for LspServer {
                     match parent {
                         // The type of assigned variables is the type of the right hand side
                         walk::Node::VariableAssgn(var) => {
-                            Some(var.init.type_of())
+                            Some(var.init.type_of().to_string())
                         }
                         walk::Node::MemberAssgn(var) => {
-                            Some(var.init.type_of())
+                            Some(var.init.type_of().to_string())
                         }
                         walk::Node::BuiltinStmt(builtin) => {
-                            Some(builtin.typ_expr.expr.clone())
+                            Some(builtin.typ_expr.to_string())
                         }
 
                         // The type of an property identifier is the type of the value
                         walk::Node::Property(property) => {
-                            Some(property.value.type_of())
+                            Some(property.value.type_of().to_string())
                         }
 
                         // The type Function parameters can be derived from the function type
@@ -906,7 +906,7 @@ impl LanguageServer for LspServer {
                                         .parameter(
                                             ident.name.as_str(),
                                         )
-                                        .cloned()
+                                        .map(|t| t.to_string())
                                 }
                                 _ => None,
                             }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1594,6 +1594,32 @@ x = 1
 }
 
 #[test]
+async fn test_hover_on_polymorphic_identifier() {
+    let fluxscript = r#"
+f = (x) => x + x
+        // ^
+"#;
+    let server = create_server();
+    open_file(&server, fluxscript.to_string(), None).await;
+
+    let params = hover_params(position_of(fluxscript));
+
+    let result = server.hover(params).await.unwrap();
+
+    assert_eq!(
+        result,
+        Some(lsp::Hover {
+            contents: lsp::HoverContents::Scalar(
+                lsp::MarkedString::String(
+                    "type: A where A: Addable".to_string()
+                )
+            ),
+            range: None,
+        })
+    );
+}
+
+#[test]
 async fn test_package_completion() {
     let fluxscript = r#"import "sql"
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1440,7 +1440,7 @@ x + 1
 #[test]
 async fn test_hover_binding() {
     let fluxscript = r#"x = "asd"
-builtin builtin_ : (v: int) => int
+builtin builtin_ : (v: A) => A where A: Numeric
 option option_ = 123
 1
 "#;
@@ -1472,7 +1472,7 @@ option option_ = 123
         Some(lsp::Hover {
             contents: lsp::HoverContents::Scalar(
                 lsp::MarkedString::String(
-                    "type: (v: int) => int".to_string()
+                    "type: (v: A) => A where A: Numeric".to_string()
                 )
             ),
             range: None,
@@ -3454,7 +3454,7 @@ async fn compute_diagnostics_non_errors() {
 
     let filename: String = "file:///path/to/script.flux".into();
     let fluxscript = r#"import "experimental"
-        
+
 from(bucket: "my-bucket")
 |> range(start: -100d)
 |> filter(fn: (r) => r.value == "b")


### PR DESCRIPTION
Picking out the constraints from the parent variable binding seems to work in this simple case but it may break down in more complicated examples. It doesn't seem like a great way to do it either but I am not sure how else we can without changes to the semantic graph.