### PR TITLE
fix: match injectFieldFilter with corresponding command

### DIFF
--- a/src/server/commands.rs
+++ b/src/server/commands.rs
@@ -21,7 +21,7 @@ impl TryFrom<String> for LspServerCommand {
                 Ok(LspServerCommand::InjectTagValueFilter)
             }
             "injectFieldFilter" => {
-                Ok(LspServerCommand::InjectTagValueFilter)
+                Ok(LspServerCommand::InjectFieldFilter)
             }
             "injectMeasurementFilter" => {
                 Ok(LspServerCommand::InjectMeasurementFilter)


### PR DESCRIPTION
This PR fixed a bug where lsp command was mismatched