### PR TITLE
chore: update Readme for test command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ An implementation of the [Language Server Protocol](https://microsoft.github.io/
 # LSP Development
 
 * LSP development requires rust version of 1.40.0 or newer.
-* run tests with `make test`
+* run tests with `cargo test`
 
 # Installing command line server
 


### PR DESCRIPTION
This PR updates the test command in Readme file. Since there is not a Makefile and rust already has its own package manager `cargo` for testing, so it makes more sense to change the command to `cargo test`