### PR TITLE
fix: revert back to using the lsp features from libflux

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -37,18 +37,7 @@ fn node_to_location(
 ) -> lsp::Location {
     lsp::Location {
         uri,
-        // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
-        // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
-        range: lsp::Range {
-            start: lsp::Position {
-                line: node.loc().start.line - 1,
-                character: node.loc().start.column - 1,
-            },
-            end: lsp::Position {
-                line: node.loc().end.line - 1,
-                character: node.loc().end.column - 1,
-            },
-        },
+        range: node.loc().clone().into(),
     }
 }
 
@@ -302,18 +291,7 @@ impl LspServer {
                         })
                         .map(|e| {
                             (e.location.file.clone(), lsp::Diagnostic {
-                    // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
-                    // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
-                    range: lsp::Range {
-                        start: lsp::Position {
-                            line: e.location.start.line - 1,
-                            character: e.location.start.column - 1,
-                        },
-                        end: lsp::Position {
-                            line: e.location.end.line - 1,
-                            character: e.location.end.column - 1,
-                        },
-                    },
+                    range: e.location.clone().into(),
                     severity: Some(lsp::DiagnosticSeverity::ERROR),
                     source: Some("flux".to_string()),
                     message: e.error.to_string(),
@@ -1072,19 +1050,7 @@ impl LanguageServer for LspServer {
             .filter(|error| {
                 crate::lsp::ranges_overlap(
                     &params.range,
-                    // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
-                    // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
-                    &lsp::Range {
-                        start: lsp::Position {
-                            line: error.location.start.line - 1,
-                            character: error.location.start.column
-                                - 1,
-                        },
-                        end: lsp::Position {
-                            line: error.location.end.line - 1,
-                            character: error.location.end.column - 1,
-                        },
-                    },
+                    &error.location.clone().into(),
                 )
             })
             .collect();

--- a/src/visitors/ast.rs
+++ b/src/visitors/ast.rs
@@ -24,19 +24,10 @@ impl<'a> NodeFinderVisitor<'a> {
 
 impl<'a> walk::Visitor<'a> for NodeFinderVisitor<'a> {
     fn visit(&mut self, node: walk::Node<'a>) -> bool {
-        // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
-        // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
-        let range = lsp::Range {
-            start: lsp::Position {
-                line: node.base().location.start.line - 1,
-                character: node.base().location.start.column - 1,
-            },
-            end: lsp::Position {
-                line: node.base().location.end.line - 1,
-                character: node.base().location.end.column - 1,
-            },
-        };
-        if crate::lsp::position_in_range(&self.position, &range) {
+        if crate::lsp::position_in_range(
+            &self.position,
+            &node.base().location.clone().into(),
+        ) {
             let parent = self.node.clone();
             if let Some(parent) = parent {
                 self.node = Some(NodeFinderNode {
@@ -63,12 +54,7 @@ impl From<&flux::ast::Package> for PackageInfo {
     fn from(pkg: &flux::ast::Package) -> Self {
         Self {
             name: pkg.package.clone(),
-            // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
-            // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
-            position: lsp::Position {
-                line: pkg.base.location.start.line - 1,
-                character: pkg.base.location.start.column - 1,
-            },
+            position: pkg.base.location.start.into(),
         }
     }
 }

--- a/src/visitors/semantic/lint.rs
+++ b/src/visitors/semantic/lint.rs
@@ -54,16 +54,7 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                     flux::semantic::nodes::Expression::Identifier(id) => {
                         if self.namespaces.contains(&format!("{}", id.name)) {
                             self.diagnostics.push((expr.loc.file.clone(), lsp::Diagnostic {
-                                range: lsp::Range {
-                                    start: lsp::Position {
-                                        line: expr.loc.start.line - 1,
-                                        character: expr.loc.start.column - 1,
-                                    },
-                                    end: lsp::Position {
-                                        line: expr.loc.end.line - 1,
-                                        character: expr.loc.end.column - 1,
-                                    },
-                                },
+                                range: expr.loc.clone().into(),
                                 severity: Some(lsp::DiagnosticSeverity::HINT),
                                 message: "experimental features can change often or be deleted/moved. Use with caution.".into(),
                                 ..lsp::Diagnostic::default()
@@ -74,16 +65,7 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                         if let flux::semantic::nodes::Expression::Identifier(id) = &member.object {
                             if self.namespaces.contains(&format!("{}", id.name)) {
                                 self.diagnostics.push((expr.loc.file.clone(), lsp::Diagnostic {
-                                    range: lsp::Range {
-                                        start: lsp::Position {
-                                            line: expr.loc.start.line -1,
-                                            character: expr.loc.start.column -1,
-                                        },
-                                        end: lsp::Position {
-                                            line: expr.loc.end.line-1,
-                                            character: expr.loc.end.column - 1,
-                                        },
-                                    },
+                                    range: expr.loc.clone().into(),
                                     severity: Some(lsp::DiagnosticSeverity::HINT),
                                     message: "experimental features can change often or be deleted/moved. Use with caution.".into(),
                                     ..lsp::Diagnostic::default()
@@ -146,16 +128,7 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                     flux::semantic::nodes::Expression::Identifier(id) => {
                         if self.namespaces.contains(&format!("{}", id.name)) {
                             self.diagnostics.push((id.loc.file.clone(), lsp::Diagnostic {
-                                range: lsp::Range {
-                                    start: lsp::Position {
-                                        line: expr.loc.start.line -1,
-                                        character: expr.loc.start.column -1,
-                                    },
-                                    end: lsp::Position {
-                                        line: expr.loc.end.line-1,
-                                        character: expr.loc.end.column - 1,
-                                    },
-                                },
+                                range: expr.loc.clone().into(),
                                 severity: Some(lsp::DiagnosticSeverity::HINT),
                                 message: "contrib packages are user-contributed, and do not carry with them the same compatibility guarantees as the standard library. Use with caution.".into(),
                                 ..lsp::Diagnostic::default()
@@ -166,16 +139,7 @@ impl<'a> flux::semantic::walk::Visitor<'a>
                         if let flux::semantic::nodes::Expression::Identifier(id) = &member.object {
                             if self.namespaces.contains(&id.name.to_string()) {
                                 self.diagnostics.push((id.loc.file.clone(), lsp::Diagnostic {
-                                    range: lsp::Range {
-                                        start: lsp::Position {
-                                            line: expr.loc.start.line - 1,
-                                            character: expr.loc.start.column - 1,
-                                        },
-                                        end: lsp::Position {
-                                            line: expr.loc.end.line - 1,
-                                            character: expr.loc.end.column - 1,
-                                        },
-                                    },
+                                    range: expr.loc.clone().into(),
                                     severity: Some(lsp::DiagnosticSeverity::HINT),
                                     message: "contrib packages are user-contributed, and do not carry with them the same compatibility guarantees as the standard library. Use with caution.".into(),
                                     ..lsp::Diagnostic::default()
@@ -213,16 +177,7 @@ impl<'a> flux::semantic::walk::Visitor<'a>
         if let WalkNode::VariableAssgn(assign) = node {
             if self.names.contains(&assign.id.name.to_string()) {
                 self.diagnostics.push((assign.loc.file.clone(), lsp::Diagnostic {
-                    range: lsp::Range {
-                        start: lsp::Position {
-                            line: assign.id.loc.start.line - 1,
-                            character: assign.id.loc.start.column - 1,
-                        },
-                        end: lsp::Position {
-                            line: assign.id.loc.end.line - 1,
-                            character: assign.id.loc.end.column - 1,
-                        },
-                    },
+                    range: assign.id.loc.clone().into(),
                     severity: Some(lsp::DiagnosticSeverity::WARNING),
                     message: format!("Avoid using `{}` as an identifier name. In some InfluxDB contexts, it may be provided at runtime.", assign.id.name),
                     ..lsp::Diagnostic::default()

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -26,24 +26,25 @@ fn contains_position(node: Node<'_>, pos: lsp::Position) -> bool {
         // a start/end location of 0:0.
         return false;
     }
-    let start_line = node.loc().start.line - 1;
-    let start_col = node.loc().start.column - 1;
-    let end_line = node.loc().end.line - 1;
-    let end_col = node.loc().end.column - 1;
+    let range: lsp::Range = node.loc().clone().into();
 
-    if pos.line < start_line {
+    if pos.line < range.start.line {
         return false;
     }
 
-    if pos.line > end_line {
+    if pos.line > range.end.line {
         return false;
     }
 
-    if pos.line == start_line && pos.character < start_col {
+    if pos.line == range.start.line
+        && pos.character < range.start.character
+    {
         return false;
     }
 
-    if pos.line == end_line && pos.character > end_col {
+    if pos.line == range.end.line
+        && pos.character > range.end.character
+    {
         return false;
     }
 
@@ -223,18 +224,7 @@ pub struct PackageNodeFinderVisitor {
 impl<'a> Visitor<'a> for PackageNodeFinderVisitor {
     fn visit(&mut self, node: Node<'a>) -> bool {
         if let Node::PackageClause(n) = node {
-            // XXX: rockstar (19 May 2022) - flux asks for too new of an lsp-types for `.into` to
-            // work. That doesn't need to be quite so bleeding edge, but that's an issue for flux.
-            self.location = Some(lsp::Range {
-                start: lsp::Position {
-                    line: n.loc.start.line - 1,
-                    character: n.loc.start.column - 1,
-                },
-                end: lsp::Position {
-                    line: n.loc.end.line - 1,
-                    character: n.loc.end.column - 1,
-                },
-            });
+            self.location = Some(n.loc.clone().into());
             return false;
         }
         true

--- a/src/visitors/semantic/symbols.rs
+++ b/src/visitors/semantic/symbols.rs
@@ -17,16 +17,7 @@ fn parse_variable_assignment(
             name: va.id.name.to_string(),
             location: lsp::Location {
                 uri: uri.clone(),
-                range: lsp::Range {
-                    start: lsp::Position {
-                        line: node.loc().start.line - 1,
-                        character: node.loc().start.column - 1,
-                    },
-                    end: lsp::Position {
-                        line: node.loc().end.line - 1,
-                        character: node.loc().end.column - 1,
-                    },
-                },
+                range: node.loc().clone().into(),
             },
             tags: None,
             deprecated: None,
@@ -39,16 +30,7 @@ fn parse_variable_assignment(
                 name: param.key.name.to_string(),
                 location: lsp::Location {
                     uri: uri.clone(),
-                    range: lsp::Range {
-                        start: lsp::Position {
-                            line: param.loc.start.line - 1,
-                            character: param.loc.start.column - 1,
-                        },
-                        end: lsp::Position {
-                            line: param.loc.end.line - 1,
-                            character: param.loc.end.column - 1,
-                        },
-                    },
+                    range: param.loc.clone().into(),
                 },
                 tags: None,
                 deprecated: None,
@@ -61,16 +43,7 @@ fn parse_variable_assignment(
             name: va.id.name.to_string(),
             location: lsp::Location {
                 uri,
-                range: lsp::Range {
-                    start: lsp::Position {
-                        line: node.loc().start.line - 1,
-                        character: node.loc().start.column - 1,
-                    },
-                    end: lsp::Position {
-                        line: node.loc().end.line - 1,
-                        character: node.loc().end.column - 1,
-                    },
-                },
+                range: node.loc().clone().into(),
             },
             tags: None,
             deprecated: None,
@@ -93,16 +66,7 @@ fn parse_call_expression(
             name: ident.name.to_string(),
             location: lsp::Location {
                 uri: uri.clone(),
-                range: lsp::Range {
-                    start: lsp::Position {
-                        line: c.loc.start.line - 1,
-                        character: c.loc.start.column - 1,
-                    },
-                    end: lsp::Position {
-                        line: c.loc.end.line - 1,
-                        character: c.loc.end.column - 1,
-                    },
-                },
+                range: c.loc.clone().into(),
             },
             tags: None,
             deprecated: None,
@@ -117,16 +81,7 @@ fn parse_call_expression(
                 name: arg.key.name.to_string(),
                 location: lsp::Location {
                     uri: uri.clone(),
-                    range: lsp::Range {
-                        start: lsp::Position {
-                            line: arg.loc.start.line - 1,
-                            character: arg.loc.start.column - 1,
-                        },
-                        end: lsp::Position {
-                            line: arg.loc.end.line - 1,
-                            character: arg.loc.end.column - 1,
-                        },
-                    },
+                    range: arg.loc.clone().into(),
                 },
                 tags: None,
                 deprecated: None,
@@ -138,16 +93,7 @@ fn parse_call_expression(
                 name: arg.key.name.to_string(),
                 location: lsp::Location {
                     uri: uri.clone(),
-                    range: lsp::Range {
-                        start: lsp::Position {
-                            line: arg.loc.start.line - 1,
-                            character: arg.loc.start.column - 1,
-                        },
-                        end: lsp::Position {
-                            line: arg.loc.end.line - 1,
-                            character: arg.loc.end.column - 1,
-                        },
-                    },
+                    range: arg.loc.clone().into(),
                 },
                 tags: None,
                 deprecated: None,
@@ -171,16 +117,7 @@ fn parse_binary_expression(
             name: ident.name.to_string(),
             location: lsp::Location {
                 uri: uri.clone(),
-                range: lsp::Range {
-                    start: lsp::Position {
-                        line: ident.loc.start.line - 1,
-                        character: ident.loc.start.column - 1,
-                    },
-                    end: lsp::Position {
-                        line: ident.loc.end.line - 1,
-                        character: ident.loc.end.column - 1,
-                    },
-                },
+                range: ident.loc.into(),
             },
             tags: None,
             deprecated: None,
@@ -194,16 +131,7 @@ fn parse_binary_expression(
             name: ident.name.to_string(),
             location: lsp::Location {
                 uri,
-                range: lsp::Range {
-                    start: lsp::Position {
-                        line: ident.loc.start.line - 1,
-                        character: ident.loc.start.column - 1,
-                    },
-                    end: lsp::Position {
-                        line: ident.loc.end.line - 1,
-                        character: ident.loc.end.column - 1,
-                    },
-                },
+                range: ident.loc.into(),
             },
             tags: None,
             deprecated: None,
@@ -271,17 +199,7 @@ impl<'a> Visitor<'a> for SymbolsVisitor<'a> {
                         name: source,
                         location: lsp::Location {
                             uri,
-                            range: lsp::Range {
-                                start: lsp::Position {
-                                    line: me.loc.start.line - 1,
-                                    character: me.loc.start.column
-                                        - 1,
-                                },
-                                end: lsp::Position {
-                                    line: me.loc.end.line - 1,
-                                    character: me.loc.end.column - 1,
-                                },
-                            },
+                            range: me.loc.clone().into(),
                         },
                         tags: None,
                         deprecated: None,
@@ -295,16 +213,7 @@ impl<'a> Visitor<'a> for SymbolsVisitor<'a> {
                     name: num.value.to_string(),
                     location: lsp::Location {
                         uri,
-                        range: lsp::Range {
-                            start: lsp::Position {
-                                line: num.loc.start.line - 1,
-                                character: num.loc.start.column - 1,
-                            },
-                            end: lsp::Position {
-                                line: num.loc.end.line - 1,
-                                character: num.loc.end.column - 1,
-                            },
-                        },
+                        range: num.loc.clone().into(),
                     },
                     tags: None,
                     deprecated: None,
@@ -318,16 +227,7 @@ impl<'a> Visitor<'a> for SymbolsVisitor<'a> {
                     name: num.value.to_string(),
                     location: lsp::Location {
                         uri,
-                        range: lsp::Range {
-                            start: lsp::Position {
-                                line: num.loc.start.line - 1,
-                                character: num.loc.start.column - 1,
-                            },
-                            end: lsp::Position {
-                                line: num.loc.end.line - 1,
-                                character: num.loc.end.column - 1,
-                            },
-                        },
+                        range: num.loc.clone().into(),
                     },
                     tags: None,
                     deprecated: None,
@@ -341,16 +241,7 @@ impl<'a> Visitor<'a> for SymbolsVisitor<'a> {
                     name: d.value.to_string(),
                     location: lsp::Location {
                         uri,
-                        range: lsp::Range {
-                            start: lsp::Position {
-                                line: d.loc.start.line - 1,
-                                character: d.loc.start.column - 1,
-                            },
-                            end: lsp::Position {
-                                line: d.loc.end.line - 1,
-                                character: d.loc.end.column - 1,
-                            },
-                        },
+                        range: d.loc.clone().into(),
                     },
                     tags: None,
                     deprecated: None,
@@ -364,16 +255,7 @@ impl<'a> Visitor<'a> for SymbolsVisitor<'a> {
                     name: b.value.to_string(),
                     location: lsp::Location {
                         uri,
-                        range: lsp::Range {
-                            start: lsp::Position {
-                                line: b.loc.start.line - 1,
-                                character: b.loc.start.column - 1,
-                            },
-                            end: lsp::Position {
-                                line: b.loc.end.line - 1,
-                                character: b.loc.end.column - 1,
-                            },
-                        },
+                        range: b.loc.clone().into(),
                     },
                     tags: None,
                     deprecated: None,
@@ -387,16 +269,7 @@ impl<'a> Visitor<'a> for SymbolsVisitor<'a> {
                     name: s.value.clone(),
                     location: lsp::Location {
                         uri,
-                        range: lsp::Range {
-                            start: lsp::Position {
-                                line: s.loc.start.line - 1,
-                                character: s.loc.start.column - 1,
-                            },
-                            end: lsp::Position {
-                                line: s.loc.end.line - 1,
-                                character: s.loc.end.column - 1,
-                            },
-                        },
+                        range: s.loc.clone().into(),
                     },
                     tags: None,
                     deprecated: None,
@@ -410,16 +283,7 @@ impl<'a> Visitor<'a> for SymbolsVisitor<'a> {
                     name: String::from("[]"),
                     location: lsp::Location {
                         uri,
-                        range: lsp::Range {
-                            start: lsp::Position {
-                                line: a.loc.start.line - 1,
-                                character: a.loc.start.column - 1,
-                            },
-                            end: lsp::Position {
-                                line: a.loc.end.line - 1,
-                                character: a.loc.end.column - 1,
-                            },
-                        },
+                        range: a.loc.clone().into(),
                     },
                     tags: None,
                     deprecated: None,


### PR DESCRIPTION
This patch goes back to using the features tagged as "lsp" from libflux,
as the library compatibility issues have been resolved.