### PR TITLE
feat: add support for semantic warnings

### DIFF
--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -29,7 +29,11 @@ fn get_analyzer() -> Result<
     LspError,
 > {
     match flux::new_semantic_analyzer(
-        flux::semantic::AnalyzerConfig::default(),
+        flux::semantic::AnalyzerConfig {
+            features: vec![
+                flux::semantic::Feature::UnusedSymbolWarnings,
+            ],
+        },
     ) {
         Ok(analyzer) => Ok(analyzer),
         Err(err) => {


### PR DESCRIPTION
This patch adds support for showing warnings found during semantic
analysis. The only supported warning at this time is a warning for
unused symbols.