### PR TITLE
refactor: rewrite/move completion code

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -96,14 +96,14 @@ pub(crate) fn walk_package(
 pub(crate) trait Completable {
     fn completion_item(
         &self,
-        imports: &Vec<Import>,
+        imports: &[Import],
     ) -> lsp::CompletionItem;
 }
 
 impl Completable for FunctionResult {
     fn completion_item(
         &self,
-        imports: &Vec<Import>,
+        imports: &[Import],
     ) -> lsp::CompletionItem {
         let mut additional_text_edits = vec![];
 
@@ -151,7 +151,7 @@ impl Completable for FunctionResult {
 impl Completable for CompletionVarResult {
     fn completion_item(
         &self,
-        _imports: &Vec<Import>,
+        _imports: &[Import],
     ) -> lsp::CompletionItem {
         lsp::CompletionItem {
             label: format!("{} (self)", self.name),
@@ -429,7 +429,7 @@ impl VarResult {
 impl Completable for VarResult {
     fn completion_item(
         &self,
-        _imports: &Vec<Import>,
+        _imports: &[Import],
     ) -> lsp::CompletionItem {
         lsp::CompletionItem {
             label: format!("{} ({})", self.name, self.package),
@@ -553,7 +553,7 @@ impl UserFunctionResult {
 impl Completable for UserFunctionResult {
     fn completion_item(
         &self,
-        _imports: &Vec<Import>,
+        _imports: &[Import],
     ) -> lsp::CompletionItem {
         lsp::CompletionItem {
             label: format!("{} (self)", self.name),

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -100,16 +100,6 @@ pub(crate) trait Completable {
     ) -> lsp::CompletionItem;
 }
 
-// Reports if the needle has a fuzzy match with the haystack.
-//
-// It is assumed that the haystack is the name of an identifier and the needle is a partial
-// identifier.
-pub fn fuzzy_match(haystack: &str, needle: &str) -> bool {
-    return haystack
-        .to_lowercase()
-        .contains(needle.to_lowercase().as_str());
-}
-
 impl Completable for FunctionResult {
     fn completion_item(
         &self,

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -48,7 +48,7 @@ fn get_function_params<'a>(
     )
 }
 
-pub (crate) fn walk_package(
+pub(crate) fn walk_package(
     package: &str,
     list: &mut Vec<Box<dyn Completable>>,
     t: &MonoType,
@@ -245,7 +245,7 @@ fn follow_function_pipes(c: &CallExpr) -> &MonoType {
     &c.typ
 }
 
-pub (crate) struct CompletableObjectFinderVisitor<'a> {
+pub(crate) struct CompletableObjectFinderVisitor<'a> {
     name: &'a str,
     pub completables: Vec<Arc<dyn Completable>>,
 }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -847,7 +847,7 @@ pub fn find_completions(
 ) -> lsp::CompletionList {
     let position = params.text_document_position.position;
 
-    let walker = AstNode::File(&ast_pkg.files[0]);
+    let walker = AstNode::Package(&ast_pkg);
     let mut visitor = NodeFinderVisitor::new(position);
 
     walk(&mut visitor, walker);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -972,14 +972,18 @@ impl LanguageServer for LspServer {
             }
         };
 
-        let items = completion::find_completions(
+        let completion_list = completion::find_completions(
             params,
             contents.as_str(),
             &ast_pkg,
             &sem_pkg,
         );
 
-        Ok(Some(lsp::CompletionResponse::List(items)))
+        if completion_list.items.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(lsp::CompletionResponse::List(completion_list)))
+        }
     }
 
     async fn semantic_tokens_full(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1007,7 +1007,6 @@ impl LanguageServer for LspServer {
                                     key.clone(),
                                 )),
                                 filter_text: Some(package_name.into()),
-                                // Could this be an import alias? See PackageResult Completable impl
                                 insert_text: Some(key.clone()),
                                 insert_text_format: Some(lsp::InsertTextFormat::PLAIN_TEXT),
                                 kind: Some(lsp::CompletionItemKind::MODULE),
@@ -1156,12 +1155,10 @@ impl LanguageServer for LspServer {
                                 walker,
                             );
 
-                            let info = completion::CompletionInfo {
-                                imports: completion::get_imports(&sem_pkg),
-                            };
+                            let imports = completion::get_imports(&sem_pkg);
                             vec![
-                                visitor.completables.iter().map(|completable| completable.completion_item(&info)).collect::<Vec<lsp::CompletionItem>>(),
-                                list.iter().map(|completable| completable.completion_item(&info)).collect(),
+                                visitor.completables.iter().map(|completable| completable.completion_item(&imports)).collect::<Vec<lsp::CompletionItem>>(),
+                                list.iter().map(|completable| completable.completion_item(&imports)).collect(),
                             ].into_iter().flatten().collect()
                         }
                         _ => return Ok(None),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -980,10 +980,11 @@ impl LanguageServer for LspServer {
             }
         };
 
-        let position = params.text_document_position.position.clone();
         let walker = flux::ast::walk::Node::Package(&ast_pkg);
         let mut visitor =
-            crate::visitors::ast::NodeFinderVisitor::new(position);
+            crate::visitors::ast::NodeFinderVisitor::new(
+                params.text_document_position.position,
+            );
 
         flux::ast::walk::walk(&mut visitor, walker);
 
@@ -1060,7 +1061,7 @@ impl LanguageServer for LspServer {
                                     lsp::CompletionItem {
                                         label: format!("{} ({})", key, "prelude"),
                                         detail: Some("Array".into()),
-                                        documentation: Some(lsp::Documentation::String(format!("from prelude"))),
+                                        documentation: Some(lsp::Documentation::String("from prelude".into())),
                                         filter_text: Some(key.into()),
                                         insert_text: Some(key.into()),
                                         insert_text_format: Some(
@@ -1089,7 +1090,7 @@ impl LanguageServer for LspServer {
                                             BuiltinType::Regexp => "Regular Expression".into(),
                                             BuiltinType::Time => "Time".into(),
                                         }),
-                                        documentation: Some(lsp::Documentation::String(format!("from prelude"))),
+                                        documentation: Some(lsp::Documentation::String("from prelude".into())),
                                         filter_text: Some(key.into()),
                                         insert_text: Some(key.into()),
                                         insert_text_format: Some(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1015,7 +1015,7 @@ impl LanguageServer for LspServer {
                             }
                         }).collect()
                         } else {
-                            vec![]
+                            return Ok(None);
                         };
 
                     let builtin_completions: Vec<
@@ -1096,7 +1096,7 @@ impl LanguageServer for LspServer {
                             }
                         }).collect()
                     } else {
-                        vec![]
+                        return Ok(None)
                     };
 
                     vec![stdlib_completions, builtin_completions]
@@ -1181,8 +1181,7 @@ impl LanguageServer for LspServer {
                                 &params, &sem_pkg, call,
                             )
                         }
-                        Some(_) => vec![],
-                        None => vec![],
+                        Some(_) | None => return Ok(None),
                     }
                 }
                 AstNode::StringLit(_) => {
@@ -1201,7 +1200,7 @@ impl LanguageServer for LspServer {
                                     (crate::shared::get_package_name(path).expect("Previous filter failed.").into(), path.clone())
                                 }).collect()
                                 } else {
-                                    vec![]
+                                    return Ok(None);
                                 };
                             let imports =
                                 completion::get_imports(&sem_pkg);
@@ -1229,8 +1228,7 @@ impl LanguageServer for LspServer {
                             }).collect()
                         }
                         // This is where bucket/measurement/field/tag completion will occur.
-                        Some(_) => vec![],
-                        None => vec![],
+                        Some(_) | None => return Ok(None),
                     }
                 }
                 _ => return Ok(None),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -7,8 +7,8 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use flux::ast::Expression as AstExpression;
 use flux::ast::walk::Node as AstNode;
+use flux::ast::Expression as AstExpression;
 use flux::semantic::nodes::{
     ErrorKind as SemanticNodeErrorKind, Package as SemanticPackage,
 };
@@ -1110,11 +1110,16 @@ impl LanguageServer for LspServer {
                             // XXX: rockstar (6 Jul 2022) - This is the last holdout from the previous
                             // completion code. There is a bit of indirection/cruft here that can be cleaned
                             // up when recursive support for member expressions is implemented.
-                            let mut list: Vec<Box<dyn completion::Completable>> = vec![];
+                            let mut list: Vec<
+                                Box<dyn completion::Completable>,
+                            > = vec![];
                             if let Some(env) = flux::imports() {
-                                if let Some(import) = completion::get_imports(&sem_pkg)
-                                    .iter()
-                                    .find(|x| x.alias == identifier.name)
+                                if let Some(import) =
+                                    completion::get_imports(&sem_pkg)
+                                        .iter()
+                                        .find(|x| {
+                                            x.alias == identifier.name
+                                        })
                                 {
                                     for (key, val) in env.iter() {
                                         if *key == import.path {
@@ -1155,7 +1160,8 @@ impl LanguageServer for LspServer {
                                 walker,
                             );
 
-                            let imports = completion::get_imports(&sem_pkg);
+                            let imports =
+                                completion::get_imports(&sem_pkg);
                             vec![
                                 visitor.completables.iter().map(|completable| completable.completion_item(&imports)).collect::<Vec<lsp::CompletionItem>>(),
                                 list.iter().map(|completable| completable.completion_item(&imports)).collect(),
@@ -1186,16 +1192,17 @@ impl LanguageServer for LspServer {
                         .map(|parent| &parent.node);
                     match parent {
                         Some(AstNode::ImportDeclaration(_)) => {
-                            let infos: Vec<(String, String)> = if let Some(env) = flux::imports() {
-                                env.iter().filter(|(path, _val)| {
+                            let infos: Vec<(String, String)> =
+                                if let Some(env) = flux::imports() {
+                                    env.iter().filter(|(path, _val)| {
                                     crate::shared::get_package_name(path).is_some()
                                 }).map(|(path, _val)| {
                                     #[allow(clippy::expect_used)]
                                     (crate::shared::get_package_name(path).expect("Previous filter failed.").into(), path.clone())
                                 }).collect()
-                            } else {
-                                vec![]
-                            };
+                                } else {
+                                    vec![]
+                                };
                             let imports =
                                 completion::get_imports(&sem_pkg);
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1104,7 +1104,7 @@ impl LanguageServer for LspServer {
                             }
                         }).collect()
                     } else {
-                        return Ok(None)
+                        return Ok(None);
                     };
 
                     vec![stdlib_completions, builtin_completions]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1054,10 +1054,6 @@ impl LanguageServer for LspServer {
                                     }
                                 }
                                 MonoType::Collection(_collection) => {
-                                    // name: key
-                                    // package: PRELUDE_PACKAGE
-                                    // package_name: None,
-                                    // var_type VarType::Array
                                     lsp::CompletionItem {
                                         label: format!("{} ({})", key, "prelude"),
                                         detail: Some("Array".into()),
@@ -1073,10 +1069,6 @@ impl LanguageServer for LspServer {
                                     }
                                 }
                                 MonoType::Builtin(builtin) => {
-                                    // name: key
-                                    // package: PRELUDE_PACKAGE
-                                    // package_name: None,
-                                    // var_type VarType::from(*b)
                                     lsp::CompletionItem {
                                         label: format!("{} ({})", key, "prelude"),
                                         detail: Some(match *builtin {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -957,6 +957,12 @@ impl LanguageServer for LspServer {
         let key = &params.text_document_position.text_document.uri;
 
         let contents = self.get_document(key)?;
+        let ast_pkg = match self.store.get_ast_package(&key) {
+            Ok(pkg) => pkg,
+            Err(err) => {
+                return Err(err.into());
+            }
+        };
         let sem_pkg = match self.store.get_semantic_package(
             &params.text_document_position.text_document.uri,
         ) {
@@ -969,11 +975,11 @@ impl LanguageServer for LspServer {
         let items = completion::find_completions(
             params,
             contents.as_str(),
+            &ast_pkg,
             &sem_pkg,
         );
 
-        let response = lsp::CompletionResponse::List(items);
-        Ok(Some(response))
+        Ok(Some(lsp::CompletionResponse::List(items)))
     }
 
     async fn semantic_tokens_full(

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1445,7 +1445,6 @@ x = 1
 }
 
 #[test]
-#[ignore]
 async fn test_package_completion() {
     let fluxscript = r#"import "sql"
 
@@ -1499,7 +1498,6 @@ sql.
 }
 
 #[test]
-#[ignore]
 async fn test_import_completion() {
     let fluxscript = r#"
 import "
@@ -1632,7 +1630,6 @@ x = 1
 }
 
 #[test]
-#[ignore]
 async fn test_variable_completion() {
     let fluxscript = r#"import "strings"
 import "csv"
@@ -1750,7 +1747,6 @@ errorCounts
 }
 
 #[test]
-#[ignore]
 async fn test_option_object_members_completion() {
     let fluxscript = r#"import "strings"
 import "csv"
@@ -1820,7 +1816,6 @@ ab = 10
 }
 
 #[test]
-#[ignore]
 async fn test_option_function_completion() {
     let fluxscript = r#"import "strings"
 import "csv"
@@ -1964,7 +1959,6 @@ ab = 10
 }
 
 #[test]
-#[ignore]
 async fn test_object_param_completion() {
     let fluxscript = r#"obj = {
     func: (name, age) => name + age
@@ -2014,7 +2008,6 @@ obj.func(
 }
 
 #[test]
-#[ignore]
 async fn test_param_completion() {
     let fluxscript = r#"import "csv"
 
@@ -2086,7 +2079,6 @@ csv.from(
 }
 
 #[test]
-#[ignore]
 async fn test_param_completion_2() {
     let fluxscript = r#"import "csv"
 
@@ -2135,7 +2127,6 @@ csv.from(
 }
 
 #[test]
-#[ignore]
 async fn test_param_completion_3() {
     let fluxscript = r#"import "csv"
 
@@ -2183,7 +2174,6 @@ x = 1
 }
 
 #[test]
-#[ignore]
 async fn test_options_completion() {
     let fluxscript = r#"import "strings"
 import "csv"
@@ -2512,7 +2502,6 @@ async fn test_rename_invalid() {
 // don't add it back in, but also serves as documentation that this was a conscious
 // choice, as the user experience was not good.
 #[test]
-#[ignore]
 async fn test_package_completion_when_it_is_not_imported() {
     let fluxscript = r#"sql"#;
     let server = create_server();
@@ -2564,7 +2553,6 @@ async fn test_package_completion_when_it_is_not_imported() {
 }
 
 #[test]
-#[ignore]
 async fn test_package_completion_when_it_is_imported() {
     let fluxscript = r#"import "sql"
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1497,6 +1497,60 @@ sql.
     };
 }
 
+/// When completing package member names, support import aliases.
+#[test]
+async fn test_package_completion_with_alias() {
+    let fluxscript = r#"import sekwel "sql"
+
+sekwel.
+   // ^
+"#;
+    let server = create_server();
+    open_file(&server, fluxscript.to_string(), None).await;
+
+    let params = lsp::CompletionParams {
+        text_document_position: lsp::TextDocumentPositionParams {
+            text_document: lsp::TextDocumentIdentifier {
+                uri: lsp::Url::parse("file:///home/user/file.flux")
+                    .unwrap(),
+            },
+            position: position_of(fluxscript),
+        },
+        work_done_progress_params: lsp::WorkDoneProgressParams {
+            work_done_token: None,
+        },
+        partial_result_params: lsp::PartialResultParams {
+            partial_result_token: None,
+        },
+        context: Some(lsp::CompletionContext {
+            trigger_kind:
+                lsp::CompletionTriggerKind::TRIGGER_CHARACTER,
+            trigger_character: Some(".".to_string()),
+        }),
+    };
+
+    let result =
+        server.completion(params.clone()).await.unwrap().unwrap();
+
+    let expected_labels: Vec<String> = vec!["to", "from"]
+        .into_iter()
+        .map(|x| x.into())
+        .collect::<Vec<String>>();
+
+    match result {
+        lsp::CompletionResponse::List(l) => {
+            assert_eq!(
+                expected_labels,
+                l.items
+                    .iter()
+                    .map(|x| x.label.clone())
+                    .collect::<Vec<String>>()
+            );
+        }
+        _ => unreachable!(),
+    };
+}
+
 #[test]
 async fn test_import_completion() {
     let fluxscript = r#"
@@ -1815,6 +1869,9 @@ ab = 10
     assert_eq!(expected, labels);
 }
 
+// XXX: rockstar (6 Jul 2022) - Is this test correct? I think it's not. It's
+// saying that when there's a `now`, and you type `n` it should complete to
+// literally everything? That makes no sense.
 #[test]
 async fn test_option_function_completion() {
     let fluxscript = r#"import "strings"

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1445,6 +1445,7 @@ x = 1
 }
 
 #[test]
+#[ignore]
 async fn test_package_completion() {
     let fluxscript = r#"import "sql"
 
@@ -1498,6 +1499,7 @@ sql.
 }
 
 #[test]
+#[ignore]
 async fn test_import_completion() {
     let fluxscript = r#"
 import "
@@ -1630,6 +1632,7 @@ x = 1
 }
 
 #[test]
+#[ignore]
 async fn test_variable_completion() {
     let fluxscript = r#"import "strings"
 import "csv"
@@ -1747,6 +1750,7 @@ errorCounts
 }
 
 #[test]
+#[ignore]
 async fn test_option_object_members_completion() {
     let fluxscript = r#"import "strings"
 import "csv"
@@ -1816,6 +1820,7 @@ ab = 10
 }
 
 #[test]
+#[ignore]
 async fn test_option_function_completion() {
     let fluxscript = r#"import "strings"
 import "csv"
@@ -1959,6 +1964,7 @@ ab = 10
 }
 
 #[test]
+#[ignore]
 async fn test_object_param_completion() {
     let fluxscript = r#"obj = {
     func: (name, age) => name + age
@@ -2008,6 +2014,7 @@ obj.func(
 }
 
 #[test]
+#[ignore]
 async fn test_param_completion() {
     let fluxscript = r#"import "csv"
 
@@ -2079,6 +2086,7 @@ csv.from(
 }
 
 #[test]
+#[ignore]
 async fn test_param_completion_2() {
     let fluxscript = r#"import "csv"
 
@@ -2127,6 +2135,7 @@ csv.from(
 }
 
 #[test]
+#[ignore]
 async fn test_param_completion_3() {
     let fluxscript = r#"import "csv"
 
@@ -2174,6 +2183,7 @@ x = 1
 }
 
 #[test]
+#[ignore]
 async fn test_options_completion() {
     let fluxscript = r#"import "strings"
 import "csv"
@@ -2502,6 +2512,7 @@ async fn test_rename_invalid() {
 // don't add it back in, but also serves as documentation that this was a conscious
 // choice, as the user experience was not good.
 #[test]
+#[ignore]
 async fn test_package_completion_when_it_is_not_imported() {
     let fluxscript = r#"sql"#;
     let server = create_server();
@@ -2553,6 +2564,7 @@ async fn test_package_completion_when_it_is_not_imported() {
 }
 
 #[test]
+#[ignore]
 async fn test_package_completion_when_it_is_imported() {
     let fluxscript = r#"import "sql"
 

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -124,28 +124,6 @@ pub fn create_function_signature(
     )
 }
 
-pub struct PackageInfo {
-    pub name: String,
-    pub path: String,
-}
-
-pub fn get_package_infos() -> Vec<PackageInfo> {
-    let mut result: Vec<PackageInfo> = vec![];
-
-    if let Some(env) = imports() {
-        for (path, _val) in env.iter() {
-            if let Some(name) = get_package_name(path) {
-                result.push(PackageInfo {
-                    name: name.into(),
-                    path: path.to_string(),
-                })
-            }
-        }
-    }
-
-    result
-}
-
 fn record_fields(
     this: &Record,
 ) -> impl Iterator<Item = &flux::semantic::types::Property> {

--- a/src/visitors/ast.rs
+++ b/src/visitors/ast.rs
@@ -24,6 +24,9 @@ impl<'a> NodeFinderVisitor<'a> {
 
 impl<'a> walk::Visitor<'a> for NodeFinderVisitor<'a> {
     fn visit(&mut self, node: walk::Node<'a>) -> bool {
+        if let walk::Node::Package(_) = node {
+            return true;
+        }
         if crate::lsp::position_in_range(
             &self.position,
             &node.base().location.clone().into(),


### PR DESCRIPTION
First things first: this patch is probably bigger than is normally appropriate
for a code review. In this case, it was unavoidable, as every time we tried to
make small changes to make this code better, it just kinda made things worse
or the attempt was abandoned. The layers and layers and layers of indirection
are just too tangled up to not make this change atomically. Even in this state,
we still didn't get all the indirection, but we've narrowed it down to a single
narrow code path.

You can tell this is a refactor because it doesn't touch any existing tests. I
found a test I think is outright wrong, and I found functionality that we
likely don't want, and I added a test, but this code doesn't change the actual
experience of this code. It's complex enough without adding features or fixes.

Some benefits from this refactor:

- _code reads more procedurally now_ - most use of the `Completable` trait has
  been removed, and much of the layers of indirection have been removed. This
  means we have similar code in a few places, but not _identical_ code. The
  The abstractions, in these cases, were causing confusion while not actually
  helping to remove complexity.
- _reduced number of `for` loops_ - Rust seems to be much better and optimizing
  iterators than it is at `for` loops, and as such, `for` doesn't get used a
  lot.
- _construction of completion items filtered only to matching identifiers_ - I
  was a bit shocked to find that "completables" were being constructed before
  ever checking that they would be converted into `CompletionItem` structs. In
  this change, we filter anything irrelevant to the completion before we ever
  go to construct the `CompletionItem` instances.
- _tech debt notes and comments added in narrow spaces_ - with the changes in
  this patch, there were many times I wanted to get distracted to fix a bug or
  address an issue, or add a feature. In an effort to prevent that, I left
  `XXX` comments for remaining technical debt, passing comments for where
  future features should be implemented, and pointers for where to look for
  more information. This should make the changes linked from the closing issue
  easier to stomach.

At this point, I feel comfortable moving on with full function snippet support,
and all the remaining legacy completion code can be done piecemeal as time
permits.

Closes #494