### PR TITLE
refactor: create semantic/ast walk macros

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -24,10 +24,10 @@ const PRELUDE_PACKAGE: &str = "prelude";
 pub fn get_imports(
     pkg: &flux::semantic::nodes::Package,
 ) -> Vec<Import> {
-    let walker = flux::semantic::walk::Node::Package(pkg);
-    let mut visitor = ImportFinderVisitor::default();
-
-    flux::semantic::walk::walk(&mut visitor, walker);
+    let visitor = crate::walk_semantic_package!(
+        ImportFinderVisitor::default(),
+        pkg
+    );
     visitor.imports
 }
 
@@ -614,13 +614,10 @@ pub fn complete_call_expr(
             ));
 
             let user_functions = {
-                let walker =
-                    flux::semantic::walk::Node::Package(sem_pkg);
-                let mut visitor =
-                    FunctionFinderVisitor::new(position);
-
-                flux::semantic::walk::walk(&mut visitor, walker);
-
+                let visitor = crate::walk_semantic_package!(
+                    FunctionFinderVisitor::new(position),
+                    sem_pkg
+                );
                 visitor.functions
             };
             completion_params.extend(get_function_params(
@@ -635,13 +632,10 @@ pub fn complete_call_expr(
                     stdlib::get_package_functions(&ident.name);
 
                 let object_functions: Vec<Function> = {
-                    let walker =
-                        flux::semantic::walk::Node::Package(sem_pkg);
-                    let mut visitor =
-                        ObjectFunctionFinderVisitor::default();
-
-                    flux::semantic::walk::walk(&mut visitor, walker);
-
+                    let visitor = crate::walk_semantic_package!(
+                        ObjectFunctionFinderVisitor::default(),
+                        sem_pkg
+                    );
                     visitor
                         .results
                         .into_iter()

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -20,11 +20,10 @@ use super::visitors::semantic::{
 pub(crate) fn experimental_lint(
     pkg: &Package,
 ) -> Vec<(Option<String>, lsp::Diagnostic)> {
-    let walker = flux::semantic::walk::Node::Package(pkg);
-    let mut visitor = ExperimentalDiagnosticVisitor::default();
-
-    flux::semantic::walk::walk(&mut visitor, walker);
-
+    let visitor = crate::walk_semantic_package!(
+        ExperimentalDiagnosticVisitor::default(),
+        pkg
+    );
     visitor.diagnostics
 }
 
@@ -36,22 +35,20 @@ pub(crate) fn experimental_lint(
 pub(crate) fn contrib_lint(
     pkg: &Package,
 ) -> Vec<(Option<String>, lsp::Diagnostic)> {
-    let walker = flux::semantic::walk::Node::Package(pkg);
-    let mut visitor = ContribDiagnosticVisitor::default();
-
-    flux::semantic::walk::walk(&mut visitor, walker);
-
+    let visitor = crate::walk_semantic_package!(
+        ContribDiagnosticVisitor::default(),
+        pkg
+    );
     visitor.diagnostics
 }
 
 pub(crate) fn no_influxdb_identifiers(
     pkg: &Package,
 ) -> Vec<(Option<String>, lsp::Diagnostic)> {
-    let walker = flux::semantic::walk::Node::Package(pkg);
-    let mut visitor = InfluxDBIdentifierDiagnosticVisitor::default();
-
-    flux::semantic::walk::walk(&mut visitor, walker);
-
+    let visitor = crate::walk_semantic_package!(
+        InfluxDBIdentifierDiagnosticVisitor::default(),
+        pkg
+    );
     visitor.diagnostics
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,27 @@ extern crate pretty_assertions;
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 pub use server::LspServer;
+
+#[macro_export]
+macro_rules! walk_ast_package {
+    ($visitor:expr, $package:ident) => {{
+        let mut visitor = $visitor;
+        flux::ast::walk::walk(
+            &mut visitor,
+            flux::ast::walk::Node::Package(&$package),
+        );
+        visitor
+    }};
+}
+
+#[macro_export]
+macro_rules! walk_semantic_package {
+    ($visitor:expr, $package:ident) => {{
+        let mut visitor_instance = $visitor;
+        flux::semantic::walk::walk(
+            &mut visitor_instance,
+            flux::semantic::walk::Node::Package(&$package),
+        );
+        visitor_instance
+    }};
+}


### PR DESCRIPTION
This patch introduces a set of macros that do a very common thing: wrap
the ast/semantic graph in a walk node, and then walk that node with a
visitor.