### PR TITLE
refactor: audit and remove unnecessary mutability

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -153,17 +153,22 @@ pub fn get_stdlib_functions() -> Vec<FunctionInfo> {
 }
 
 pub fn get_builtin_functions() -> Vec<Function> {
-    let mut list = vec![];
-
     if let Some(env) = prelude() {
-        for (key, val) in env.iter() {
-            if let MonoType::Fun(f) = &val.expr {
-                list.push(Function::new(key.to_string(), f));
-            }
-        }
+        env.iter()
+            .filter(|(_key, val)| {
+                matches!(&val.expr, MonoType::Fun(_))
+            })
+            .map(|(key, val)| match &val.expr {
+                MonoType::Fun(f) => Function::new(key.into(), f),
+                _ => unreachable!(
+                    "Previous filter call failed. Got: {}",
+                    val.expr
+                ),
+            })
+            .collect()
+    } else {
+        vec![]
     }
-
-    list
 }
 
 pub struct FunctionInfo {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -799,15 +799,11 @@ impl LanguageServer for LspServer {
             })
             .collect::<Vec<lsp::TextEdit>>();
 
-        let mut changes = HashMap::new();
-        changes.insert(key, edits);
-
-        let response = lsp::WorkspaceEdit {
-            changes: Some(changes),
+        Ok(Some(lsp::WorkspaceEdit {
+            changes: Some(HashMap::from([(key, edits)])),
             document_changes: None,
             change_annotations: None,
-        };
-        Ok(Some(response))
+        }))
     }
 
     async fn document_highlight(

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -66,9 +66,10 @@ impl Store {
         match self.backend.write() {
             Ok(mut store) => match store.entry(key) {
                 Entry::Vacant(entry) => {
-                    let mut map = HashMap::new();
-                    map.insert(val, (contents.into(), url.clone()));
-                    entry.insert(map);
+                    entry.insert(HashMap::from([(
+                        val,
+                        (contents.into(), url.clone()),
+                    )]));
                 }
                 Entry::Occupied(mut entry) => {
                     let map = entry.get_mut();


### PR DESCRIPTION
This patch is the result of an audit of all the places where mutable
values are used, and removes them where possible. In some cases, it
wasn't realistic to remove them, either because it would make the code
much less readable, or because that change would be big enough to
warrant its own patch.