### PR TITLE
chore: upgrade the version of rust

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.60"
+channel = "1.62"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown", ]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -87,9 +87,9 @@ fn find_references<'a>(
             _ => return Vec::new(),
         };
 
-        let mut path_iter = path.iter().rev();
-        let scope: walk::Node =
-            match path_iter.find_map(|n| match n {
+        let scope: walk::Node = match path
+            .iter()
+            .map(|n| match n {
                 walk::Node::FunctionExpr(f)
                     if f.params
                         .iter()
@@ -111,10 +111,12 @@ fn find_references<'a>(
                     }
                 }
                 _ => None,
-            }) {
-                Some(n) => n.to_owned(),
-                None => return Vec::new(),
-            };
+            })
+            .next()
+        {
+            Some(Some(n)) => n.to_owned(),
+            _ => return Vec::new(),
+        };
         let mut visitor =
             semantic::IdentFinderVisitor::new(name.clone());
         walk::walk(&mut visitor, scope);


### PR DESCRIPTION
Additionally, there was a new `clippy` lint introduced in 1.61 that needed to
be addressed.