### PR TITLE
chore: hide lang features behind a feature flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           name: "run lint"
           command: |
             cargo clippy --locked -- -Dclippy::all
-            cargo clippy --no-default-features --features=wasm
+            cargo clippy --no-default-features --features=wasm,fluxlang
 
   test:
     docker:
@@ -24,7 +24,7 @@ jobs:
           name: "run cargo tests"
           command: |
             cargo test --locked
-            cargo test --no-default-features --features=wasm
+            cargo test --no-default-features --features=wasm,fluxlang
 
   bench-test:
     docker:
@@ -43,7 +43,7 @@ jobs:
       - checkout
       - run:
           name: "run tests"
-          command: wasm-pack test --node -- --locked --no-default-features --features=wasm
+          command: wasm-pack test --node -- --locked --no-default-features --features=wasm,fluxlang
       - run:
           name: "run node integration tests"
           command: cd integration && BUILD_MODE=release npm run test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default = ["cmd"]
 strict = []
 cmd = ["clap", "simplelog", "tokio", "tower-service", "lspower/runtime-tokio"]
 wasm = ["futures", "js-sys", "lspower/runtime-agnostic", "tower-service", "wasm-bindgen", "wasm-bindgen-futures", "wee_alloc"]
+fluxlang = []
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,11 +1,13 @@
 #![allow(clippy::panic)]
 
+#[cfg(feature = "fluxlang")]
 mod lang;
 mod lsp;
 #[cfg(test)]
 mod tests;
 
 pub use self::lang::Flux;
+#[cfg(feature = "fluxlang")]
 pub use self::lsp::Lsp;
 
 use flux::{ast, formatter, parser};

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -6,8 +6,8 @@ mod lsp;
 #[cfg(test)]
 mod tests;
 
-pub use self::lang::Flux;
 #[cfg(feature = "fluxlang")]
+pub use self::lang::Flux;
 pub use self::lsp::Lsp;
 
 use flux::{ast, formatter, parser};


### PR DESCRIPTION
Months ago, we started thinking about an API for working with flux AST
in javascript. That work then got de-prioritized for other work. This
API is still pretty experimental, and it shouldn't ship in the default
wasm binary for now.

BREAKING CHANGE: The exported `Flux` object in the wasm is no longer
available.