### PR TITLE
feat: enable console_error_panic_hook by default

### DIFF
--- a/wasm-build.sh
+++ b/wasm-build.sh
@@ -5,14 +5,14 @@ set -e
 BUILD_MODE=${BUILD_MODE-release}
 
 BUILD_FLAG=""
-BUILD_MODE_ARGS="--no-default-features --features wasm"
+BUILD_MODE_ARGS="--no-default-features --features wasm,console_error_panic_hook"
 case $BUILD_MODE in
     "release")
         BUILD_FLAG="--release"
         ;;
     "dev")
         BUILD_FLAG="--dev"
-        BUILD_MODE_ARGS="${BUILD_MODE_ARGS},console_log,console_error_panic_hook"
+        BUILD_MODE_ARGS="${BUILD_MODE_ARGS},console_log"
         ;;
     *)
         echo "Invalid build mode: ${BUILD_MODE}"


### PR DESCRIPTION
While we were trying to shrink the size of the wasm, we removed some
infrastructure for learning about errors in the lsp. One of those is an
installed hook for catching panics and logging them (with traceback
information) to the console. The idea was that we were delivering a
binary, and we (usually) wouldn't leave debug symbols in a shipped
artifact. That decision wasn't correct. This patch re-instates that
panic hook by flipping that flag on in the build script.

Aside: While I don't think we should be careless with the size of the shipped
wasm binary, I don't believe we need to be super sensitive to it, and we
should especially not make compromises to delivering a rock solid binary.