### PR TITLE
refactor: more lang indirection and mutability removal

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -10,8 +10,8 @@ use std::iter::Iterator;
 
 const BUILTIN_PACKAGE: &str = "builtin";
 
-pub fn get_package_name(name: &str) -> Option<&str> {
-    name.split('/').last()
+pub fn get_package_name(name: &str) -> &str {
+    name.split('/').last().expect("Invalid package path/name supplied")
 }
 
 pub fn create_function_signature(
@@ -88,13 +88,11 @@ pub fn get_package_functions(name: &str) -> Vec<Function> {
 
     if let Some(env) = imports() {
         for (key, val) in env.iter() {
-            if let Some(package_name) = get_package_name(key) {
-                if package_name == name {
-                    walk_package_functions(
-                        &mut list,
-                        &val.typ().expr,
-                    );
-                }
+            if get_package_name(key) == name {
+                walk_package_functions(
+                    &mut list,
+                    &val.typ().expr,
+                );
             }
         }
     }
@@ -110,15 +108,11 @@ fn walk_functions(
     if let MonoType::Record(record) = t {
         for head in record_fields(record) {
             if let MonoType::Fun(f) = &head.v {
-                if let Some(package_name) =
-                    get_package_name(package.as_str())
-                {
-                    list.push(FunctionInfo::new(
-                        head.k.to_string(),
-                        f.as_ref(),
-                        package_name.into(),
-                    ));
-                }
+                list.push(FunctionInfo::new(
+                    head.k.to_string(),
+                    f.as_ref(),
+                    get_package_name(package.as_str()).into(),
+                ));
             }
         }
     }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -78,66 +78,64 @@ fn record_fields(
 }
 
 pub fn get_package_functions(name: &str) -> Vec<Function> {
-        STDLIB.iter()
-            .filter(|(_key, val)| {
-                matches!(&val.typ().expr, MonoType::Record(_))
-            })
-            .flat_map(|(key, val)| match &val.typ().expr {
-                MonoType::Record(record) => record_fields(record)
-                    .filter(|head| {
-                        matches!(&head.v, MonoType::Fun(_))
-                            && get_package_name(key) == name
-                    })
-                    .map(|head| match &head.v {
-                        MonoType::Fun(f) => {
-                            Function::new(head.k.to_string(), f)
-                        }
-                        _ => unreachable!("Previous filter failed"),
-                    })
-                    .collect::<Vec<Function>>(),
-                _ => unreachable!("Previous filter failer"),
-            })
-            .collect()
+    STDLIB
+        .iter()
+        .filter(|(_key, val)| {
+            matches!(&val.typ().expr, MonoType::Record(_))
+        })
+        .flat_map(|(key, val)| match &val.typ().expr {
+            MonoType::Record(record) => record_fields(record)
+                .filter(|head| {
+                    matches!(&head.v, MonoType::Fun(_))
+                        && get_package_name(key) == name
+                })
+                .map(|head| match &head.v {
+                    MonoType::Fun(f) => {
+                        Function::new(head.k.to_string(), f)
+                    }
+                    _ => unreachable!("Previous filter failed"),
+                })
+                .collect::<Vec<Function>>(),
+            _ => unreachable!("Previous filter failer"),
+        })
+        .collect()
 }
 
 pub fn get_stdlib_functions() -> Vec<FunctionInfo> {
-    let builtins: Vec<FunctionInfo> = PRELUDE.iter()
-            .filter(|(_key, val)| {
-                matches!(&val.expr, MonoType::Fun(_))
-            })
-            .map(|(key, val)| match &val.expr {
-                MonoType::Fun(f) => FunctionInfo::new(
-                    key.into(),
-                    f.as_ref(),
-                    BUILTIN_PACKAGE.into(),
-                ),
-                _ => unreachable!("Previous filter failed"),
-            })
-            .collect();
+    let builtins = PRELUDE
+        .iter()
+        .filter(|(_key, val)| matches!(&val.expr, MonoType::Fun(_)))
+        .map(|(key, val)| match &val.expr {
+            MonoType::Fun(f) => FunctionInfo::new(
+                key.into(),
+                f.as_ref(),
+                BUILTIN_PACKAGE.into(),
+            ),
+            _ => unreachable!("Previous filter failed"),
+        });
 
-    let imported: Vec<FunctionInfo> = STDLIB
-            .iter()
-            .filter(|(_key, val)| {
-                matches!(&val.typ().expr, MonoType::Record(_))
-            })
-            .flat_map(|(key, val)| match &val.typ().expr {
-                MonoType::Record(record) => record_fields(record)
-                    .filter(|property| {
-                        matches!(&property.v, MonoType::Fun(_))
-                    })
-                    .map(|property| match &property.v {
-                        MonoType::Fun(f) => FunctionInfo::new(
-                            property.k.to_string(),
-                            f.as_ref(),
-                            get_package_name(key).into(),
-                        ),
-                        _ => unreachable!("Previous filter failed"),
-                    })
-                    .collect::<Vec<FunctionInfo>>(),
-                _ => unreachable!("Previous filter failed"),
-            })
-            .collect();
-    builtins.into_iter().chain(imported.into_iter()).collect()
+    let imported = STDLIB
+        .iter()
+        .filter(|(_key, val)| {
+            matches!(&val.typ().expr, MonoType::Record(_))
+        })
+        .flat_map(|(key, val)| match &val.typ().expr {
+            MonoType::Record(record) => record_fields(record)
+                .filter(|property| {
+                    matches!(&property.v, MonoType::Fun(_))
+                })
+                .map(|property| match &property.v {
+                    MonoType::Fun(f) => FunctionInfo::new(
+                        property.k.to_string(),
+                        f.as_ref(),
+                        get_package_name(key).into(),
+                    ),
+                    _ => unreachable!("Previous filter failed"),
+                })
+                .collect::<Vec<FunctionInfo>>(),
+            _ => unreachable!("Previous filter failed"),
+        });
+    builtins.chain(imported.into_iter()).collect()
 }
 
 pub fn get_builtin_functions() -> Vec<Function> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -983,7 +983,6 @@ impl LanguageServer for LspServer {
                         lang::STDLIB.iter().filter(|(key, _val)| {
                             fuzzy_match(lang::get_package_name(key), &identifier.name)
                         }).map(|(key, _val)| {
-                            #[allow(clippy::unwrap_used)]
                             let package_name = lang::get_package_name(key);
                             lsp::CompletionItem {
                                 label: key.clone(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1110,15 +1110,15 @@ impl LanguageServer for LspServer {
                                     }
                                 } else {
                                     for (key, val) in env.iter() {
-                                            if lang::get_package_name(key)
-                                                == identifier.name
-                                            {
-                                                completion::walk_package(
-                                                    key,
-                                                    &mut list,
-                                                    &val.typ().expr,
-                                                );
-                                            }
+                                        if lang::get_package_name(key)
+                                            == identifier.name
+                                        {
+                                            completion::walk_package(
+                                                key,
+                                                &mut list,
+                                                &val.typ().expr,
+                                            );
+                                        }
                                     }
                                 }
                             }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -539,17 +539,20 @@ csv.from(
         server.signature_help(params).await.unwrap().unwrap();
 
     let expected_signature_labels: Vec<String> = vec![
-            "from()",
-            "from(csv: $csv)",
-            "from(file: $file)",
-            "from(mode: $mode)",
-            "from(csv: $csv , file: $file)",
-            "from(csv: $csv , mode: $mode)",
-            "from(file: $file , mode: $mode)",
-            "from(csv: $csv , file: $file , mode: $mode)",
-           "from(url: $url)",
-            "from(url: $url)",
-        ].into_iter().map(|x| x.into()).collect::<Vec<String>>();
+        "from()",
+        "from(csv: $csv)",
+        "from(file: $file)",
+        "from(mode: $mode)",
+        "from(csv: $csv , file: $file)",
+        "from(csv: $csv , mode: $mode)",
+        "from(file: $file , mode: $mode)",
+        "from(csv: $csv , file: $file , mode: $mode)",
+        "from(url: $url)",
+        "from(url: $url)",
+    ]
+    .into_iter()
+    .map(|x| x.into())
+    .collect::<Vec<String>>();
 
     assert_eq!(
         expected_signature_labels,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -511,6 +511,58 @@ async fn test_signature_help() {
     assert_eq!(None, result.active_parameter);
 }
 
+/// Test signature help on imported modules
+#[test]
+async fn test_signature_help_imports() {
+    let server = create_server();
+    let fluxscript = r#"import "csv"
+csv.from(
+      // ^"#;
+    open_file(&server, fluxscript.into(), None).await;
+
+    let params = lsp::SignatureHelpParams {
+        context: None,
+        text_document_position_params:
+            lsp::TextDocumentPositionParams::new(
+                lsp::TextDocumentIdentifier::new(
+                    lsp::Url::parse("file:///home/user/file.flux")
+                        .unwrap(),
+                ),
+                position_of(fluxscript),
+            ),
+        work_done_progress_params: lsp::WorkDoneProgressParams {
+            work_done_token: None,
+        },
+    };
+
+    let result =
+        server.signature_help(params).await.unwrap().unwrap();
+
+    let expected_signature_labels: Vec<String> = vec![
+            "from()",
+            "from(csv: $csv)",
+            "from(file: $file)",
+            "from(mode: $mode)",
+            "from(csv: $csv , file: $file)",
+            "from(csv: $csv , mode: $mode)",
+            "from(file: $file , mode: $mode)",
+            "from(csv: $csv , file: $file , mode: $mode)",
+           "from(url: $url)",
+            "from(url: $url)",
+        ].into_iter().map(|x| x.into()).collect::<Vec<String>>();
+
+    assert_eq!(
+        expected_signature_labels,
+        result
+            .signatures
+            .iter()
+            .map(|x| x.label.clone())
+            .collect::<Vec<String>>()
+    );
+    assert_eq!(None, result.active_signature);
+    assert_eq!(None, result.active_parameter);
+}
+
 // If the file hasn't been opened on the server, return an error.
 #[test]
 async fn test_formatting_not_opened() {

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -183,8 +183,7 @@ impl<'a> Visitor<'a> for FoldFinderVisitor<'a> {
 #[derive(Clone, Debug)]
 pub struct Import {
     pub path: String,
-    pub initial_name: Option<String>,
-    pub alias: String,
+    pub name: String,
 }
 
 #[derive(Default)]
@@ -195,20 +194,15 @@ pub struct ImportFinderVisitor {
 impl<'a> Visitor<'a> for ImportFinderVisitor {
     fn visit(&mut self, node: Node<'a>) -> bool {
         if let Node::ImportDeclaration(import) = node {
-            let alias = match import.alias.clone() {
+            let name = match import.alias.clone() {
                 Some(alias) => alias.name.to_string(),
                 None => get_package_name(import.path.value.as_str())
-                    .unwrap_or_default()
                     .to_owned(),
             };
 
             self.imports.push(Import {
                 path: import.path.value.clone(),
-                alias,
-                initial_name: get_package_name(
-                    import.path.value.as_str(),
-                )
-                .map(|s| s.to_owned()),
+                name,
             });
         }
 


### PR DESCRIPTION
This is the final refactor patch that helped me understand the full interaction
here and what's going wrong with my current feature work. This patch removes
more indirection from functions that exist to only be called once, as well
`for` loops that required mutability and mutable parameters.

This patch seems scatter-brained, and it's true, to an extent. This area of the
code evolved in a kinda scatter-brained way, and my brain was also fried while
trying to figure this out. I'm confident, at this point, that I know the path
forward, and would like to take that path forward without littering it up with
the changes from this patch.