### PR TITLE
refactor: Provide interfaces for querying flux stdlib

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -586,21 +586,33 @@ pub fn complete_call_expr(
                     visitor.functions
                 };
 
-                vec![
-                    get_function_params(
-                        ident.name.as_str(),
-                        &lang::get_builtin_functions(),
-                        &provided,
-                    ),
-                    get_function_params(
+                let initial_params: Vec<(String, Option<MonoType>)> =
+                    match lang::UNIVERSE.function(ident.name.as_str())
+                    {
+                        Some(function) => function
+                            .parameters()
+                            .iter()
+                            .filter(|(k, _)| {
+                                !provided
+                                    .clone()
+                                    .iter()
+                                    .any(|p| p == k)
+                            })
+                            .map(|(k, v)| {
+                                (k.to_owned(), Some(v.to_owned()))
+                            })
+                            .collect(),
+                        None => vec![],
+                    };
+
+                initial_params
+                    .into_iter()
+                    .chain(get_function_params(
                         ident.name.as_str(),
                         &user_functions,
                         &provided,
-                    ),
-                ]
-                .into_iter()
-                .flatten()
-                .collect()
+                    ))
+                    .collect()
             }
             Expression::Member(me) => {
                 if let Expression::Identifier(ident) = &me.object {

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -724,7 +724,6 @@ pub fn complete_call_expr(
         .collect()
 }
 
-
 #[derive(Clone)]
 pub struct CompletionFunction {
     pub name: String,

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -641,7 +641,7 @@ pub fn complete_call_expr(
                     let initial_params: Vec<(
                         String,
                         Option<MonoType>,
-                    )> = match lang::STDLIB_.package(&ident.name) {
+                    )> = match lang::STDLIB.package(&ident.name) {
                         Some(package) => {
                             match package.function(key) {
                                 Some(function) => function

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -190,8 +190,16 @@ fn create_function_result(
         if let MonoType::Fun(fun) = &f.typ {
             return Some(UserFunctionResult {
                 name: name.into(),
-                required_args: fun.req.keys().map(String::from).collect(),
-                optional_args: fun.opt.keys().map(String::from).collect(),
+                required_args: fun
+                    .req
+                    .keys()
+                    .map(String::from)
+                    .collect(),
+                optional_args: fun
+                    .opt
+                    .keys()
+                    .map(String::from)
+                    .collect(),
                 signature: create_function_signature(fun),
             });
         }
@@ -722,7 +730,6 @@ pub fn complete_call_expr(
         })
         .collect()
 }
-
 
 #[derive(Clone)]
 pub struct CompletionFunction {

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -231,12 +231,6 @@ impl Function {
     }
 }
 
-pub fn get_package_name(name: &str) -> &str {
-    name.split('/')
-        .last()
-        .expect("Invalid package path/name supplied")
-}
-
 pub fn create_function_signature(
     f: &flux::semantic::types::Function,
 ) -> String {

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -156,8 +156,10 @@ impl Function {
     pub fn signature_information(
         &self,
     ) -> Vec<lsp::SignatureInformation> {
-        let required: Vec<String> = self.expr.req.keys().map(String::from).collect();
-        let optional: Vec<String> = self.expr.opt.keys().map(String::from).collect();
+        let required: Vec<String> =
+            self.expr.req.keys().map(String::from).collect();
+        let optional: Vec<String> =
+            self.expr.opt.keys().map(String::from).collect();
         let mut result = vec![required.clone()];
 
         let mut combos = vec![];
@@ -178,7 +180,8 @@ impl Function {
         }
 
         result
-            .into_iter().map(|arguments| lsp::SignatureInformation {
+            .into_iter()
+            .map(|arguments| lsp::SignatureInformation {
                 label: {
                     let args = arguments
                         .iter()

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -15,7 +15,7 @@ const BUILTIN_PACKAGE: &str = "builtin";
 lazy_static::lazy_static! {
     pub static ref PRELUDE: flux::semantic::PackageExports = flux::prelude().expect("Could not initialize prelude.");
     pub static ref STDLIB: flux::semantic::import::Packages = flux::imports().expect("Could not initialize stdlib.");
-    static ref STDLIB_: Stdlib = Stdlib(flux::imports().expect("Could not initialize stdlib."));
+    pub static ref STDLIB_: Stdlib = Stdlib(flux::imports().expect("Could not initialize stdlib."));
     pub static ref UNIVERSE: Package = Package::new("universe", flux::prelude().expect("Could not initialize prelude"));
 }
 
@@ -23,11 +23,11 @@ lazy_static::lazy_static! {
 ///
 /// The flux stdlib is a collection of packages, and this interface
 /// provides a method for querying those packages.
-struct Stdlib(flux::semantic::import::Packages);
+pub struct Stdlib(flux::semantic::import::Packages);
 
 impl Stdlib {
     /// Get all packages from the stdlib.
-    fn packages(&self) -> Vec<Package> {
+    pub fn packages(&self) -> Vec<Package> {
         self.0
             .iter()
             .map(|(path, package)| {
@@ -37,7 +37,7 @@ impl Stdlib {
     }
 
     /// Get a package by path from the stdlib.
-    fn package(&self, path: &str) -> Option<Package> {
+    pub fn package(&self, path: &str) -> Option<Package> {
         self.packages()
             .iter()
             .filter(|package| package.path == path)
@@ -116,7 +116,7 @@ impl Package {
 /// The contract here is that all public interfaces here return lsp data
 /// structures. Any deviation from that contract should be considered technical
 /// debt and handled accordingly.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Function_ {
     pub name: String,
     expr: flux::semantic::types::Function,

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -183,52 +183,6 @@ impl Function {
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect()
     }
-
-    fn signature(&self) -> String {
-        let required = self
-            .expr
-            .req
-            .iter()
-            // Sort args with BTree
-            .collect::<BTreeMap<_, _>>()
-            .iter()
-            .map(|(&k, &v)| (k.clone(), format!("{}", v)))
-            .collect::<Vec<_>>();
-
-        let optional = self
-            .expr
-            .opt
-            .iter()
-            // Sort args with BTree
-            .collect::<BTreeMap<_, _>>()
-            .iter()
-            .map(|(&k, &v)| (k.clone(), format!("{}", v.typ)))
-            .collect::<Vec<_>>();
-
-        let pipe = match &self.expr.pipe {
-            Some(pipe) => {
-                if pipe.k == "<-" {
-                    vec![(pipe.k.clone(), format!("{}", pipe.v))]
-                } else {
-                    vec![(
-                        format!("<-{}", pipe.k),
-                        format!("{}", pipe.v),
-                    )]
-                }
-            }
-            None => vec![],
-        };
-
-        format!(
-            "({}) -> {}",
-            pipe.iter()
-                .chain(required.iter().chain(optional.iter()))
-                .map(|arg| format!("{}:{}", arg.0, arg.1))
-                .collect::<Vec<_>>()
-                .join(", "),
-            self.expr.retn
-        )
-    }
 }
 
 pub fn create_function_signature(

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -31,10 +31,7 @@ impl Stdlib {
 
     /// Get a package by path from the stdlib.
     pub fn package(&self, path: &str) -> Option<Package> {
-        self.packages()
-            .filter(|package| package.path == path)
-            .map(|package| package.clone())
-            .next()
+        self.packages().find(|package| package.path == path)
     }
 
     /// Get all packages that fuzzy match on the needle.
@@ -112,9 +109,8 @@ impl Package {
     pub fn function(&self, name: &str) -> Option<Function> {
         self.functions()
             .iter()
-            .filter(|function| function.name == name)
-            .map(|function| function.clone())
-            .next()
+            .find(|function| function.name == name)
+            .cloned()
     }
 }
 
@@ -170,7 +166,7 @@ impl Function {
                     .collect();
             combos.extend(c);
         }
-        combos.push(optional.clone());
+        combos.push(optional);
 
         for l in combos {
             let mut arguments = required.clone();

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,5 +1,10 @@
 /// Tools for working with the Flux language and APIs for bridging
 /// the gap between Flux language data structures and the needs of the LSP.
+///
+/// The purpose of this module is to be the single source of truth for all
+/// things libflux. No other part of this library should
+use std::cmp::Ordering;
+
 use flux::semantic::types::{MonoType, Record};
 use lspower::lsp;
 
@@ -10,6 +15,193 @@ const BUILTIN_PACKAGE: &str = "builtin";
 lazy_static::lazy_static! {
     pub static ref PRELUDE: flux::semantic::PackageExports = flux::prelude().expect("Could not initialize prelude.");
     pub static ref STDLIB: flux::semantic::import::Packages = flux::imports().expect("Could not initialize stdlib.");
+    static ref STDLIB_: Stdlib = Stdlib(flux::imports().expect("Could not initialize stdlib."));
+    pub static ref UNIVERSE: Package = Package::new("universe", flux::prelude().expect("Could not initialize prelude"));
+}
+
+/// Stdlib serves as the API for querying the flux stdlib.
+///
+/// The flux stdlib is a collection of packages, and this interface
+/// provides a method for querying those packages.
+struct Stdlib(flux::semantic::import::Packages);
+
+impl Stdlib {
+    /// Get all packages from the stdlib.
+    fn packages(&self) -> Vec<Package> {
+        self.0
+            .iter()
+            .map(|(path, package)| {
+                Package::new(path, package.clone())
+            })
+            .collect()
+    }
+
+    /// Get a package by path from the stdlib.
+    fn package(&self, path: &str) -> Option<Package> {
+        self.packages()
+            .iter()
+            .filter(|package| package.path == path)
+            .map(|package| package.clone())
+            .next()
+    }
+}
+
+/// Package represents a flux package.
+#[derive(Debug, Clone)]
+pub struct Package {
+    name: String,
+    path: String,
+    exports: flux::semantic::PackageExports,
+}
+
+impl Package {
+    fn new(
+        path: &str,
+        exports: flux::semantic::PackageExports,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            name: path
+                .split('/')
+                .last()
+                .expect("Received an unsupported package name")
+                .into(),
+            exports,
+        }
+    }
+
+    /// Get all functions in the package.
+    pub fn functions(&self) -> Vec<Function_> {
+        if let MonoType::Record(record) = self.exports.typ().expr {
+            let mut functions: Vec<Function_> = record
+                .fields()
+                .filter(|property| {
+                    matches!(&property.v, MonoType::Fun(_))
+                        && !property.k.to_string().starts_with('_')
+                })
+                .map(|property| match &property.v {
+                    MonoType::Fun(f) => Function_ {
+                        name: property.k.to_string(),
+                        expr: f.as_ref().clone(),
+                    },
+                    _ => unreachable!(
+                        "Previous filter function failed"
+                    ),
+                })
+                .collect();
+            // Sort the functions into alphabetical order, plz.
+            functions.sort();
+            functions
+        } else {
+            log::warn!("Package is not actually a flux package.");
+            vec![]
+        }
+    }
+
+    /// Get a function by name from the package.
+    pub fn function(&self, name: &str) -> Option<Function_> {
+        self.functions()
+            .iter()
+            .filter(|function| function.name == name)
+            .map(|function| function.clone())
+            .next()
+    }
+}
+
+/// A flux function struct
+///
+/// This struct provides a bridge between the flux language function and
+/// its lsp representations around completion, signature help, etc.
+///
+/// The contract here is that all public interfaces here return lsp data
+/// structures. Any deviation from that contract should be considered technical
+/// debt and handled accordingly.
+#[derive(Clone)]
+pub struct Function_ {
+    pub name: String,
+    expr: flux::semantic::types::Function,
+}
+
+impl std::cmp::Ord for Function_ {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+impl std::cmp::PartialOrd for Function_ {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Function_ {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+impl Eq for Function_ {}
+
+impl Function_ {
+    fn signature_information(
+        &self,
+    ) -> Vec<lsp::SignatureInformation> {
+        vec![]
+    }
+
+    pub fn parameters(&self) -> Vec<(String, MonoType)> {
+        self.expr
+            .req
+            .iter()
+            .chain(self.expr.opt.iter().map(|p| (p.0, &p.1.typ)))
+            .chain(self.expr.pipe.as_ref().map(|p| (&p.k, &p.v)))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+    fn signature(&self) -> String {
+        let required = self
+            .expr
+            .req
+            .iter()
+            // Sort args with BTree
+            .collect::<BTreeMap<_, _>>()
+            .iter()
+            .map(|(&k, &v)| (k.clone(), format!("{}", v)))
+            .collect::<Vec<_>>();
+
+        let optional = self
+            .expr
+            .opt
+            .iter()
+            // Sort args with BTree
+            .collect::<BTreeMap<_, _>>()
+            .iter()
+            .map(|(&k, &v)| (k.clone(), format!("{}", v.typ)))
+            .collect::<Vec<_>>();
+
+        let pipe = match &self.expr.pipe {
+            Some(pipe) => {
+                if pipe.k == "<-" {
+                    vec![(pipe.k.clone(), format!("{}", pipe.v))]
+                } else {
+                    vec![(
+                        format!("<-{}", pipe.k),
+                        format!("{}", pipe.v),
+                    )]
+                }
+            }
+            None => vec![],
+        };
+
+        format!(
+            "({}) -> {}",
+            pipe.iter()
+                .chain(required.iter().chain(optional.iter()))
+                .map(|arg| format!("{}:{}", arg.0, arg.1))
+                .collect::<Vec<_>>()
+                .join(", "),
+            self.expr.retn
+        )
+    }
 }
 
 pub fn get_package_name(name: &str) -> &str {
@@ -136,20 +328,6 @@ pub fn get_stdlib_functions() -> Vec<FunctionInfo> {
             _ => unreachable!("Previous filter failed"),
         });
     builtins.chain(imported.into_iter()).collect()
-}
-
-pub fn get_builtin_functions() -> Vec<Function> {
-    PRELUDE
-        .iter()
-        .filter(|(_key, val)| matches!(&val.expr, MonoType::Fun(_)))
-        .map(|(key, val)| match &val.expr {
-            MonoType::Fun(f) => Function::new(key.into(), f),
-            _ => unreachable!(
-                "Previous filter call failed. Got: {}",
-                val.expr
-            ),
-        })
-        .collect()
 }
 
 pub struct FunctionInfo {
@@ -291,5 +469,319 @@ impl Function {
             })
             .collect::<Vec<_>>();
         Self { name, params }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All stdlib packages are fetched.
+    ///
+    /// There is some logic that makes assumptions about flux packages,
+    /// and this test ensures those assumptions don't cause a panic. This
+    /// test is especially important as packages are added, as the new packages
+    /// may press those assumptions.
+    #[test]
+    fn get_stdlib() {
+        expect_test::expect![[r#"
+            [
+              "array",
+              "bitwise",
+              "contrib/RohanSreerama5/naiveBayesClassifier",
+              "contrib/anaisdg/anomalydetection",
+              "contrib/anaisdg/statsmodels",
+              "contrib/bonitoo-io/alerta",
+              "contrib/bonitoo-io/hex",
+              "contrib/bonitoo-io/servicenow",
+              "contrib/bonitoo-io/tickscript",
+              "contrib/bonitoo-io/victorops",
+              "contrib/bonitoo-io/zenoss",
+              "contrib/chobbs/discord",
+              "contrib/jsternberg/aggregate",
+              "contrib/jsternberg/influxdb",
+              "contrib/jsternberg/math",
+              "contrib/rhajek/bigpanda",
+              "contrib/sranka/opsgenie",
+              "contrib/sranka/sensu",
+              "contrib/sranka/teams",
+              "contrib/sranka/telegram",
+              "contrib/sranka/webexteams",
+              "contrib/tomhollingworth/events",
+              "csv",
+              "date",
+              "date/boundaries",
+              "dict",
+              "experimental",
+              "experimental/aggregate",
+              "experimental/array",
+              "experimental/bigtable",
+              "experimental/bitwise",
+              "experimental/csv",
+              "experimental/geo",
+              "experimental/http",
+              "experimental/http/requests",
+              "experimental/influxdb",
+              "experimental/iox",
+              "experimental/json",
+              "experimental/mqtt",
+              "experimental/oee",
+              "experimental/prometheus",
+              "experimental/query",
+              "experimental/record",
+              "experimental/table",
+              "experimental/universe",
+              "experimental/usage",
+              "generate",
+              "http",
+              "http/requests",
+              "influxdata/influxdb",
+              "influxdata/influxdb/monitor",
+              "influxdata/influxdb/sample",
+              "influxdata/influxdb/schema",
+              "influxdata/influxdb/secrets",
+              "influxdata/influxdb/tasks",
+              "influxdata/influxdb/v1",
+              "internal/boolean",
+              "internal/debug",
+              "internal/gen",
+              "internal/influxql",
+              "internal/location",
+              "internal/promql",
+              "internal/testutil",
+              "interpolate",
+              "join",
+              "json",
+              "kafka",
+              "math",
+              "pagerduty",
+              "planner",
+              "profiler",
+              "pushbullet",
+              "regexp",
+              "runtime",
+              "sampledata",
+              "slack",
+              "socket",
+              "sql",
+              "strings",
+              "system",
+              "testing",
+              "testing/expect",
+              "timezone",
+              "types",
+              "universe"
+            ]"#]]
+        .assert_eq(
+            &serde_json::to_string_pretty(
+                &STDLIB_
+                    .packages()
+                    .iter()
+                    .map(|package| package.path.clone())
+                    .collect::<Vec<String>>(),
+            )
+            .unwrap(),
+        );
+    }
+
+    /// All universe functions are fetched.
+    ///
+    /// Universe is just a single Package, and thus can be navigated like any
+    /// other package.
+    #[test]
+    fn get_universe_functions() {
+        expect_test::expect![[r#"
+            [
+              "aggregateWindow",
+              "bool",
+              "bottom",
+              "buckets",
+              "bytes",
+              "cardinality",
+              "chandeMomentumOscillator",
+              "columns",
+              "contains",
+              "count",
+              "cov",
+              "covariance",
+              "cumulativeSum",
+              "derivative",
+              "die",
+              "difference",
+              "display",
+              "distinct",
+              "doubleEMA",
+              "drop",
+              "duplicate",
+              "duration",
+              "elapsed",
+              "exponentialMovingAverage",
+              "fill",
+              "filter",
+              "findColumn",
+              "findRecord",
+              "first",
+              "float",
+              "from",
+              "getColumn",
+              "getRecord",
+              "group",
+              "highestAverage",
+              "highestCurrent",
+              "highestMax",
+              "histogram",
+              "histogramQuantile",
+              "holtWinters",
+              "hourSelection",
+              "increase",
+              "int",
+              "integral",
+              "join",
+              "kaufmansAMA",
+              "kaufmansER",
+              "keep",
+              "keyValues",
+              "keys",
+              "last",
+              "length",
+              "limit",
+              "linearBins",
+              "logarithmicBins",
+              "lowestAverage",
+              "lowestCurrent",
+              "lowestMin",
+              "map",
+              "max",
+              "mean",
+              "median",
+              "min",
+              "mode",
+              "movingAverage",
+              "now",
+              "pearsonr",
+              "pivot",
+              "quantile",
+              "range",
+              "reduce",
+              "relativeStrengthIndex",
+              "rename",
+              "sample",
+              "set",
+              "skew",
+              "sort",
+              "spread",
+              "stateCount",
+              "stateDuration",
+              "stateTracking",
+              "stddev",
+              "string",
+              "sum",
+              "tableFind",
+              "tail",
+              "time",
+              "timeShift",
+              "timeWeightedAvg",
+              "timedMovingAverage",
+              "to",
+              "toBool",
+              "toFloat",
+              "toInt",
+              "toString",
+              "toTime",
+              "toUInt",
+              "today",
+              "top",
+              "tripleEMA",
+              "tripleExponentialDerivative",
+              "truncateTimeColumn",
+              "uint",
+              "union",
+              "unique",
+              "wideTo",
+              "window",
+              "yield"
+            ]"#]]
+        .assert_eq(
+            &serde_json::to_string_pretty(
+                &UNIVERSE
+                    .functions()
+                    .iter()
+                    .map(|function| function.name.clone())
+                    .collect::<Vec<String>>(),
+            )
+            .unwrap(),
+        );
+    }
+
+    /// All functions from a package can be fetched
+    #[test]
+    fn csv_package_functions() {
+        let csv = STDLIB_.package("csv").unwrap();
+
+        let functions = csv.functions();
+
+        expect_test::expect![[r#"
+            [
+              "from"
+            ]"#]]
+        .assert_eq(
+            &serde_json::to_string_pretty(
+                &functions
+                    .iter()
+                    .map(|function| function.name.clone())
+                    .collect::<Vec<String>>(),
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn function_signature() {
+        let from =
+            STDLIB_.package("csv").unwrap().function("from").unwrap();
+
+        assert_eq!(
+            "(csv:string, file:string, mode:string) -> stream[A]",
+            from.signature()
+        );
+    }
+
+    #[test]
+    fn function_parameters() {
+        let from =
+            STDLIB_.package("csv").unwrap().function("from").unwrap();
+
+        expect_test::expect![[r#"
+            [
+              [
+                "csv",
+                "String"
+              ],
+              [
+                "file",
+                "String"
+              ],
+              [
+                "mode",
+                "String"
+              ]
+            ]"#]]
+        .assert_eq(
+            &serde_json::to_string_pretty(&from.parameters())
+                .unwrap(),
+        );
+    }
+
+    #[test]
+    fn function_signature_information() {
+        let from =
+            STDLIB_.package("csv").unwrap().function("from").unwrap();
+
+        expect_test::expect![[r#"[]"#]].assert_eq(
+            &serde_json::to_string_pretty(
+                &from.signature_information(),
+            )
+            .unwrap(),
+        );
     }
 }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -594,17 +594,6 @@ mod tests {
     }
 
     #[test]
-    fn function_signature() {
-        let from =
-            STDLIB.package("csv").unwrap().function("from").unwrap();
-
-        assert_eq!(
-            "(csv:string, file:string, mode:string) -> stream[A]",
-            from.signature()
-        );
-    }
-
-    #[test]
     fn function_parameters() {
         let from =
             STDLIB.package("csv").unwrap().function("from").unwrap();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -538,14 +538,18 @@ impl LanguageServer for LspServer {
             ),
             pkg
         );
-        let signatures: Vec<lsp::SignatureInformation> = if let Some(node) = visitor.node {
+        let signatures: Vec<lsp::SignatureInformation> = if let Some(
+            node,
+        ) =
+            visitor.node
+        {
             if let walk::Node::CallExpr(call) = node {
                 let callee = call.callee.clone();
 
                 if let flux::semantic::nodes::Expression::Member(member) = callee.clone() {
                     let name = member.property.clone();
                     if let flux::semantic::nodes::Expression::Identifier(ident) = member.object.clone() {
-                        match lang::STDLIB_.package(&ident.name) {
+                        match lang::STDLIB.package(&ident.name) {
                             None => return Ok(None),
                             Some(package) => match package.function(&name) {
                                 None => return Ok(None),
@@ -970,28 +974,26 @@ impl LanguageServer for LspServer {
                     // XXX: rockstar (6 Jul 2022) - This is helping to complete packages that
                     // have never been imported. That's probably not a great pattern.
                     let stdlib_completions: Vec<lsp::CompletionItem> =
-                        lang::STDLIB.iter().filter(|(key, _val)| {
-                            fuzzy_match(lang::get_package_name(key), &identifier.name)
-                        }).map(|(key, _val)| {
-                            let package_name = lang::get_package_name(key);
+                        lang::STDLIB.fuzzy_matches(&identifier.name)
+                        .map(|package| {
                             lsp::CompletionItem {
-                                label: key.clone(),
+                                label: package.path.clone(),
                                 detail: Some("Package".into()),
                                 documentation: Some(lsp::Documentation::String(
-                                    key.clone(),
+                                    package.path.clone(),
                                 )),
-                                filter_text: Some(package_name.into()),
-                                insert_text: Some(key.clone()),
+                                filter_text: Some(package.name.clone()),
+                                insert_text: Some(package.path.clone()),
                                 insert_text_format: Some(lsp::InsertTextFormat::PLAIN_TEXT),
                                 kind: Some(lsp::CompletionItemKind::MODULE),
-                                sort_text: Some(key.clone()),
+                                sort_text: Some(package.path.clone()),
                                 ..lsp::CompletionItem::default()
                             }
                         }).collect();
 
                     let builtin_completions: Vec<
                         lsp::CompletionItem,
-                    > = lang::PRELUDE.iter().filter(|(key, val)| {
+                    > = lang::UNIVERSE.exports.iter().filter(|(key, val)| {
                             // Don't allow users to "discover" private-ish functionality.
                             // Filter out irrelevent items that won't match.
                             // Only pass expressions that have completion support.
@@ -1005,27 +1007,12 @@ impl LanguageServer for LspServer {
                             match &val.expr {
                                 MonoType::Fun(function) => {
                                     lsp::CompletionItem {
-                                        label: key.into(),
+                                        label: key.to_string(),
                                         detail: Some(lang::create_function_signature(function)),
-                                        filter_text: Some(key.into()),
+                                        filter_text: Some(key.to_string()),
                                         insert_text_format: Some(lsp::InsertTextFormat::SNIPPET),
                                         kind: Some(lsp::CompletionItemKind::FUNCTION),
-                                        sort_text: Some(key.into()),
-                                        ..lsp::CompletionItem::default()
-                                    }
-                                }
-                                MonoType::Collection(_collection) => {
-                                    lsp::CompletionItem {
-                                        label: format!("{} ({})", key, "prelude"),
-                                        detail: Some("Array".into()),
-                                        documentation: Some(lsp::Documentation::String("from prelude".into())),
-                                        filter_text: Some(key.into()),
-                                        insert_text: Some(key.into()),
-                                        insert_text_format: Some(
-                                            lsp::InsertTextFormat::PLAIN_TEXT
-                                        ),
-                                        kind: Some(lsp::CompletionItemKind::VARIABLE),
-                                        sort_text: Some(format!("{} prelude", key)),
+                                        sort_text: Some(key.to_string()),
                                         ..lsp::CompletionItem::default()
                                     }
                                 }
@@ -1044,8 +1031,8 @@ impl LanguageServer for LspServer {
                                             BuiltinType::Time => "Time".into(),
                                         }),
                                         documentation: Some(lsp::Documentation::String("from prelude".into())),
-                                        filter_text: Some(key.into()),
-                                        insert_text: Some(key.into()),
+                                        filter_text: Some(key.to_string()),
+                                        insert_text: Some(key.to_string()),
                                         insert_text_format: Some(
                                             lsp::InsertTextFormat::PLAIN_TEXT
                                         ),
@@ -1079,26 +1066,24 @@ impl LanguageServer for LspServer {
                                         x.name == identifier.name
                                     })
                             {
-                                for (key, val) in lang::STDLIB.iter()
+                                for package in lang::STDLIB.packages()
                                 {
-                                    if *key == import.path {
+                                    if package.path == import.path {
                                         completion::walk_package(
-                                            key,
+                                            &package.path,
                                             &mut list,
-                                            &val.typ().expr,
+                                            &package.exports.typ().expr,
                                         );
                                     }
                                 }
                             } else {
-                                for (key, val) in lang::STDLIB.iter()
+                                for package in lang::STDLIB.packages()
                                 {
-                                    if lang::get_package_name(key)
-                                        == identifier.name
-                                    {
+                                    if package.name == identifier.name {
                                         completion::walk_package(
-                                            key,
+                                            &package.path,
                                             &mut list,
-                                            &val.typ().expr,
+                                            &package.exports.typ().expr,
                                         );
                                     }
                                 }
@@ -1139,20 +1124,18 @@ impl LanguageServer for LspServer {
                             let imports =
                                 completion::get_imports(&sem_pkg);
 
-                            lang::STDLIB.iter().map(|(path, _val)| {
-                                (lang::get_package_name(path).into(), path.clone())
-                            }).filter(|(name, _path): &(String, String)| {
-                                !&imports.iter().any(|x| &x.path == name)
-                            }).map(|(_name, path)| {
+                            lang::STDLIB.packages().filter(|package| {
+                                !&imports.iter().any(|x| x.path == package.path)
+                            }).map(|package| {
                                 let trigger = if let Some(context) = & params.context {
                                     context.trigger_character.as_deref()
                                 } else {
                                     None
                                 };
                                 let insert_text = if trigger == Some("\"") {
-                                    path.as_str().to_string()
+                                    package.path.as_str().to_string()
                                 } else {
-                                    format!(r#""{}""#, path.as_str())
+                                    format!(r#""{}""#, package.path.as_str())
                                 };
                                 lsp::CompletionItem {
                                     label: insert_text.clone(),
@@ -1268,16 +1251,16 @@ impl LanguageServer for LspServer {
             if let ErrorKind::Inference(kind) = &error.error {
                 match kind {
                     SemanticNodeErrorKind::UndefinedIdentifier(identifier) => {
-                        // When encountering undefined identifiers, check to see if they match a corresponding
-                        // package available for import.
-                        let potential_imports: Vec<&String> = lang::STDLIB.iter().filter(|x| lang::get_package_name(x.0) == identifier).map(|x| x.0).collect();
+                        // When encountering undefined identifiers, check to see if they match any corresponding
+                        // packages available for import.
+                        let potential_imports: Vec<lang::Package> = lang::STDLIB.fuzzy_matches(identifier).collect();
                         if potential_imports.is_empty() {
                             return None;
                         }
 
-                        let inner_actions: Vec<lsp::CodeActionOrCommand> = potential_imports.iter().map(|package_name| {
+                        let inner_actions: Vec<lsp::CodeActionOrCommand> = potential_imports.iter().map(|package| {
                             lsp::CodeAction {
-                                title: format!("Import `{}`", package_name),
+                                title: format!("Import `{}`", package.path),
                                 kind: Some(lsp::CodeActionKind::QUICKFIX),
                                 diagnostics: None,
                                 edit: Some(lsp::WorkspaceEdit {
@@ -1288,7 +1271,7 @@ impl LanguageServer for LspServer {
                                                     start: import_position,
                                                     end: import_position,
                                                 },
-                                                new_text: format!("import \"{}\"\n", package_name),
+                                                new_text: format!("import \"{}\"\n", package.path),
                                             }
                                         ])
                                     ])),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1018,7 +1018,7 @@ impl LanguageServer for LspServer {
                                 MonoType::Fun(function) => {
                                     lsp::CompletionItem {
                                         label: key.to_string(),
-                                        detail: Some(lang::create_function_signature(function)),
+                                        detail: Some(completion::create_function_signature(function)),
                                         filter_text: Some(key.to_string()),
                                         insert_text_format: Some(lsp::InsertTextFormat::SNIPPET),
                                         kind: Some(lsp::CompletionItemKind::FUNCTION),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -996,7 +996,7 @@ impl LanguageServer for LspServer {
                                 kind: Some(
                                     lsp::CompletionItemKind::MODULE,
                                 ),
-                                sort_text: Some(package.path.clone()),
+                                sort_text: Some(package.path),
                                 ..lsp::CompletionItem::default()
                             })
                             .collect();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -974,22 +974,32 @@ impl LanguageServer for LspServer {
                     // XXX: rockstar (6 Jul 2022) - This is helping to complete packages that
                     // have never been imported. That's probably not a great pattern.
                     let stdlib_completions: Vec<lsp::CompletionItem> =
-                        lang::STDLIB.fuzzy_matches(&identifier.name)
-                        .map(|package| {
-                            lsp::CompletionItem {
+                        lang::STDLIB
+                            .fuzzy_matches(&identifier.name)
+                            .map(|package| lsp::CompletionItem {
                                 label: package.path.clone(),
                                 detail: Some("Package".into()),
-                                documentation: Some(lsp::Documentation::String(
+                                documentation: Some(
+                                    lsp::Documentation::String(
+                                        package.path.clone(),
+                                    ),
+                                ),
+                                filter_text: Some(
+                                    package.name.clone(),
+                                ),
+                                insert_text: Some(
                                     package.path.clone(),
-                                )),
-                                filter_text: Some(package.name.clone()),
-                                insert_text: Some(package.path.clone()),
-                                insert_text_format: Some(lsp::InsertTextFormat::PLAIN_TEXT),
-                                kind: Some(lsp::CompletionItemKind::MODULE),
+                                ),
+                                insert_text_format: Some(
+                                    lsp::InsertTextFormat::PLAIN_TEXT,
+                                ),
+                                kind: Some(
+                                    lsp::CompletionItemKind::MODULE,
+                                ),
                                 sort_text: Some(package.path.clone()),
                                 ..lsp::CompletionItem::default()
-                            }
-                        }).collect();
+                            })
+                            .collect();
 
                     let builtin_completions: Vec<
                         lsp::CompletionItem,
@@ -1072,18 +1082,25 @@ impl LanguageServer for LspServer {
                                         completion::walk_package(
                                             &package.path,
                                             &mut list,
-                                            &package.exports.typ().expr,
+                                            &package
+                                                .exports
+                                                .typ()
+                                                .expr,
                                         );
                                     }
                                 }
                             } else {
                                 for package in lang::STDLIB.packages()
                                 {
-                                    if package.name == identifier.name {
+                                    if package.name == identifier.name
+                                    {
                                         completion::walk_package(
                                             &package.path,
                                             &mut list,
-                                            &package.exports.typ().expr,
+                                            &package
+                                                .exports
+                                                .typ()
+                                                .expr,
                                         );
                                     }
                                 }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -547,8 +547,6 @@ csv.from(
         "from(csv: $csv , mode: $mode)",
         "from(file: $file , mode: $mode)",
         "from(csv: $csv , file: $file , mode: $mode)",
-        "from(url: $url)",
-        "from(url: $url)",
     ]
     .into_iter()
     .map(|x| x.into())

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -511,9 +511,9 @@ async fn test_signature_help() {
     assert_eq!(None, result.active_parameter);
 }
 
-/// Test signature help on imported modules
+/// Signature help on stdlib functions is provided.
 #[test]
-async fn test_signature_help_imports() {
+async fn test_signature_help_stdlib() {
     let server = create_server();
     let fluxscript = r#"import "csv"
 csv.from(

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2275,13 +2275,6 @@ csv.from(
               "detail": "string",
               "insertText": "mode: ",
               "insertTextFormat": 2
-            },
-            {
-              "label": "url",
-              "kind": 5,
-              "detail": "string",
-              "insertText": "url: ",
-              "insertTextFormat": 2
             }
           ]
         }"#]]
@@ -2331,7 +2324,7 @@ csv.from(
     let labels: Vec<&str> =
         items.iter().map(|item| item.label.as_str()).collect();
 
-    let expected = vec!["csv", "file", "mode", "url"];
+    let expected = vec!["csv", "file", "mode"];
 
     assert_eq!(expected, labels);
 }
@@ -2378,7 +2371,7 @@ x = 1
     let labels: Vec<&str> =
         items.iter().map(|item| item.label.as_str()).collect();
 
-    let expected = vec!["csv", "file", "url"];
+    let expected = vec!["csv", "file"];
 
     assert_eq!(expected, labels);
 }

--- a/src/visitors/semantic/completion.rs
+++ b/src/visitors/semantic/completion.rs
@@ -4,7 +4,7 @@ use flux::semantic::types::MonoType;
 use flux::semantic::walk::{Node, Visitor};
 use lspower::lsp;
 
-use crate::lang::Function;
+use crate::completion::CompletionFunction;
 
 fn defined_after(loc: &SourceLocation, pos: lsp::Position) -> bool {
     if loc.start.line > pos.line + 1
@@ -19,7 +19,7 @@ fn defined_after(loc: &SourceLocation, pos: lsp::Position) -> bool {
 
 pub struct FunctionFinderVisitor {
     pub pos: lsp::Position,
-    pub functions: Vec<Function>,
+    pub functions: Vec<CompletionFunction>,
 }
 
 impl FunctionFinderVisitor {
@@ -44,7 +44,7 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
 
             if let Expression::Function(f) = &assgn.init {
                 self.functions
-                    .push(Function::from_expr(name.to_string(), f));
+                    .push(CompletionFunction::from_expr(name.to_string(), f));
             }
         }
 
@@ -56,7 +56,7 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
                 let name = &assgn.id.name;
                 if let Expression::Function(f) = &assgn.init {
                     if let MonoType::Fun(fun) = &f.typ {
-                        self.functions.push(Function::new(
+                        self.functions.push(CompletionFunction::new(
                             name.to_string(),
                             fun,
                         ));
@@ -72,7 +72,7 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
 #[derive(Clone)]
 pub struct ObjectFunction {
     pub object: String,
-    pub function: Function,
+    pub function: CompletionFunction,
 }
 
 #[derive(Default)]
@@ -94,7 +94,7 @@ impl<'a> Visitor<'a> for ObjectFunctionFinderVisitor {
                         {
                             self.results.push(ObjectFunction {
                                 object: object_name.to_string(),
-                                function: Function::from_expr(
+                                function: CompletionFunction::from_expr(
                                     func_name.to_string(),
                                     fun,
                                 ),
@@ -121,7 +121,7 @@ impl<'a> Visitor<'a> for ObjectFunctionFinderVisitor {
                             {
                                 self.results.push(ObjectFunction {
                                     object: object_name.to_string(),
-                                    function: Function::from_expr(
+                                    function: CompletionFunction::from_expr(
                                         func_name.to_string(),
                                         fun,
                                     ),

--- a/src/visitors/semantic/completion.rs
+++ b/src/visitors/semantic/completion.rs
@@ -43,8 +43,10 @@ impl<'a> Visitor<'a> for FunctionFinderVisitor {
             let name = &assgn.id.name;
 
             if let Expression::Function(f) = &assgn.init {
-                self.functions
-                    .push(CompletionFunction::from_expr(name.to_string(), f));
+                self.functions.push(CompletionFunction::from_expr(
+                    name.to_string(),
+                    f,
+                ));
             }
         }
 
@@ -94,10 +96,11 @@ impl<'a> Visitor<'a> for ObjectFunctionFinderVisitor {
                         {
                             self.results.push(ObjectFunction {
                                 object: object_name.to_string(),
-                                function: CompletionFunction::from_expr(
-                                    func_name.to_string(),
-                                    fun,
-                                ),
+                                function:
+                                    CompletionFunction::from_expr(
+                                        func_name.to_string(),
+                                        fun,
+                                    ),
                             });
 
                             return false;
@@ -121,10 +124,11 @@ impl<'a> Visitor<'a> for ObjectFunctionFinderVisitor {
                             {
                                 self.results.push(ObjectFunction {
                                     object: object_name.to_string(),
-                                    function: CompletionFunction::from_expr(
-                                        func_name.to_string(),
-                                        fun,
-                                    ),
+                                    function:
+                                        CompletionFunction::from_expr(
+                                            func_name.to_string(),
+                                            fun,
+                                        ),
                                 });
 
                                 return false;

--- a/src/visitors/semantic/functions.rs
+++ b/src/visitors/semantic/functions.rs
@@ -6,8 +6,6 @@ use flux::semantic::types::MonoType;
 use flux::semantic::walk::{Node, Visitor};
 use lspower::lsp;
 
-use crate::lang;
-
 pub struct FunctionInfo {
     pub name: String,
     pub package_name: String,
@@ -24,8 +22,8 @@ impl FunctionInfo {
         FunctionInfo {
             name,
             package_name,
-            required_args: lang::get_argument_names(&f.req),
-            optional_args: lang::get_optional_argument_names(&f.opt),
+            required_args: f.req.keys().map(String::from).collect(),
+            optional_args: f.opt.keys().map(String::from).collect(),
         }
     }
 }

--- a/src/visitors/semantic/functions.rs
+++ b/src/visitors/semantic/functions.rs
@@ -6,7 +6,29 @@ use flux::semantic::types::MonoType;
 use flux::semantic::walk::{Node, Visitor};
 use lspower::lsp;
 
-use crate::lang::FunctionInfo;
+use crate::lang;
+
+pub struct FunctionInfo {
+    pub name: String,
+    pub package_name: String,
+    pub required_args: Vec<String>,
+    pub optional_args: Vec<String>,
+}
+
+impl FunctionInfo {
+    pub fn new(
+        name: String,
+        f: &flux::semantic::types::Function,
+        package_name: String,
+    ) -> Self {
+        FunctionInfo {
+            name,
+            package_name,
+            required_args: lang::get_argument_names(&f.req),
+            optional_args: lang::get_optional_argument_names(&f.opt),
+        }
+    }
+}
 
 pub struct FunctionFinderVisitor {
     pub pos: lsp::Position,

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -197,7 +197,11 @@ impl<'a> Visitor<'a> for ImportFinderVisitor {
                 None => {
                     // XXX: rockstar (15 Jul 2022) - This block duplicates effort found
                     // in `lang`.
-                    import.path.value.as_str().split('/')
+                    import
+                        .path
+                        .value
+                        .as_str()
+                        .split('/')
                         .last()
                         .expect("Invalid package path/name supplied")
                         .to_string()

--- a/src/visitors/semantic/mod.rs
+++ b/src/visitors/semantic/mod.rs
@@ -1,5 +1,3 @@
-use crate::lang::get_package_name;
-
 use flux::semantic::{
     nodes::{Expression, Symbol},
     walk::{self, Node, Visitor},
@@ -194,10 +192,16 @@ pub struct ImportFinderVisitor {
 impl<'a> Visitor<'a> for ImportFinderVisitor {
     fn visit(&mut self, node: Node<'a>) -> bool {
         if let Node::ImportDeclaration(import) = node {
-            let name = match import.alias.clone() {
+            let name = match &import.alias {
                 Some(alias) => alias.name.to_string(),
-                None => get_package_name(import.path.value.as_str())
-                    .to_owned(),
+                None => {
+                    // XXX: rockstar (15 Jul 2022) - This block duplicates effort found
+                    // in `lang`.
+                    import.path.value.as_str().split('/')
+                        .last()
+                        .expect("Invalid package path/name supplied")
+                        .to_string()
+                }
             };
 
             self.imports.push(Import {


### PR DESCRIPTION
This patch introduces an API for querying the flux stdlib and prelude/universe.
Having a standard way to do this will cut down on the repeated allocations
that come about from each call point getting its own copy of the stdlib, using
it for a very narrow case, and then throwing it away (likely with more call
points doing the same down the road).

Architecturally, this starts to provide an abstraction to the flux stdlib for
the cases where a low-level api probably isn't needed, e.g. we need the names
of packages, but not the package itself. These new apis would hide those
implementations, and handle some logic between flux<->lsp data structures.

This is the last of the refactoring needed to clean up the path for making
function completion (and injection) work without much accompanying baggage.