### PR TITLE
fix: address release issues in publish script

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
+set -o xtrace
 
-cd target/pkg-node
+CWD=`pwd`
+
+cd $CWD/target/pkg-node
 npm publish --access public
-cd ..
 
-cd target/pkg-browser
+cd $CWD/target/pkg-browser
 npm publish --access public


### PR DESCRIPTION
The path to where the wasm artifacts are built changed recently, and
while the `publish.sh` script was updated, there were issues in it that
meant that we couldn't successfully release. This patch fixes those
issues (theoretically, as it can't be fully tested).