### PR TITLE
feat: add function snippet syntax

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -695,15 +695,16 @@ pub fn complete_call_expr(
 
     completion_params
         .into_iter()
-        .map(|(name, typ)| {
+        .enumerate()
+        .map(|(index, (name, typ))| {
             let insert_text = if let Some(trigger) = trigger {
                 if trigger == "(" {
-                    format!("{}: ", name)
+                    format!("{}: ${}", name, index + 1)
                 } else {
-                    format!(" {}: ", name)
+                    format!(" {}: ${}", name, index + 1)
                 }
             } else {
-                format!("{}: ", name)
+                format!("{}: ${}", name, index + 1)
             };
 
             lsp::CompletionItem {


### PR DESCRIPTION
This patch adds real snippet support to function parameter completion.
This means that one could potentially tab through each parameter in the
parameter list and add their associated values.

This patch is hilariously small and direct now that all the refactoring is
done.

Fixes #435
Fixes #431