### PR TITLE
feat: wrap completion snippets string types

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -697,14 +697,17 @@ pub fn complete_call_expr(
         .into_iter()
         .enumerate()
         .map(|(index, (name, typ))| {
-            let insert_text = if let Some(trigger) = trigger {
-                if trigger == "(" {
-                    format!("{}: ${}", name, index + 1)
-                } else {
-                    format!(" {}: ${}", name, index + 1)
+            let snippet_blurb = match typ {
+                Some(MonoType::STRING) => {
+                    format!(r#""${}""#, index + 1)
                 }
-            } else {
-                format!("{}: ${}", name, index + 1)
+                _ => format!("${}", index + 1),
+            };
+            let insert_text = match trigger {
+                Some("(") | None => {
+                    format!("{}: {}", name, snippet_blurb)
+                }
+                Some(_) => format!(" {}: {}", name, snippet_blurb),
             };
 
             lsp::CompletionItem {

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2065,42 +2065,42 @@ from()
             "label": "bucket",
             "kind": 5,
             "detail": "string",
-            "insertText": "bucket: $1",
+            "insertText": "bucket: \"$1\"",
             "insertTextFormat": 2
           },
           {
             "label": "bucketID",
             "kind": 5,
             "detail": "string",
-            "insertText": "bucketID: $2",
+            "insertText": "bucketID: \"$2\"",
             "insertTextFormat": 2
           },
           {
             "label": "host",
             "kind": 5,
             "detail": "string",
-            "insertText": "host: $3",
+            "insertText": "host: \"$3\"",
             "insertTextFormat": 2
           },
           {
             "label": "org",
             "kind": 5,
             "detail": "string",
-            "insertText": "org: $4",
+            "insertText": "org: \"$4\"",
             "insertTextFormat": 2
           },
           {
             "label": "orgID",
             "kind": 5,
             "detail": "string",
-            "insertText": "orgID: $5",
+            "insertText": "orgID: \"$5\"",
             "insertTextFormat": 2
           },
           {
             "label": "token",
             "kind": 5,
             "detail": "string",
-            "insertText": "token: $6",
+            "insertText": "token: \"$6\"",
             "insertTextFormat": 2
           }
         ]"#]]
@@ -2344,21 +2344,21 @@ csv.from(
               "label": "csv",
               "kind": 5,
               "detail": "string",
-              "insertText": "csv: $1",
+              "insertText": "csv: \"$1\"",
               "insertTextFormat": 2
             },
             {
               "label": "file",
               "kind": 5,
               "detail": "string",
-              "insertText": "file: $2",
+              "insertText": "file: \"$2\"",
               "insertTextFormat": 2
             },
             {
               "label": "mode",
               "kind": 5,
               "detail": "string",
-              "insertText": "mode: $3",
+              "insertText": "mode: \"$3\"",
               "insertTextFormat": 2
             }
           ]


### PR DESCRIPTION
This patch wraps completion snippets for function parameters that could
be strings in double quotes.