### PR TITLE
fix: revert wasm-pack to bundler type

### DIFF
--- a/wasm-build.sh
+++ b/wasm-build.sh
@@ -35,7 +35,7 @@ wasm-pack build \
     --locked \
     $BUILD_MODE_ARGS
 wasm-pack build \
-    -t web \
+    -t bundler \
     -d $TARGET_BROWSER_DIR \
     --out-name flux-lsp-browser \
     --scope influxdata \


### PR DESCRIPTION
Earlier this week, we discovered that some time ago, the `browser`
type had disappeared from `wasm-pack` and was replaced with `bundler`
and `web`. Specifying `-t browser` fell through to using the `bundler`
type. In an attempt to possibly make debugging the wasm a little easier,
we switched to using `-t web`, which uses `WebAssembly` for memory
management instead of using raw memory management.

Unfortunately, this new format broke the InfluxDB ui build. Webpack in
the UI will likely need some help understanding the `web` type, if
that's a direction we'd like to go. For now, we'll support just the
bundler.

Fixes #540