### PR TITLE
feat: introduce a lint rule to prefer camelCase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +691,7 @@ dependencies = [
 name = "flux-lsp"
 version = "0.8.27"
 dependencies = [
+ "Inflector",
  "async-std",
  "async-trait",
  "clap 3.2.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 console_log = { version = "0.2", optional = true }
 flux = { git = "https://github.com/influxdata/flux", rev = "e811f6c8", features = ["lsp"], default-features = false }
 futures = { version = "0.3.21", optional = true }
+Inflector = "0.11.4"
 js-sys = { version = "0.3.57", optional = true }
 lazy_static = "1.4.0"
 line-col = "0.2.1"

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -165,6 +165,7 @@ impl LspServer {
                 super::diagnostics::contrib_lint,
                 super::diagnostics::experimental_lint,
                 super::diagnostics::no_influxdb_identifiers,
+                super::diagnostics::prefer_camel_case,
             ],
             store: store::Store::default(),
             state: Mutex::new(LspServerState::default()),


### PR DESCRIPTION
This patch adds a diagnostic check for usage of an identifier that isn't
using camelCase. This came about from a conversation with the flux team
where everyone felt good about preferring camelCase.

Fixes #537