### PR TITLE
refactor: use macros to build the ast

### DIFF
--- a/src/server/transform.rs
+++ b/src/server/transform.rs
@@ -134,7 +134,7 @@ macro_rules! pipe {
             base: ast::BaseNode::default(),
             call: $b,
         }
-    }
+    };
 }
 
 macro_rules! filter {
@@ -223,7 +223,10 @@ macro_rules! filter {
 fn make_from_function(bucket: String) -> ast::Statement {
     ast::Statement::Expr(Box::new(ast::ExprStmt {
         base: ast::BaseNode::default(),
-        expression: ast::Expression::PipeExpr(Box::new(pipe!(ast::Expression::Call(Box::new(from!(bucket))), range!()))),
+        expression: ast::Expression::PipeExpr(Box::new(pipe!(
+            ast::Expression::Call(Box::new(from!(bucket))),
+            range!()
+        ))),
     }))
 }
 
@@ -406,15 +409,18 @@ pub(crate) fn inject_field_filter(
 
     let call = if let ast::Statement::Expr(expr) =
         find_the_from(&mut ast, bucket)
-        {
-            expr.expression
-        } else {
-            return Err(());
-        };
+    {
+        expr.expression
+    } else {
+        return Err(());
+    };
 
     ast.body.push(ast::Statement::Expr(Box::new(ast::ExprStmt {
         base: ast::BaseNode::default(),
-        expression: ast::Expression::PipeExpr(Box::new(pipe!(call, filter!("_field".to_string(), name)))),
+        expression: ast::Expression::PipeExpr(Box::new(pipe!(
+            call,
+            filter!("_field".to_string(), name)
+        ))),
     })));
     Ok(ast)
 }
@@ -437,7 +443,10 @@ pub(crate) fn inject_tag_value_filter(
 
     ast.body.push(ast::Statement::Expr(Box::new(ast::ExprStmt {
         base: ast::BaseNode::default(),
-        expression: ast::Expression::PipeExpr(Box::new(pipe!(call, filter!(name, value)))),
+        expression: ast::Expression::PipeExpr(Box::new(pipe!(
+            call,
+            filter!(name, value)
+        ))),
     })));
     Ok(ast)
 }
@@ -459,7 +468,10 @@ pub(crate) fn inject_measurement_filter(
 
     ast.body.push(ast::Statement::Expr(Box::new(ast::ExprStmt {
         base: ast::BaseNode::default(),
-        expression: ast::Expression::PipeExpr(Box::new(pipe!(call, filter!("_measurement".into(), name)))),
+        expression: ast::Expression::PipeExpr(Box::new(pipe!(
+            call,
+            filter!("_measurement".into(), name)
+        ))),
     })));
     Ok(ast)
 }

--- a/src/server/transform.rs
+++ b/src/server/transform.rs
@@ -44,6 +44,89 @@ macro_rules! from {
     };
 }
 
+macro_rules! range {
+    () => {
+        ast::CallExpr {
+            arguments: vec![ast::Expression::Object(
+                Box::new(ast::ObjectExpr {
+                    base: ast::BaseNode::default(),
+                    properties: vec![ast::Property {
+                        base: ast::BaseNode::default(),
+                        key: ast::PropertyKey::Identifier(
+                            ast::Identifier {
+                                base: ast::BaseNode::default(
+                                ),
+                                name: "start".into(),
+                            },
+                        ),
+                        value: Some(
+                            ast::Expression::Member(Box::new(ast::MemberExpr {
+                                base: ast::BaseNode::default(),
+                                lbrack: vec![],
+                                rbrack: vec![],
+                                object: ast::Expression::Identifier(
+                                    ast::Identifier {
+                                        base: ast::BaseNode::default(),
+                                        name: "v".into(),
+                                    }
+                                ),
+                                property: ast::PropertyKey::Identifier(ast::Identifier {
+                                    base: ast::BaseNode::default(),
+                                    name: "timeRangeStart".into(),
+                                })
+                            }))
+                        ),
+                        comma: vec![],
+                        separator: vec![],
+                    },
+                    ast::Property {
+                        base: ast::BaseNode::default(),
+                        key: ast::PropertyKey::Identifier(
+                            ast::Identifier {
+                                base: ast::BaseNode::default(
+                                ),
+                                name: "stop".into(),
+                            },
+                        ),
+                        value: Some(
+                            ast::Expression::Member(Box::new(ast::MemberExpr {
+                                base: ast::BaseNode::default(),
+                                lbrack: vec![],
+                                rbrack: vec![],
+                                object: ast::Expression::Identifier(
+                                    ast::Identifier {
+                                        base: ast::BaseNode::default(),
+                                        name: "v".into(),
+                                    }
+                                ),
+                                property: ast::PropertyKey::Identifier(ast::Identifier {
+                                    base: ast::BaseNode::default(),
+                                    name: "timeRangeStop".into(),
+                                })
+                            }))
+                        ),
+                        comma: vec![],
+                        separator: vec![],
+                    }
+                    ],
+                    lbrace: vec![],
+                    rbrace: vec![],
+                    with: None,
+                }),
+            )],
+            base: ast::BaseNode::default(),
+            callee: ast::Expression::Identifier(
+                ast::Identifier {
+                    base: ast::BaseNode::default(),
+                    name: "range".into(),
+                },
+            ),
+            lparen: vec![],
+            rparen: vec![],
+        }
+    }
+}
+
 fn make_from_function(bucket: String) -> ast::Statement {
     let range = ast::ExprStmt {
         base: ast::BaseNode::default(),
@@ -51,84 +134,7 @@ fn make_from_function(bucket: String) -> ast::Statement {
             ast::PipeExpr {
                 argument: ast::Expression::Call(Box::new(from!(bucket))),
                 base: ast::BaseNode::default(),
-                call: ast::CallExpr {
-                    arguments: vec![ast::Expression::Object(
-                        Box::new(ast::ObjectExpr {
-                            base: ast::BaseNode::default(),
-                            properties: vec![ast::Property {
-                                base: ast::BaseNode::default(),
-                                key: ast::PropertyKey::Identifier(
-                                    ast::Identifier {
-                                        base: ast::BaseNode::default(
-                                        ),
-                                        name: "start".into(),
-                                    },
-                                ),
-                                value: Some(
-                                    ast::Expression::Member(Box::new(ast::MemberExpr {
-                                        base: ast::BaseNode::default(),
-                                        lbrack: vec![],
-                                        rbrack: vec![],
-                                        object: ast::Expression::Identifier(
-                                            ast::Identifier {
-                                                base: ast::BaseNode::default(),
-                                                name: "v".into(),
-                                            }
-                                        ),
-                                        property: ast::PropertyKey::Identifier(ast::Identifier {
-                                            base: ast::BaseNode::default(),
-                                            name: "timeRangeStart".into(),
-                                        })
-                                    }))
-                                ),
-                                comma: vec![],
-                                separator: vec![],
-                            },
-                            ast::Property {
-                                base: ast::BaseNode::default(),
-                                key: ast::PropertyKey::Identifier(
-                                    ast::Identifier {
-                                        base: ast::BaseNode::default(
-                                        ),
-                                        name: "stop".into(),
-                                    },
-                                ),
-                                value: Some(
-                                    ast::Expression::Member(Box::new(ast::MemberExpr {
-                                        base: ast::BaseNode::default(),
-                                        lbrack: vec![],
-                                        rbrack: vec![],
-                                        object: ast::Expression::Identifier(
-                                            ast::Identifier {
-                                                base: ast::BaseNode::default(),
-                                                name: "v".into(),
-                                            }
-                                        ),
-                                        property: ast::PropertyKey::Identifier(ast::Identifier {
-                                            base: ast::BaseNode::default(),
-                                            name: "timeRangeStop".into(),
-                                        })
-                                    }))
-                                ),
-                                comma: vec![],
-                                separator: vec![],
-                            }
-                            ],
-                            lbrace: vec![],
-                            rbrace: vec![],
-                            with: None,
-                        }),
-                    )],
-                    base: ast::BaseNode::default(),
-                    callee: ast::Expression::Identifier(
-                        ast::Identifier {
-                            base: ast::BaseNode::default(),
-                            name: "range".into(),
-                        },
-                    ),
-                    lparen: vec![],
-                    rparen: vec![],
-                },
+                call: range!(),
             },
         )),
     };

--- a/src/server/transform.rs
+++ b/src/server/transform.rs
@@ -153,10 +153,51 @@ macro_rules! filter {
                             },
                         ),
                         value: Some(
-                            make_flux_filter_function(
-                                $key,
-                                $value,
-                            ),
+                            ast::Expression::Function(Box::new(ast::FunctionExpr {
+                                arrow: vec![],
+                                base: ast::BaseNode::default(),
+                                body: ast::FunctionBody::Expr(ast::Expression::Binary(
+                                    Box::new(ast::BinaryExpr {
+                                        base: ast::BaseNode::default(),
+                                        left: ast::Expression::Member(Box::new(
+                                            ast::MemberExpr {
+                                                base: ast::BaseNode::default(),
+                                                lbrack: vec![],
+                                                rbrack: vec![],
+                                                object: ast::Expression::Identifier(
+                                                    ast::Identifier {
+                                                        base: ast::BaseNode::default(),
+                                                        name: "r".into(),
+                                                    },
+                                                ),
+                                                property: ast::PropertyKey::Identifier(
+                                                    ast::Identifier {
+                                                        base: ast::BaseNode::default(),
+                                                        name: $key,
+                                                    },
+                                                ),
+                                            },
+                                        )),
+                                        right: ast::Expression::StringLit(ast::StringLit {
+                                            base: ast::BaseNode::default(),
+                                            value: $value,
+                                        }),
+                                        operator: ast::Operator::EqualOperator,
+                                    }),
+                                )),
+                                lparen: vec![],
+                                rparen: vec![],
+                                params: vec![ast::Property {
+                                    base: ast::BaseNode::default(),
+                                    key: ast::PropertyKey::Identifier(ast::Identifier {
+                                        base: ast::BaseNode::default(),
+                                        name: "r".into(),
+                                    }),
+                                    comma: vec![],
+                                    separator: vec![],
+                                    value: None,
+                                }],
+                            }))
                         ),
                         comma: vec![],
                         separator: vec![],
@@ -269,60 +310,6 @@ fn find_the_from(
         }
         None => make_from_function(bucket),
     }
-}
-
-/// Create a function used as then `fn` parameter of `filter`
-///
-/// This will return the ast equivalent of `(r) => r.{field} == "{value}"`.
-fn make_flux_filter_function(
-    field: String,
-    value: String,
-) -> ast::Expression {
-    ast::Expression::Function(Box::new(ast::FunctionExpr {
-        arrow: vec![],
-        base: ast::BaseNode::default(),
-        body: ast::FunctionBody::Expr(ast::Expression::Binary(
-            Box::new(ast::BinaryExpr {
-                base: ast::BaseNode::default(),
-                left: ast::Expression::Member(Box::new(
-                    ast::MemberExpr {
-                        base: ast::BaseNode::default(),
-                        lbrack: vec![],
-                        rbrack: vec![],
-                        object: ast::Expression::Identifier(
-                            ast::Identifier {
-                                base: ast::BaseNode::default(),
-                                name: "r".into(),
-                            },
-                        ),
-                        property: ast::PropertyKey::Identifier(
-                            ast::Identifier {
-                                base: ast::BaseNode::default(),
-                                name: field,
-                            },
-                        ),
-                    },
-                )),
-                right: ast::Expression::StringLit(ast::StringLit {
-                    base: ast::BaseNode::default(),
-                    value,
-                }),
-                operator: ast::Operator::EqualOperator,
-            }),
-        )),
-        lparen: vec![],
-        rparen: vec![],
-        params: vec![ast::Property {
-            base: ast::BaseNode::default(),
-            key: ast::PropertyKey::Identifier(ast::Identifier {
-                base: ast::BaseNode::default(),
-                name: "r".into(),
-            }),
-            comma: vec![],
-            separator: vec![],
-            value: None,
-        }],
-    }))
 }
 
 pub(crate) fn inject_tag_filter(

--- a/src/server/transform.rs
+++ b/src/server/transform.rs
@@ -221,12 +221,10 @@ macro_rules! filter {
 }
 
 fn make_from_function(bucket: String) -> ast::Statement {
-    let range = ast::ExprStmt {
+    ast::Statement::Expr(Box::new(ast::ExprStmt {
         base: ast::BaseNode::default(),
         expression: ast::Expression::PipeExpr(Box::new(pipe!(ast::Expression::Call(Box::new(from!(bucket))), range!()))),
-    };
-
-    ast::Statement::Expr(Box::new(range))
+    }))
 }
 
 #[derive(Default)]

--- a/src/server/transform.rs
+++ b/src/server/transform.rs
@@ -5,47 +5,51 @@
 use flux::ast;
 use flux::ast::walk;
 
-fn make_from_function(bucket: String) -> ast::Statement {
-    let from = ast::CallExpr {
-        base: ast::BaseNode::default(),
-        callee: ast::Expression::Identifier(ast::Identifier {
+macro_rules! from {
+    ($bucket_name:expr) => {
+        ast::CallExpr {
             base: ast::BaseNode::default(),
-            name: "from".into(),
-        }),
-        arguments: vec![ast::Expression::Object(Box::new(
-            ast::ObjectExpr {
+            callee: ast::Expression::Identifier(ast::Identifier {
                 base: ast::BaseNode::default(),
-                lbrace: vec![],
-                with: None,
-                properties: vec![flux::ast::Property {
+                name: "from".into(),
+            }),
+            arguments: vec![ast::Expression::Object(Box::new(
+                ast::ObjectExpr {
                     base: ast::BaseNode::default(),
-                    key: ast::PropertyKey::Identifier(
-                        ast::Identifier {
-                            base: ast::BaseNode::default(),
-                            name: "bucket".into(),
-                        },
-                    ),
-                    separator: vec![],
-                    value: Some(ast::Expression::StringLit(
-                        ast::StringLit {
-                            base: ast::BaseNode::default(),
-                            value: bucket,
-                        },
-                    )),
-                    comma: vec![],
-                }],
-                rbrace: vec![],
-            },
-        ))],
-        lparen: vec![],
-        rparen: vec![],
+                    lbrace: vec![],
+                    with: None,
+                    properties: vec![flux::ast::Property {
+                        base: ast::BaseNode::default(),
+                        key: ast::PropertyKey::Identifier(
+                            ast::Identifier {
+                                base: ast::BaseNode::default(),
+                                name: "bucket".into(),
+                            },
+                        ),
+                        separator: vec![],
+                        value: Some(ast::Expression::StringLit(
+                            ast::StringLit {
+                                base: ast::BaseNode::default(),
+                                value: $bucket_name,  // BUCKET GOES HERE
+                            },
+                        )),
+                        comma: vec![],
+                    }],
+                    rbrace: vec![],
+                },
+            ))],
+            lparen: vec![],
+            rparen: vec![],
+        }
     };
+}
 
+fn make_from_function(bucket: String) -> ast::Statement {
     let range = ast::ExprStmt {
         base: ast::BaseNode::default(),
         expression: ast::Expression::PipeExpr(Box::new(
             ast::PipeExpr {
-                argument: ast::Expression::Call(Box::new(from)),
+                argument: ast::Expression::Call(Box::new(from!(bucket))),
                 base: ast::BaseNode::default(),
                 call: ast::CallExpr {
                     arguments: vec![ast::Expression::Object(


### PR DESCRIPTION
This patch is a first (experimental) attempt at creating a macro api for
constructing asts.