### PR TITLE
feat: implement the initial composition

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -1,0 +1,489 @@
+/// Composition functionality
+///
+/// This module covers all the functionality that comes from the Composition feature of the
+/// LSP server. It's spec can be found in the docs/ folder of source control.
+///
+/// This module _only_ operates on an AST. It will never operate on semantic graph.
+use flux::ast;
+
+static YIELD_IDENTIFIER: &str = "_editor_composition";
+
+macro_rules! from {
+    ($bucket_name:expr) => {
+        ast::CallExpr {
+            base: ast::BaseNode::default(),
+            callee: ast::Expression::Identifier(ast::Identifier {
+                base: ast::BaseNode::default(),
+                name: "from".into(),
+            }),
+            arguments: vec![ast::Expression::Object(Box::new(
+                ast::ObjectExpr {
+                    base: ast::BaseNode::default(),
+                    lbrace: vec![],
+                    with: None,
+                    properties: vec![flux::ast::Property {
+                        base: ast::BaseNode::default(),
+                        key: ast::PropertyKey::Identifier(
+                            ast::Identifier {
+                                base: ast::BaseNode::default(),
+                                name: "bucket".into(),
+                            },
+                        ),
+                        separator: vec![],
+                        value: Some(ast::Expression::StringLit(
+                            ast::StringLit {
+                                base: ast::BaseNode::default(),
+                                value: $bucket_name,  // BUCKET GOES HERE
+                            },
+                        )),
+                        comma: vec![],
+                    }],
+                    rbrace: vec![],
+                },
+            ))],
+            lparen: vec![],
+            rparen: vec![],
+        }
+    };
+}
+
+macro_rules! range {
+    () => {
+        ast::CallExpr {
+            arguments: vec![ast::Expression::Object(
+                Box::new(ast::ObjectExpr {
+                    base: ast::BaseNode::default(),
+                    properties: vec![ast::Property {
+                        base: ast::BaseNode::default(),
+                        key: ast::PropertyKey::Identifier(
+                            ast::Identifier {
+                                base: ast::BaseNode::default(
+                                ),
+                                name: "start".into(),
+                            },
+                        ),
+                        value: Some(
+                            ast::Expression::Member(Box::new(ast::MemberExpr {
+                                base: ast::BaseNode::default(),
+                                lbrack: vec![],
+                                rbrack: vec![],
+                                object: ast::Expression::Identifier(
+                                    ast::Identifier {
+                                        base: ast::BaseNode::default(),
+                                        name: "v".into(),
+                                    }
+                                ),
+                                property: ast::PropertyKey::Identifier(ast::Identifier {
+                                    base: ast::BaseNode::default(),
+                                    name: "timeRangeStart".into(),
+                                })
+                            }))
+                        ),
+                        comma: vec![],
+                        separator: vec![],
+                    },
+                    ast::Property {
+                        base: ast::BaseNode::default(),
+                        key: ast::PropertyKey::Identifier(
+                            ast::Identifier {
+                                base: ast::BaseNode::default(
+                                ),
+                                name: "stop".into(),
+                            },
+                        ),
+                        value: Some(
+                            ast::Expression::Member(Box::new(ast::MemberExpr {
+                                base: ast::BaseNode::default(),
+                                lbrack: vec![],
+                                rbrack: vec![],
+                                object: ast::Expression::Identifier(
+                                    ast::Identifier {
+                                        base: ast::BaseNode::default(),
+                                        name: "v".into(),
+                                    }
+                                ),
+                                property: ast::PropertyKey::Identifier(ast::Identifier {
+                                    base: ast::BaseNode::default(),
+                                    name: "timeRangeStop".into(),
+                                })
+                            }))
+                        ),
+                        comma: vec![],
+                        separator: vec![],
+                    }
+                    ],
+                    lbrace: vec![],
+                    rbrace: vec![],
+                    with: None,
+                }),
+            )],
+            base: ast::BaseNode::default(),
+            callee: ast::Expression::Identifier(
+                ast::Identifier {
+                    base: ast::BaseNode::default(),
+                    name: "range".into(),
+                },
+            ),
+            lparen: vec![],
+            rparen: vec![],
+        }
+    }
+}
+
+macro_rules! filter {
+    ($key:expr, $value:expr) => {
+        ast::CallExpr {
+            arguments: vec![ast::Expression::Object(
+                Box::new(ast::ObjectExpr {
+                    base: ast::BaseNode::default(),
+                    properties: vec![ast::Property {
+                        base: ast::BaseNode::default(),
+                        key: ast::PropertyKey::Identifier(
+                            ast::Identifier {
+                                base: ast::BaseNode::default(
+                                ),
+                                name: "fn".into(),
+                            },
+                        ),
+                        value: Some(
+                            ast::Expression::Function(Box::new(ast::FunctionExpr {
+                                arrow: vec![],
+                                base: ast::BaseNode::default(),
+                                body: ast::FunctionBody::Expr(ast::Expression::Binary(
+                                    Box::new(ast::BinaryExpr {
+                                        base: ast::BaseNode::default(),
+                                        left: ast::Expression::Member(Box::new(
+                                            ast::MemberExpr {
+                                                base: ast::BaseNode::default(),
+                                                lbrack: vec![],
+                                                rbrack: vec![],
+                                                object: ast::Expression::Identifier(
+                                                    ast::Identifier {
+                                                        base: ast::BaseNode::default(),
+                                                        name: "r".into(),
+                                                    },
+                                                ),
+                                                property: ast::PropertyKey::Identifier(
+                                                    ast::Identifier {
+                                                        base: ast::BaseNode::default(),
+                                                        name: $key,
+                                                    },
+                                                ),
+                                            },
+                                        )),
+                                        right: ast::Expression::StringLit(ast::StringLit {
+                                            base: ast::BaseNode::default(),
+                                            value: $value,
+                                        }),
+                                        operator: ast::Operator::EqualOperator,
+                                    }),
+                                )),
+                                lparen: vec![],
+                                rparen: vec![],
+                                params: vec![ast::Property {
+                                    base: ast::BaseNode::default(),
+                                    key: ast::PropertyKey::Identifier(ast::Identifier {
+                                        base: ast::BaseNode::default(),
+                                        name: "r".into(),
+                                    }),
+                                    comma: vec![],
+                                    separator: vec![],
+                                    value: None,
+                                }],
+                            }))
+                        ),
+                        comma: vec![],
+                        separator: vec![],
+                    }],
+                    lbrace: vec![],
+                    rbrace: vec![],
+                    with: None,
+                }),
+            )],
+            base: ast::BaseNode::default(),
+            callee: ast::Expression::Identifier(
+                ast::Identifier {
+                    base: ast::BaseNode::default(),
+                    name: "filter".into(),
+                },
+            ),
+            lparen: vec![],
+            rparen: vec![],
+        }
+    }
+}
+
+macro_rules! yield_ {
+    () => {
+        ast::CallExpr {
+            arguments: vec![ast::Expression::Object(Box::new(
+                ast::ObjectExpr {
+                    base: ast::BaseNode::default(),
+                    properties: vec![ast::Property {
+                        base: ast::BaseNode::default(),
+                        key: ast::PropertyKey::Identifier(
+                            ast::Identifier {
+                                base: ast::BaseNode::default(),
+                                name: "name".into(),
+                            },
+                        ),
+                        value: Some(ast::Expression::StringLit(
+                            ast::StringLit {
+                                base: ast::BaseNode::default(),
+                                value: YIELD_IDENTIFIER.into(),
+                            },
+                        )),
+                        comma: vec![],
+                        separator: vec![],
+                    }],
+                    lbrace: vec![],
+                    rbrace: vec![],
+                    with: None,
+                },
+            ))],
+            base: ast::BaseNode::default(),
+            callee: ast::Expression::Identifier(ast::Identifier {
+                base: ast::BaseNode::default(),
+                name: "yield".into(),
+            }),
+            lparen: vec![],
+            rparen: vec![],
+        }
+    };
+}
+
+macro_rules! pipe {
+    ($a:expr, $b:expr) => {
+        ast::PipeExpr {
+            argument: $a,
+            base: ast::BaseNode::default(),
+            call: $b,
+        }
+    };
+}
+
+/// Find the composition statement.
+///
+/// The composition statement is identified as follows: a `from` function that contains
+/// a yield with the name "_editor_composition".
+#[derive(Default)]
+struct CompositionStatementFinderVisitor {
+    statement: Option<ast::ExprStmt>,
+}
+
+impl<'a> ast::walk::Visitor<'a>
+    for CompositionStatementFinderVisitor
+{
+    fn visit(&mut self, node: ast::walk::Node<'a>) -> bool {
+        if self.statement.is_some() {
+            // If the statement was found, don't keep looking.
+            return false;
+        }
+
+        if let ast::walk::Node::ExprStmt(expr_statement) = node {
+            if let ast::Expression::PipeExpr(expr) =
+                &expr_statement.expression
+            {
+                if let ast::Expression::Identifier(identifier) =
+                    &expr.call.callee
+                {
+                    if identifier.name == "yield" {
+                        expr.call.arguments.iter().any(|argument| {
+                            if let ast::Expression::Object(object) = argument {
+                                object.properties.iter().any(|property| {
+                                    if let ast::PropertyKey::Identifier(key) = &property.key {
+                                        if key.name == "name" {
+                                            // Because we would have generated this statement, we'll always be able to
+                                            // assert the simplicity of the yield name, i.e. it won't be a deeply nested
+                                            // expression.
+                                            if let Some(ast::Expression::StringLit(literal)) = &property.value {
+                                                if literal.value == YIELD_IDENTIFIER {
+                                                    self.statement = Some(expr_statement.clone());
+                                                    return true;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    false
+                                })
+                            } else {
+                                false
+                            }
+                        });
+                        return false;
+                    }
+                }
+            }
+        }
+        true
+    }
+}
+
+/// Composition acts as the public entry point into the composition functionality.
+struct Composition {
+    file: ast::File,
+}
+
+impl ToString for Composition {
+    fn to_string(&self) -> String {
+        flux::formatter::convert_to_string(&self.file)
+            .expect("Unable to convert composition file to string.")
+    }
+}
+
+impl Composition {
+    #[allow(dead_code)]
+    fn new(file: ast::File) -> Self {
+        Self { file }
+    }
+
+    /// Initialize an ast::File for use in composition.
+    ///
+    /// This must be called before any other composition can be made, as it'll set up the
+    /// statement that will be managed by composition.
+    #[allow(dead_code)]
+    fn initialize(
+        &mut self,
+        bucket: &str,
+        measurement: Option<&str>,
+    ) -> Result<(), ()> {
+        let mut visitor =
+            CompositionStatementFinderVisitor::default();
+        flux::ast::walk::walk(
+            &mut visitor,
+            flux::ast::walk::Node::File(&self.file),
+        );
+        if let Some(expr_statement) = visitor.statement {
+            self.file.body = self
+                .file
+                .body
+                .iter()
+                .filter(|statement| match statement {
+                    ast::Statement::Expr(expression) => {
+                        expr_statement != *expression.as_ref()
+                    }
+                    _ => true,
+                })
+                .cloned()
+                .collect();
+        }
+
+        let statement = match measurement {
+            None => {
+                pipe!(
+                    ast::Expression::PipeExpr(Box::new(pipe!(
+                        ast::Expression::Call(Box::new(from!(
+                            bucket.to_string()
+                        ))),
+                        range!()
+                    ))),
+                    yield_!()
+                )
+            }
+            Some(measurement) => {
+                pipe!(
+                    ast::Expression::PipeExpr(Box::new(pipe!(
+                        ast::Expression::PipeExpr(Box::new(pipe!(
+                            ast::Expression::Call(Box::new(from!(
+                                bucket.to_string()
+                            ))),
+                            range!()
+                        ),)),
+                        filter!(
+                            "_measurement".into(),
+                            measurement.into()
+                        )
+                    ))),
+                    yield_!()
+                )
+            }
+        };
+
+        self.file.body.insert(
+            0,
+            ast::Statement::Expr(Box::new(ast::ExprStmt {
+                base: ast::BaseNode::default(),
+                expression: ast::Expression::PipeExpr(Box::new(
+                    statement,
+                )),
+            })),
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Initializing composition for a file will add a composition-owned statement
+    /// that will be the statement that filters will be added/removed.
+    #[test]
+    fn composition_initialize() {
+        let fluxscript = r#"from(bucket: "my-bucket") |> yield(name: "my-result")"#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+
+        let mut composition = Composition::new(ast);
+
+        composition.initialize(&"an-composition", None).unwrap();
+
+        assert_eq!(
+            r#"from(bucket: "an-composition")
+    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+    |> yield(name: "_editor_composition")
+from(bucket: "my-bucket") |> yield(name: "my-result")
+"#
+            .to_string(),
+            composition.to_string()
+        );
+    }
+
+    /// Initializing composition on a file already initialized acts as a "reset",
+    /// where buckets can be changed and filters removed.
+    #[test]
+    fn composition_initialize_reset() {
+        let fluxscript = r#"from(bucket: "an-composition")
+|> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+|> filter(fn: (r) => r.myTag == "myValue")
+|> yield(name: "_editor_composition")"#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+
+        let mut composition = Composition::new(ast);
+
+        composition.initialize(&"an-composition", None).unwrap();
+
+        assert_eq!(
+            r#"from(bucket: "an-composition")
+    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+    |> yield(name: "_editor_composition")
+"#
+            .to_string(),
+            composition.to_string()
+        );
+    }
+
+    /// Initializing with a measurement will add a new |> filter call to go along
+    /// with the rest of the function.
+    #[test]
+    fn composition_initialize_with_measurement() {
+        let fluxscript = r#""#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+
+        let mut composition = Composition::new(ast);
+
+        composition
+            .initialize(&"an-composition", Some("myMeasurement"))
+            .unwrap();
+
+        assert_eq!(
+            r#"from(bucket: "an-composition")
+    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+    |> filter(fn: (r) => r._measurement == "myMeasurement")
+    |> yield(name: "_editor_composition")
+"#
+            .to_string(),
+            composition.to_string()
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
     clippy::wildcard_imports
 )]
 mod completion;
+mod composition;
 mod diagnostics;
 mod lang;
 mod lsp;
@@ -27,7 +28,7 @@ pub use server::LspServer;
 
 #[macro_export]
 macro_rules! walk_ast_package {
-    ($visitor:expr, $package:ident) => {{
+    ($visitor:expr, $package:expr) => {{
         let mut visitor = $visitor;
         flux::ast::walk::walk(
             &mut visitor,


### PR DESCRIPTION
This patch implements the Composition feature as far as initialization and
adding of a measurement. It includes the constraints for not being able to add
multiple measurements.