### PR TITLE
feat: add_field() for composition

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -345,6 +345,7 @@ impl CompositionQueryAnalyzer {
                 )
             }
             Some(measurement) => {
+                let measurements = vec![measurement.to_owned()];
                 pipe!(
                     ast::Expression::PipeExpr(Box::new(pipe!(
                         ast::Expression::PipeExpr(Box::new(pipe!(
@@ -355,7 +356,11 @@ impl CompositionQueryAnalyzer {
                         ),)),
                         filter!(
                             "_measurement".into(),
+<<<<<<< HEAD
                             &[measurement.to_owned()],
+=======
+                            &measurements,
+>>>>>>> b172270 (feat: have macro filter! handle multiple predicate statements, all with the same logical operator. Use macros for the compile time AST construction, sandwiched around a runtime fn logical_expr() which handles the runtime determined length of the values array.)
                             ast::LogicalOperator::OrOperator
                         )
                     ))),

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -332,8 +332,9 @@ impl CompositionQueryAnalyzer {
     }
 
     fn build(&mut self) -> ast::PipeExpr {
-        match &self.measurement {
-            None => {
+        match (&self.measurement, self.fields.len(), self.tags.len())
+        {
+            (None, 0, 0) => {
                 pipe!(
                     ast::Expression::PipeExpr(Box::new(pipe!(
                         ast::Expression::Call(Box::new(from!(self
@@ -362,6 +363,53 @@ impl CompositionQueryAnalyzer {
                     yield_!()
                 )
             }
+            (None, 1.., 0) => {
+                pipe!(
+                    ast::Expression::PipeExpr(Box::new(pipe!(
+                        ast::Expression::PipeExpr(Box::new(pipe!(
+                            ast::Expression::Call(Box::new(from!(
+                                self.bucket.to_owned()
+                            ))),
+                            range!()
+                        ),)),
+                        filter!(
+                            "_field".into(),
+                            &self.fields,
+                            ast::LogicalOperator::OrOperator
+                        )
+                    ))),
+                    yield_!()
+                )
+            }
+            (Some(measurement), 1.., 0) => {
+                let measurements = vec![measurement.to_owned()];
+                pipe!(
+                    ast::Expression::PipeExpr(Box::new(pipe!(
+                        ast::Expression::PipeExpr(Box::new(pipe!(
+                            ast::Expression::PipeExpr(Box::new(
+                                pipe!(
+                                    ast::Expression::Call(Box::new(
+                                        from!(self.bucket.to_owned())
+                                    )),
+                                    range!()
+                                ),
+                            )),
+                            filter!(
+                                "_measurement".into(),
+                                &measurements,
+                                ast::LogicalOperator::OrOperator
+                            )
+                        ))),
+                        filter!(
+                            "_field".into(),
+                            &self.fields,
+                            ast::LogicalOperator::OrOperator
+                        )
+                    ))),
+                    yield_!()
+                )
+            }
+            _ => todo!(),
         }
     }
 }
@@ -632,6 +680,56 @@ impl Composition {
         );
         Ok(())
     }
+
+    #[allow(dead_code)]
+    fn add_field(&mut self, field: &str) -> CompositionResult {
+        let mut visitor =
+            CompositionStatementFinderVisitor::default();
+        flux::ast::walk::walk(
+            &mut visitor,
+            flux::ast::walk::Node::File(&self.file),
+        );
+        if visitor.statement.is_none() {
+            return Err(());
+        }
+        let expr_statement =
+            visitor.statement.expect("Previous check failed.");
+
+        let mut analyzer = CompositionQueryAnalyzer::default();
+        analyzer.analyze(expr_statement.clone());
+
+        if analyzer.fields.contains(&field.to_string()) {
+            return Err(());
+        } else {
+            analyzer.fields.push(field.to_string());
+        }
+        let statement = analyzer.build();
+
+        self.file.body = self
+            .file
+            .body
+            .iter()
+            .filter(|statement| match statement {
+                ast::Statement::Expr(expression) => {
+                    expr_statement != *expression.as_ref()
+                }
+                _ => true,
+            })
+            .cloned()
+            .collect();
+
+        self.file.body.insert(
+            0,
+            ast::Statement::Expr(Box::new(ast::ExprStmt {
+                base: ast::BaseNode::default(),
+                expression: ast::Expression::PipeExpr(Box::new(
+                    statement,
+                )),
+            })),
+        );
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -792,5 +890,95 @@ from(bucket: "my-bucket") |> yield(name: "my-result")
         assert!(composition
             .add_measurement(&"myMeasurement")
             .is_err());
+    }
+
+    #[test]
+    fn composition_add_field() {
+        let fluxscript = r#"from(bucket: "an-composition")
+        |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+        |> yield(name: "_editor_composition")
+    "#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+
+        let mut composition = Composition::new(ast);
+        // DON'T INITIALIZE THIS! WE'RE SIMULATING AN ALREADY INITIALIZED QUERY.
+        composition.add_field(&"myField").unwrap();
+
+        assert_eq!(
+            r#"from(bucket: "an-composition")
+    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+    |> filter(fn: (r) => r._field == "myField")
+    |> yield(name: "_editor_composition")
+"#
+            .to_string(),
+            composition.to_string()
+        )
+    }
+
+    #[test]
+    fn composition_add_field_with_measurement() {
+        let fluxscript = r#"from(bucket: "an-composition")
+        |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+        |> filter(fn: (r) => r._measurement == "anMeasurement")
+        |> yield(name: "_editor_composition")
+    "#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+
+        let mut composition = Composition::new(ast);
+        // DON'T INITIALIZE THIS! WE'RE SIMULATING AN ALREADY INITIALIZED QUERY.
+        composition.add_field(&"myField").unwrap();
+
+        assert_eq!(
+            r#"from(bucket: "an-composition")
+    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+    |> filter(fn: (r) => r._measurement == "anMeasurement")
+    |> filter(fn: (r) => r._field == "myField")
+    |> yield(name: "_editor_composition")
+"#
+            .to_string(),
+            composition.to_string()
+        )
+    }
+
+    #[test]
+    fn composition_add_field_field_already_exists() {
+        let fluxscript = r#"from(bucket: "an-composition")
+        |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+        |> filter(fn: (r) => r._measurement == "anMeasurement")
+        |> filter(fn: (r) => r._field == "anField")
+        |> yield(name: "_editor_composition")
+    "#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+
+        let mut composition = Composition::new(ast);
+        // DON'T INITIALIZE THIS! WE'RE SIMULATING AN ALREADY INITIALIZED QUERY.
+
+        assert!(composition.add_field(&"anField").is_err());
+    }
+
+    #[test]
+    fn composition_add_field_second_field() {
+        let fluxscript = r#"from(bucket: "an-composition")
+        |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+        |> filter(fn: (r) => r._measurement == "anMeasurement")
+        |> filter(fn: (r) => r._field == "firstField")
+        |> yield(name: "_editor_composition")
+    "#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+
+        let mut composition = Composition::new(ast);
+        // DON'T INITIALIZE THIS! WE'RE SIMULATING AN ALREADY INITIALIZED QUERY.
+        composition.add_field(&"secondField").unwrap();
+
+        assert_eq!(
+            r#"from(bucket: "an-composition")
+    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+    |> filter(fn: (r) => r._measurement == "anMeasurement")
+    |> filter(fn: (r) => r._field == "firstField" or r._field == "secondField")
+    |> yield(name: "_editor_composition")
+"#
+            .to_string(),
+            composition.to_string()
+        )
     }
 }

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -345,7 +345,6 @@ impl CompositionQueryAnalyzer {
                 )
             }
             Some(measurement) => {
-                let measurements = vec![measurement.to_owned()];
                 pipe!(
                     ast::Expression::PipeExpr(Box::new(pipe!(
                         ast::Expression::PipeExpr(Box::new(pipe!(
@@ -356,11 +355,7 @@ impl CompositionQueryAnalyzer {
                         ),)),
                         filter!(
                             "_measurement".into(),
-<<<<<<< HEAD
                             &[measurement.to_owned()],
-=======
-                            &measurements,
->>>>>>> b172270 (feat: have macro filter! handle multiple predicate statements, all with the same logical operator. Use macros for the compile time AST construction, sandwiched around a runtime fn logical_expr() which handles the runtime determined length of the values array.)
                             ast::LogicalOperator::OrOperator
                         )
                     ))),


### PR DESCRIPTION
### In chain of PRs:
1. composition query analyzer
   * https://github.com/influxdata/flux-lsp/pull/551
2. composition query builder
   * https://github.com/influxdata/flux-lsp/pull/554
3. filter with multiple predicates in logical expression
   * https://github.com/influxdata/flux-lsp/pull/555
4. `add_field()`
   * **THIS PR**
5. `add_tag_values()`
   * https://github.com/influxdata/flux-lsp/pull/557
6. `add_tag()`
   * https://github.com/influxdata/flux-lsp/pull/558
7. DRY: `remove_previous()` and `add_updated()` methods
   * https://github.com/influxdata/flux-lsp/pull/559

### Goal for this PR:
Ability to add a field filter to a composition. Also allow adding the next field to the same filter.