### PR TITLE
chore: DRY for schema composition

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -644,29 +644,9 @@ impl Composition {
         let statement = analyzer.build();
 
         if let Some(expr_statement) = visitor.statement {
-            self.file.body = self
-                .file
-                .body
-                .iter()
-                .filter(|statement| match statement {
-                    ast::Statement::Expr(expression) => {
-                        expr_statement != *expression.as_ref()
-                    }
-                    _ => true,
-                })
-                .cloned()
-                .collect();
+            self.remove_previous(expr_statement);
         }
-
-        self.file.body.insert(
-            0,
-            ast::Statement::Expr(Box::new(ast::ExprStmt {
-                base: ast::BaseNode::default(),
-                expression: ast::Expression::PipeExpr(Box::new(
-                    statement,
-                )),
-            })),
-        );
+        self.add_updated(statement);
         Ok(())
     }
 
@@ -696,28 +676,8 @@ impl Composition {
         }
         let statement = analyzer.build();
 
-        self.file.body = self
-            .file
-            .body
-            .iter()
-            .filter(|statement| match statement {
-                ast::Statement::Expr(expression) => {
-                    expr_statement != *expression.as_ref()
-                }
-                _ => true,
-            })
-            .cloned()
-            .collect();
-
-        self.file.body.insert(
-            0,
-            ast::Statement::Expr(Box::new(ast::ExprStmt {
-                base: ast::BaseNode::default(),
-                expression: ast::Expression::PipeExpr(Box::new(
-                    statement,
-                )),
-            })),
-        );
+        self.remove_previous(expr_statement);
+        self.add_updated(statement);
         Ok(())
     }
 
@@ -745,29 +705,8 @@ impl Composition {
         }
         let statement = analyzer.build();
 
-        self.file.body = self
-            .file
-            .body
-            .iter()
-            .filter(|statement| match statement {
-                ast::Statement::Expr(expression) => {
-                    expr_statement != *expression.as_ref()
-                }
-                _ => true,
-            })
-            .cloned()
-            .collect();
-
-        self.file.body.insert(
-            0,
-            ast::Statement::Expr(Box::new(ast::ExprStmt {
-                base: ast::BaseNode::default(),
-                expression: ast::Expression::PipeExpr(Box::new(
-                    statement,
-                )),
-            })),
-        );
-
+        self.remove_previous(expr_statement);
+        self.add_updated(statement);
         Ok(())
     }
 
@@ -795,29 +734,8 @@ impl Composition {
         }
         let statement = analyzer.build();
 
-        self.file.body = self
-            .file
-            .body
-            .iter()
-            .filter(|statement| match statement {
-                ast::Statement::Expr(expression) => {
-                    expr_statement != *expression.as_ref()
-                }
-                _ => true,
-            })
-            .cloned()
-            .collect();
-
-        self.file.body.insert(
-            0,
-            ast::Statement::Expr(Box::new(ast::ExprStmt {
-                base: ast::BaseNode::default(),
-                expression: ast::Expression::PipeExpr(Box::new(
-                    statement,
-                )),
-            })),
-        );
-
+        self.remove_previous(expr_statement);
+        self.add_updated(statement);
         Ok(())
     }
 
@@ -850,19 +768,27 @@ impl Composition {
         }
         let statement = analyzer.build();
 
+        self.remove_previous(expr_statement);
+        self.add_updated(statement);
+        Ok(())
+    }
+
+    fn remove_previous(&mut self, found_composition: ast::ExprStmt) {
         self.file.body = self
             .file
             .body
             .iter()
             .filter(|statement| match statement {
                 ast::Statement::Expr(expression) => {
-                    expr_statement != *expression.as_ref()
+                    found_composition != *expression.as_ref()
                 }
                 _ => true,
             })
             .cloned()
             .collect();
+    }
 
+    fn add_updated(&mut self, statement: ast::PipeExpr) {
         self.file.body.insert(
             0,
             ast::Statement::Expr(Box::new(ast::ExprStmt {
@@ -871,9 +797,7 @@ impl Composition {
                     statement,
                 )),
             })),
-        );
-
-        Ok(())
+        )
     }
 }
 


### PR DESCRIPTION
### In chain of PRs:
1. composition query analyzer
   * https://github.com/influxdata/flux-lsp/pull/551
2. composition query builder
   * https://github.com/influxdata/flux-lsp/pull/554
3. filter with multiple predicates in logical expression
   * https://github.com/influxdata/flux-lsp/pull/555
4. `add_field()`
   * https://github.com/influxdata/flux-lsp/pull/556
5. `add_tag_values()`
   * https://github.com/influxdata/flux-lsp/pull/557
6. `add_tag()`
   * https://github.com/influxdata/flux-lsp/pull/558
7. DRY: `remove_previous()` and `add_updated()` methods
   * **THIS PR**

### Goal for this PR:
Now that we have demonstrated the exact same code everywhere, start DRY on the common code pattern.

This PR is intentionally the last in the PR daisy chain, because there is **alot more common code** which we could extract...but I don't want to push the limits without insight from the rest of the team. Once peeps are back, we can expand more on this PR.