### PR TITLE
feat: multiple filters of same schema type

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -1306,8 +1306,8 @@ from(bucket: "my-bucket") |> yield(name: "my-result")
         assert_eq!(
             r#"from(bucket: "an-composition")
     |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-    |> filter(fn: (r) => exists r.tagKey)
     |> filter(fn: (r) => r.tagKey == "tagValue")
+    |> filter(fn: (r) => exists r.tagKey)
     |> yield(name: "_editor_composition")
 "#
             .to_string(),


### PR DESCRIPTION
### In chain of PRs:
1. composition query analyzer
   * https://github.com/influxdata/flux-lsp/pull/551
2. composition query builder
   * https://github.com/influxdata/flux-lsp/pull/554
3. filter with multiple predicates in logical expression
   * https://github.com/influxdata/flux-lsp/pull/555
4. `add_field()`
   * https://github.com/influxdata/flux-lsp/pull/556
5. `add_tag_values()`
   * https://github.com/influxdata/flux-lsp/pull/557
6. `add_tag()`
   * https://github.com/influxdata/flux-lsp/pull/558
7. DRY: `remove_previous()` and `add_updated()` methods
   * https://github.com/influxdata/flux-lsp/pull/559
8. have `add_tag()` and `add_tag_values()` occur in separate filters.
   * **THIS PR**

### Goal for this PR:
* when a user adds a tag or tag_value, create a new filter
* these new filters can be added in any order, in relation to existing filters. (e.g. a field or measurement filter).
* The addition of a new filter, does not preclude existing filters using an AND.
  * you have an existing `|> filter((r) => exists r.tag1 and exists r.tag2)`
  * analyzer will detect the previous AND statement
  * `add_tag` will insert a new filter 