### PR TITLE
feat: wire composition add_tag() and remove_tag() into LspServer

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -823,8 +823,10 @@ impl Composition {
         Ok(())
     }
 
-    #[allow(dead_code)]
-    fn add_tag(&mut self, tag: &str) -> CompositionResult {
+    pub(crate) fn add_tag(
+        &mut self,
+        tag: String,
+    ) -> CompositionResult {
         let mut visitor =
             CompositionStatementFinderVisitor::default();
         flux::ast::walk::walk(
@@ -840,10 +842,10 @@ impl Composition {
         let mut analyzer = CompositionQueryAnalyzer::default();
         analyzer.analyze(expr_statement.clone());
 
-        if analyzer.tags.contains(&tag.to_string()) {
+        if analyzer.tags.contains(&tag) {
             return Err(());
         } else {
-            analyzer.tags.push(tag.to_string());
+            analyzer.tags.push(tag);
         }
         let statement = analyzer.build();
 
@@ -873,8 +875,10 @@ impl Composition {
         Ok(())
     }
 
-    #[allow(dead_code)]
-    fn remove_tag(&mut self, tag: &str) -> CompositionResult {
+    pub(crate) fn remove_tag(
+        &mut self,
+        tag: String,
+    ) -> CompositionResult {
         let mut visitor =
             CompositionStatementFinderVisitor::default();
         flux::ast::walk::walk(
@@ -891,7 +895,7 @@ impl Composition {
         analyzer.analyze(expr_statement.clone());
 
         let previous_len = analyzer.tags.len();
-        analyzer.tags.retain(|t| t != &tag.to_string());
+        analyzer.tags.retain(|t| t != &tag);
 
         if previous_len == analyzer.tags.len() {
             return Err(());
@@ -1520,7 +1524,7 @@ from(bucket: "my-bucket") |> yield(name: "my-result")
 
         let mut composition = Composition::new(ast);
         // DON'T INITIALIZE THIS! WE'RE SIMULATING AN ALREADY INITIALIZED QUERY.
-        composition.add_tag(&"tagKey").unwrap();
+        composition.add_tag(String::from("tagKey")).unwrap();
 
         assert_eq!(
             r#"from(bucket: "an-composition")
@@ -1545,7 +1549,7 @@ from(bucket: "my-bucket") |> yield(name: "my-result")
         let mut composition = Composition::new(ast);
         // DON'T INITIALIZE THIS! WE'RE SIMULATING AN ALREADY INITIALIZED QUERY.
 
-        assert!(composition.add_tag(&"tagKey").is_err());
+        assert!(composition.add_tag(String::from("tagKey")).is_err());
     }
 
     #[test]
@@ -1559,7 +1563,7 @@ from(bucket: "my-bucket") |> yield(name: "my-result")
 
         let mut composition = Composition::new(ast);
         // DON'T INITIALIZE THIS! WE'RE SIMULATING AN ALREADY INITIALIZED QUERY.
-        composition.add_tag(&"tagKey").unwrap();
+        composition.add_tag(String::from("tagKey")).unwrap();
 
         assert_eq!(
             r#"from(bucket: "an-composition")
@@ -1586,7 +1590,7 @@ from(bucket: "my-bucket") |> yield(name: "my-result")
 
         let mut composition = Composition::new(ast);
         // DON'T INITIALIZE THIS! WE'RE SIMULATING AN ALREADY INITIALIZED QUERY.
-        composition.add_tag(&"tagKey2").unwrap();
+        composition.add_tag(String::from("tagKey2")).unwrap();
 
         assert_eq!(
             r#"from(bucket: "an-composition")
@@ -1614,7 +1618,7 @@ from(bucket: "my-bucket") |> yield(name: "my-result")
 
         let mut composition = Composition::new(ast);
         // DON'T INITIALIZE THIS! WE'RE SIMULATING AN ALREADY INITIALIZED QUERY.
-        composition.remove_tag(&"tagKey").unwrap();
+        composition.remove_tag(String::from("tagKey")).unwrap();
 
         assert_eq!(
             r#"from(bucket: "an-composition")
@@ -1640,7 +1644,7 @@ from(bucket: "my-bucket") |> yield(name: "my-result")
 
         let mut composition = Composition::new(ast);
         // DON'T INITIALIZE THIS! WE'RE SIMULATING AN ALREADY INITIALIZED QUERY.
-        composition.remove_tag(&"tagKey2").unwrap();
+        composition.remove_tag(String::from("tagKey2")).unwrap();
 
         assert_eq!(
             r#"from(bucket: "an-composition")
@@ -1666,6 +1670,8 @@ from(bucket: "my-bucket") |> yield(name: "my-result")
 
         let mut composition = Composition::new(ast);
         // DON'T INITIALIZE THIS! WE'RE SIMULATING AN ALREADY INITIALIZED QUERY.
-        assert!(composition.remove_tag(&"tagKey2").is_err());
+        assert!(composition
+            .remove_tag(String::from("tagKey2"))
+            .is_err());
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1958,8 +1958,152 @@ impl LanguageServer for LspServer {
 
                 Ok(None)
             }
-            Ok(LspServerCommand::AddTagFilter) => todo!(),
-            Ok(LspServerCommand::RemoveTagFilter) => todo!(),
+            Ok(LspServerCommand::AddTagFilter) => {
+                let command_params: ValueFilterParams =
+                    match serde_json::value::from_value(
+                        params.arguments[0].clone(),
+                    ) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            return Err(LspError::InternalError(
+                                format!("{:?}", err),
+                            )
+                            .into())
+                        }
+                    };
+
+                let file = self.store.get_ast_file(
+                    &command_params.text_document.uri,
+                )?;
+                let mut composition =
+                    composition::Composition::new(file);
+                let status =
+                    composition.add_tag(command_params.value);
+                if status.is_err() {
+                    return Err(LspError::InternalError(
+                        "Failed to add tag to composition."
+                            .to_string(),
+                    )
+                    .into());
+                }
+                let new_text = composition.to_string();
+
+                let last_pos =
+                    line_col::LineColLookup::new(&new_text)
+                        .get(new_text.len());
+
+                let edit = lsp::WorkspaceEdit {
+                    changes: Some(HashMap::from([(
+                        command_params.text_document.uri.clone(),
+                        vec![lsp::TextEdit {
+                            new_text: new_text.clone(),
+                            range: lsp::Range {
+                                start: lsp::Position::default(),
+                                end: lsp::Position {
+                                    line: last_pos.0 as u32,
+                                    character: last_pos.1 as u32,
+                                },
+                            },
+                        }],
+                    )])),
+                    document_changes: None,
+                    change_annotations: None,
+                };
+
+                if let Some(client) = self.get_client() {
+                    match client.apply_edit(edit, None).await {
+                        Ok(response) => {
+                            if response.applied {
+                                self.store.put(
+                                    &command_params.text_document.uri,
+                                    &new_text,
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            return Err(LspError::InternalError(
+                                format!("{:?}", err),
+                            )
+                            .into())
+                        }
+                    };
+                };
+
+                Ok(None)
+            }
+            Ok(LspServerCommand::RemoveTagFilter) => {
+                let command_params: ValueFilterParams =
+                    match serde_json::value::from_value(
+                        params.arguments[0].clone(),
+                    ) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            return Err(LspError::InternalError(
+                                format!("{:?}", err),
+                            )
+                            .into())
+                        }
+                    };
+
+                let file = self.store.get_ast_file(
+                    &command_params.text_document.uri,
+                )?;
+                let mut composition =
+                    composition::Composition::new(file);
+                let status =
+                    composition.remove_tag(command_params.value);
+                if status.is_err() {
+                    return Err(LspError::InternalError(
+                        "Failed to remove tag from composition."
+                            .to_string(),
+                    )
+                    .into());
+                }
+                let new_text = composition.to_string();
+
+                let last_pos =
+                    line_col::LineColLookup::new(&new_text)
+                        .get(new_text.len());
+
+                let edit = lsp::WorkspaceEdit {
+                    changes: Some(HashMap::from([(
+                        command_params.text_document.uri.clone(),
+                        vec![lsp::TextEdit {
+                            new_text: new_text.clone(),
+                            range: lsp::Range {
+                                start: lsp::Position::default(),
+                                end: lsp::Position {
+                                    line: last_pos.0 as u32,
+                                    character: last_pos.1 as u32,
+                                },
+                            },
+                        }],
+                    )])),
+                    document_changes: None,
+                    change_annotations: None,
+                };
+
+                if let Some(client) = self.get_client() {
+                    match client.apply_edit(edit, None).await {
+                        Ok(response) => {
+                            if response.applied {
+                                self.store.put(
+                                    &command_params.text_document.uri,
+                                    &new_text,
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            return Err(LspError::InternalError(
+                                format!("{:?}", err),
+                            )
+                            .into())
+                        }
+                    };
+                };
+
+                Ok(None)
+            }
             Ok(LspServerCommand::AddTagValueFilter) => todo!(),
             Ok(LspServerCommand::RemoveTagValueFilter) => todo!(),
             Ok(LspServerCommand::GetFunctionList) => Ok(Some(


### PR DESCRIPTION
Part of #549.

Implemented in accordance with the spec defined here:
https://github.com/influxdata/flux-lsp/pull/547

### Done:
* the composition submodule code is already in existence.
* in this PR:
  - [x] wire in the existing `add_tag()` and `remove_tag()` into the server layer
  - [x] update the composition submodule as needed (e.g. make function signatures take strings)