### PR TITLE
fix: applyEdit replacement text size, upon composition initialize

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1542,6 +1542,7 @@ impl LanguageServer for LspServer {
                             .into())
                         }
                     };
+
                 let last_pos =
                     line_col::LineColLookup::new(&new_text)
                         .get(new_text.len());
@@ -1684,6 +1685,8 @@ impl LanguageServer for LspServer {
                 )?;
                 let mut composition =
                     composition::Composition::new(file);
+                let old_text = composition.composition_string();
+
                 let status = composition.initialize(
                     command_params.bucket,
                     command_params.measurement,
@@ -1697,9 +1700,12 @@ impl LanguageServer for LspServer {
                 }
                 let new_text = composition.to_string();
 
-                let last_pos =
-                    line_col::LineColLookup::new(&new_text)
-                        .get(new_text.len());
+                let last_pos = match old_text {
+                    Some(text) => line_col::LineColLookup::new(&text)
+                        .get(text.len()),
+                    None => line_col::LineColLookup::new(&new_text)
+                        .get(new_text.len()),
+                };
 
                 let edit = lsp::WorkspaceEdit {
                     changes: Some(HashMap::from([(


### PR DESCRIPTION
## Bug:
1. create a schema composition. Make it longer (more tags etc).
2. re-init the composition by selecting a new measurement.
3. the replacement applyEdit is only for the first 3-4 lines. So we get half old block, half new block.

Vid:

https://user-images.githubusercontent.com/10232835/186808056-058ace8d-8ab4-4311-92be-cec05350171a.mp4




