### PR TITLE
feat: allow initialize to add extra filters

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -1159,7 +1159,13 @@ from(bucket: "an-composition")
         let mut composition = Composition::new(ast);
 
         composition
-            .initialize(String::from("an-composition"), None, None, None, None)
+            .initialize(
+                String::from("an-composition"),
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap();
 
         assert_eq!(
@@ -1186,7 +1192,13 @@ from(bucket: "my-bucket") |> yield(name: "my-result")
         let mut composition = Composition::new(ast);
 
         composition
-            .initialize(String::from("an-composition"), None, None, None, None)
+            .initialize(
+                String::from("an-composition"),
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap();
 
         assert_eq!(
@@ -1214,7 +1226,7 @@ from(bucket: "my-bucket") |> yield(name: "my-result")
                 Some(String::from("myMeasurement")),
                 None,
                 None,
-                None
+                None,
             )
             .unwrap();
 
@@ -1239,7 +1251,16 @@ from(bucket: "my-bucket") |> yield(name: "my-result")
         let mut composition = Composition::new(ast);
 
         composition
-            .initialize(String::from("an-composition"), Some("myMeasurement".into()), Some(vec!["myField".into(), "myField2".into()]), Some(vec!["myTag".into()]), Some(vec![("myTag".into(), "myTagValue".into()), ("myTag".into(), "myTagValue2".into())]))
+            .initialize(
+                String::from("an-composition"),
+                Some("myMeasurement".into()),
+                Some(vec!["myField".into(), "myField2".into()]),
+                Some(vec!["myTag".into()]),
+                Some(vec![
+                    ("myTag".into(), "myTagValue".into()),
+                    ("myTag".into(), "myTagValue2".into()),
+                ]),
+            )
             .unwrap();
 
         assert_eq!(

--- a/src/server/commands.rs
+++ b/src/server/commands.rs
@@ -153,7 +153,14 @@ pub struct InjectMeasurementFilterParams {
 pub struct CompositionInitializeParams {
     pub text_document: lsp::TextDocumentIdentifier,
     pub bucket: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub measurement: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag_values: Option<Vec<(String, String)>>,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1690,6 +1690,9 @@ impl LanguageServer for LspServer {
                 let status = composition.initialize(
                     command_params.bucket,
                     command_params.measurement,
+                    command_params.fields,
+                    command_params.tags,
+                    command_params.tag_values,
                 );
                 if status.is_err() {
                     return Err(LspError::InternalError(


### PR DESCRIPTION
This patch allows initialize to add extra filters atomically on
initialization. This means that users who continue to tack on state
after the composition is turned off will be able to see those changes
when composition is turned back on, as the client has the ability to
specify them all in a single request.