### PR TITLE
fix(576): new_text in composition applyEdit should only be the composition string. Not the entire file string.

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -1102,6 +1102,35 @@ from(bucket: "an-composition")
     }
 
     #[test]
+    fn test_composition_string_only_returns_composition() {
+        let fluxscript = r#"from(bucket: "an-composition")
+|> yield(name: "_editor_composition")
+
+query1 = from(bucket: "an-composition")
+"#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+        let composition = Composition::new(ast);
+
+        assert_eq!("from(bucket: \"an-composition\")\n    |> yield(name: \"_editor_composition\")\n".to_string(), composition.composition_string().unwrap());
+    }
+
+    #[test]
+    fn test_composition_string_will_return_updated_composition() {
+        let fluxscript = r#"from(bucket: "an-composition")
+|> yield(name: "_editor_composition")
+
+query1 = from(bucket: "an-composition")
+"#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+        let mut composition = Composition::new(ast);
+        composition
+            .add_measurement(String::from("myMeasurement"))
+            .unwrap();
+
+        assert_eq!("from(bucket: \"an-composition\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> filter(fn: (r) => r._measurement == \"myMeasurement\")\n    |> yield(name: \"_editor_composition\")\n".to_string(), composition.composition_string().unwrap());
+    }
+
+    #[test]
     fn test_query_analyzer() {
         let fluxscript = r#"from(bucket: "an-composition")
 |> range(start: v.timeRangeStart, stop: v.timeRangeStop)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1701,7 +1701,9 @@ impl LanguageServer for LspServer {
                     )
                     .into());
                 }
-                let new_text = composition.to_string();
+                let new_text = composition
+                    .composition_string()
+                    .expect("bad composition state");
 
                 let last_pos = match old_text {
                     Some(text) => line_col::LineColLookup::new(&text)
@@ -1779,7 +1781,9 @@ impl LanguageServer for LspServer {
                     )
                     .into());
                 }
-                let new_text = composition.to_string();
+                let new_text = composition
+                    .composition_string()
+                    .expect("bad composition state");
 
                 let last_pos = match old_text {
                     Some(text) => line_col::LineColLookup::new(&text)
@@ -1857,7 +1861,9 @@ impl LanguageServer for LspServer {
                     )
                     .into());
                 }
-                let new_text = composition.to_string();
+                let new_text = composition
+                    .composition_string()
+                    .expect("bad composition state");
 
                 let last_pos = match old_text {
                     Some(text) => line_col::LineColLookup::new(&text)
@@ -1935,7 +1941,9 @@ impl LanguageServer for LspServer {
                     )
                     .into());
                 }
-                let new_text = composition.to_string();
+                let new_text = composition
+                    .composition_string()
+                    .expect("bad composition state");
 
                 let last_pos = match old_text {
                     Some(text) => line_col::LineColLookup::new(&text)
@@ -2013,7 +2021,9 @@ impl LanguageServer for LspServer {
                     )
                     .into());
                 }
-                let new_text = composition.to_string();
+                let new_text = composition
+                    .composition_string()
+                    .expect("bad composition state");
 
                 let last_pos = match old_text {
                     Some(text) => line_col::LineColLookup::new(&text)
@@ -2091,7 +2101,9 @@ impl LanguageServer for LspServer {
                     )
                     .into());
                 }
-                let new_text = composition.to_string();
+                let new_text = composition
+                    .composition_string()
+                    .expect("bad composition state");
 
                 let last_pos = match old_text {
                     Some(text) => line_col::LineColLookup::new(&text)
@@ -2171,7 +2183,9 @@ impl LanguageServer for LspServer {
                     )
                     .into());
                 }
-                let new_text = composition.to_string();
+                let new_text = composition
+                    .composition_string()
+                    .expect("bad composition state");
 
                 let last_pos = match old_text {
                     Some(text) => line_col::LineColLookup::new(&text)
@@ -2251,7 +2265,9 @@ impl LanguageServer for LspServer {
                     )
                     .into());
                 }
-                let new_text = composition.to_string();
+                let new_text = composition
+                    .composition_string()
+                    .expect("bad composition state");
 
                 let last_pos = match old_text {
                     Some(text) => line_col::LineColLookup::new(&text)


### PR DESCRIPTION
Closes #576 
Closes https://github.com/influxdata/ui/issues/5634


It was creating duplicated code in the UI editor. ApplyEdit was inserting both the composition, and code existing in the rest of the file (outside the block).

With this change, we can hopefully preserve the flux code outside of the block...which also means copy/paste of previous compositions (to make subqueries) in the same flux script.


