### PR TITLE
fix: Complete empty properties on member expressions

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -313,10 +313,9 @@ impl LspServer {
                 // up when recursive support for member expressions is implemented.
                 let mut list: Vec<Box<dyn completion::Completable>> =
                     vec![];
-                if let Some(import) =
-                    completion::get_imports(sem_pkg)
-                        .iter()
-                        .find(|x| x.name == identifier.name)
+                if let Some(import) = completion::get_imports(sem_pkg)
+                    .iter()
+                    .find(|x| x.name == identifier.name)
                 {
                     for package in lang::STDLIB.packages() {
                         if package.path == import.path {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use flux::ast::walk::Node as AstNode;
-use flux::ast::Expression as AstExpression;
+use flux::ast::{self, Expression as AstExpression};
 use flux::semantic::nodes::{
     ErrorKind as SemanticNodeErrorKind, Package as SemanticPackage,
 };
@@ -299,6 +299,75 @@ impl LspServer {
         });
 
         diagnostic_map
+    }
+
+    fn complete_member_expression(
+        &self,
+        sem_pkg: &SemanticPackage,
+        member: &ast::MemberExpr,
+    ) -> Option<Vec<lsp::CompletionItem>> {
+        match &member.object {
+            AstExpression::Identifier(identifier) => {
+                // XXX: rockstar (6 Jul 2022) - This is the last holdout from the previous
+                // completion code. There is a bit of indirection/cruft here that can be cleaned
+                // up when recursive support for member expressions is implemented.
+                let mut list: Vec<Box<dyn completion::Completable>> =
+                    vec![];
+                if let Some(import) =
+                    completion::get_imports(&sem_pkg)
+                        .iter()
+                        .find(|x| x.name == identifier.name)
+                {
+                    for package in lang::STDLIB.packages() {
+                        if package.path == import.path {
+                            completion::walk_package(
+                                &package.path,
+                                &mut list,
+                                &package.exports.typ().expr,
+                            );
+                        }
+                    }
+                } else {
+                    for package in lang::STDLIB.packages() {
+                        if package.name == identifier.name {
+                            completion::walk_package(
+                                &package.path,
+                                &mut list,
+                                &package.exports.typ().expr,
+                            );
+                        }
+                    }
+                }
+
+                let visitor = crate::walk_semantic_package!(
+                    completion::CompletableObjectFinderVisitor::new(
+                        &identifier.name
+                    ),
+                    sem_pkg
+                );
+                let imports = completion::get_imports(&sem_pkg);
+                Some(
+                    vec![
+                        visitor
+                            .completables
+                            .iter()
+                            .map(|completable| {
+                                completable.completion_item(&imports)
+                            })
+                            .collect::<Vec<lsp::CompletionItem>>(),
+                        list.iter()
+                            .map(|completable| {
+                                completable.completion_item(&imports)
+                            })
+                            .collect(),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                )
+            }
+            _ => None,
+        }
     }
 }
 
@@ -965,6 +1034,10 @@ impl LanguageServer for LspServer {
             ),
             ast_pkg
         );
+        dbg!((
+            &params,
+            &visitor.node.as_ref().map(|node| &node.node)
+        ));
         let items = match visitor.node {
             Some(walk_node) => match walk_node.node {
                 AstNode::CallExpr(call) => {
@@ -973,12 +1046,36 @@ impl LanguageServer for LspServer {
                     )
                 }
                 AstNode::Identifier(identifier) => {
-                    // XXX: rockstar (6 Jul 2022) - This is helping to complete packages that
-                    // have never been imported. That's probably not a great pattern.
-                    let stdlib_completions: Vec<lsp::CompletionItem> =
-                        lang::STDLIB
-                            .fuzzy_matches(&identifier.name)
-                            .map(|package| lsp::CompletionItem {
+                    match walk_node
+                        .parent
+                        .as_ref()
+                        .map(|node| &node.node)
+                    {
+                        // The identifier is a member property so do member completion
+                        Some(AstNode::MemberExpr(member))
+                            if member
+                                .property
+                                .base()
+                                .location
+                                .start
+                                == identifier.base.location.start =>
+                        {
+                            match self.complete_member_expression(
+                                &sem_pkg, &member,
+                            ) {
+                                Some(items) => items,
+                                None => return Ok(None),
+                            }
+                        }
+                        _ => {
+                            // XXX: rockstar (6 Jul 2022) - This is helping to complete packages that
+                            // have never been imported. That's probably not a great pattern.
+                            let stdlib_completions: Vec<
+                                lsp::CompletionItem,
+                            > = lang::STDLIB
+                                .fuzzy_matches(&identifier.name)
+                                .map(|package| {
+                                    lsp::CompletionItem {
                                 label: package.path.clone(),
                                 detail: Some("Package".into()),
                                 documentation: Some(
@@ -1000,10 +1097,11 @@ impl LanguageServer for LspServer {
                                 ),
                                 sort_text: Some(package.path),
                                 ..lsp::CompletionItem::default()
-                            })
-                            .collect();
+                            }
+                                })
+                                .collect();
 
-                    let builtin_completions: Vec<
+                            let builtin_completions: Vec<
                         lsp::CompletionItem,
                     > = lang::UNIVERSE.exports.iter().filter(|(key, val)| {
                             // Don't allow users to "discover" private-ish functionality.
@@ -1057,66 +1155,22 @@ impl LanguageServer for LspServer {
                             }
                         }).collect();
 
-                    vec![stdlib_completions, builtin_completions]
-                        .into_iter()
-                        .flatten()
-                        .collect()
+                            vec![
+                                stdlib_completions,
+                                builtin_completions,
+                            ]
+                            .into_iter()
+                            .flatten()
+                            .collect()
+                        }
+                    }
                 }
                 AstNode::MemberExpr(member) => {
-                    match &member.object {
-                        AstExpression::Identifier(identifier) => {
-                            // XXX: rockstar (6 Jul 2022) - This is the last holdout from the previous
-                            // completion code. There is a bit of indirection/cruft here that can be cleaned
-                            // up when recursive support for member expressions is implemented.
-                            let mut list: Vec<
-                                Box<dyn completion::Completable>,
-                            > = vec![];
-                            if let Some(import) =
-                                completion::get_imports(&sem_pkg)
-                                    .iter()
-                                    .find(|x| {
-                                        x.name == identifier.name
-                                    })
-                            {
-                                for package in lang::STDLIB.packages()
-                                {
-                                    if package.path == import.path {
-                                        completion::walk_package(
-                                            &package.path,
-                                            &mut list,
-                                            &package
-                                                .exports
-                                                .typ()
-                                                .expr,
-                                        );
-                                    }
-                                }
-                            } else {
-                                for package in lang::STDLIB.packages()
-                                {
-                                    if package.name == identifier.name
-                                    {
-                                        completion::walk_package(
-                                            &package.path,
-                                            &mut list,
-                                            &package
-                                                .exports
-                                                .typ()
-                                                .expr,
-                                        );
-                                    }
-                                }
-                            }
-
-                            let visitor = crate::walk_semantic_package!(completion::CompletableObjectFinderVisitor::new(&identifier.name), sem_pkg);
-                            let imports =
-                                completion::get_imports(&sem_pkg);
-                            vec![
-                                visitor.completables.iter().map(|completable| completable.completion_item(&imports)).collect::<Vec<lsp::CompletionItem>>(),
-                                list.iter().map(|completable| completable.completion_item(&imports)).collect(),
-                            ].into_iter().flatten().collect()
-                        }
-                        _ => return Ok(None),
+                    match self
+                        .complete_member_expression(&sem_pkg, &member)
+                    {
+                        Some(items) => items,
+                        None => return Ok(None),
                     }
                 }
                 AstNode::ObjectExpr(_) => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -314,7 +314,7 @@ impl LspServer {
                 let mut list: Vec<Box<dyn completion::Completable>> =
                     vec![];
                 if let Some(import) =
-                    completion::get_imports(&sem_pkg)
+                    completion::get_imports(sem_pkg)
                         .iter()
                         .find(|x| x.name == identifier.name)
                 {
@@ -345,7 +345,7 @@ impl LspServer {
                     ),
                     sem_pkg
                 );
-                let imports = completion::get_imports(&sem_pkg);
+                let imports = completion::get_imports(sem_pkg);
                 Some(
                     vec![
                         visitor
@@ -1034,10 +1034,6 @@ impl LanguageServer for LspServer {
             ),
             ast_pkg
         );
-        dbg!((
-            &params,
-            &visitor.node.as_ref().map(|node| &node.node)
-        ));
         let items = match visitor.node {
             Some(walk_node) => match walk_node.node {
                 AstNode::CallExpr(call) => {
@@ -1061,7 +1057,7 @@ impl LanguageServer for LspServer {
                                 == identifier.base.location.start =>
                         {
                             match self.complete_member_expression(
-                                &sem_pkg, &member,
+                                &sem_pkg, member,
                             ) {
                                 Some(items) => items,
                                 None => return Ok(None),
@@ -1167,7 +1163,7 @@ impl LanguageServer for LspServer {
                 }
                 AstNode::MemberExpr(member) => {
                     match self
-                        .complete_member_expression(&sem_pkg, &member)
+                        .complete_member_expression(&sem_pkg, member)
                     {
                         Some(items) => items,
                         None => return Ok(None),

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2896,6 +2896,136 @@ sql"#;
     .assert_eq(&serde_json::to_string_pretty(&result).unwrap());
 }
 
+#[test]
+async fn test_member_completion() {
+
+    let fluxscript =
+    r#"
+import "json"
+
+from(bucket: "bucket")
+  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+  |> filter(fn: (r) => r["_measurement"] == "measurement")
+  |> filter(fn: (r) => r["_field"] == "request")
+  |> map(fn: (r) => (json.(v: r._value)))
+                      // ^
+  "#;
+
+
+    let server = create_server();
+    open_file(&server, fluxscript.to_string(), None).await;
+
+    let params = lsp::CompletionParams {
+        text_document_position: lsp::TextDocumentPositionParams {
+            text_document: lsp::TextDocumentIdentifier {
+                uri: lsp::Url::parse("file:///home/user/file.flux")
+                    .unwrap(),
+            },
+            position: position_of(fluxscript),
+        },
+        work_done_progress_params: lsp::WorkDoneProgressParams {
+            work_done_token: None,
+        },
+        partial_result_params: lsp::PartialResultParams {
+            partial_result_token: None,
+        },
+        context: Some(lsp::CompletionContext {
+            trigger_kind: lsp::CompletionTriggerKind::INVOKED,
+            trigger_character: None,
+        }),
+    };
+
+    let result =
+        server.completion(params.clone()).await.unwrap().unwrap();
+
+    expect_test::expect![[r#"
+        {
+          "isIncomplete": false,
+          "items": [
+            {
+              "label": "encode",
+              "kind": 3,
+              "detail": "(v:A) -> bytes",
+              "sortText": "encode",
+              "filterText": "encode",
+              "insertTextFormat": 2
+            }
+          ]
+        }"#]]
+        .assert_eq(&serde_json::to_string_pretty(&result).unwrap());
+}
+
+#[test]
+async fn test_member_completion_2() {
+
+    let fluxscript =
+    r#"
+import "json"
+
+from(bucket: "bucket")
+  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+  |> filter(fn: (r) => r["_measurement"] == "measurement")
+  |> filter(fn: (r) => r["_field"] == "request")
+  |> map(fn: (r) => (json.(v: r._value)))
+                    // ^
+  "#;
+
+
+    let server = create_server();
+    open_file(&server, fluxscript.to_string(), None).await;
+
+    let params = lsp::CompletionParams {
+        text_document_position: lsp::TextDocumentPositionParams {
+            text_document: lsp::TextDocumentIdentifier {
+                uri: lsp::Url::parse("file:///home/user/file.flux")
+                    .unwrap(),
+            },
+            position: position_of(fluxscript),
+        },
+        work_done_progress_params: lsp::WorkDoneProgressParams {
+            work_done_token: None,
+        },
+        partial_result_params: lsp::PartialResultParams {
+            partial_result_token: None,
+        },
+        context: Some(lsp::CompletionContext {
+            trigger_kind: lsp::CompletionTriggerKind::INVOKED,
+            trigger_character: None,
+        }),
+    };
+
+    let result =
+        server.completion(params.clone()).await.unwrap().unwrap();
+
+    expect_test::expect![[r#"
+        {
+          "isIncomplete": false,
+          "items": [
+            {
+              "label": "experimental/json",
+              "kind": 9,
+              "detail": "Package",
+              "documentation": "experimental/json",
+              "sortText": "experimental/json",
+              "filterText": "json",
+              "insertText": "experimental/json",
+              "insertTextFormat": 1
+            },
+            {
+              "label": "json",
+              "kind": 9,
+              "detail": "Package",
+              "documentation": "json",
+              "sortText": "json",
+              "filterText": "json",
+              "insertText": "json",
+              "insertTextFormat": 1
+            }
+          ]
+        }"#]]
+        .assert_eq(&serde_json::to_string_pretty(&result).unwrap());
+}
+
 use crate::visitors::ast::{
     SEMANTIC_TOKEN_KEYWORD, SEMANTIC_TOKEN_NUMBER,
     SEMANTIC_TOKEN_STRING,
@@ -3452,7 +3582,7 @@ async fn compute_diagnostics_non_errors() {
 
     let filename: String = "file:///path/to/script.flux".into();
     let fluxscript = r#"import "experimental"
-        
+
 from(bucket: "my-bucket")
 |> range(start: -100d)
 |> filter(fn: (r) => r.value == "b")

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2898,9 +2898,7 @@ sql"#;
 
 #[test]
 async fn test_member_completion() {
-
-    let fluxscript =
-    r#"
+    let fluxscript = r#"
 import "json"
 
 from(bucket: "bucket")
@@ -2910,7 +2908,6 @@ from(bucket: "bucket")
   |> map(fn: (r) => (json.(v: r._value)))
                       // ^
   "#;
-
 
     let server = create_server();
     open_file(&server, fluxscript.to_string(), None).await;
@@ -2952,14 +2949,12 @@ from(bucket: "bucket")
             }
           ]
         }"#]]
-        .assert_eq(&serde_json::to_string_pretty(&result).unwrap());
+    .assert_eq(&serde_json::to_string_pretty(&result).unwrap());
 }
 
 #[test]
 async fn test_member_completion_2() {
-
-    let fluxscript =
-    r#"
+    let fluxscript = r#"
 import "json"
 
 from(bucket: "bucket")
@@ -2969,7 +2964,6 @@ from(bucket: "bucket")
   |> map(fn: (r) => (json.(v: r._value)))
                     // ^
   "#;
-
 
     let server = create_server();
     open_file(&server, fluxscript.to_string(), None).await;
@@ -3023,7 +3017,7 @@ from(bucket: "bucket")
             }
           ]
         }"#]]
-        .assert_eq(&serde_json::to_string_pretty(&result).unwrap());
+    .assert_eq(&serde_json::to_string_pretty(&result).unwrap());
 }
 
 use crate::visitors::ast::{


### PR DESCRIPTION
Thought we might have gotten this for free with https://github.com/influxdata/flux/pull/4957 but I ran into this again today. Previously this would complete the identifier like any other identifier, now it will only select properties of the object.