### PR TITLE
fix: provide all lsp execute commands in initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,8 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
+ "strum",
+ "strum_macros",
  "tokio",
  "tower-service",
  "wasm-bindgen",
@@ -1385,6 +1387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1543,25 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ lspower = { version = "1.5.0", default-features = false, optional = true }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.79"
 simplelog = { version = "0.12.0", optional = true }
+strum = "0.24.1"
+strum_macros = "0.24.3"
 tokio = { version = "1.17.0", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread"], optional = true }
 tower-service = { version = "0.3.1", optional = true }
 wasm-bindgen = { version = "0.2.80", features = ["serde-serialize"], optional = true }

--- a/src/server/commands.rs
+++ b/src/server/commands.rs
@@ -1,6 +1,8 @@
 use lspower::lsp;
 use serde::{Deserialize, Serialize};
+use strum_macros::EnumIter;
 
+#[derive(EnumIter)]
 pub enum LspServerCommand {
     CompositionInitialize,
     AddMeasurementFilter,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -19,6 +19,7 @@ use flux::semantic::{walk, ErrorKind};
 use lspower::{
     jsonrpc::Result as RpcResult, lsp, Client, LanguageServer,
 };
+use strum::IntoEnumIterator;
 
 use crate::{completion, composition, lang, visitors::semantic};
 
@@ -413,7 +414,7 @@ impl LanguageServer for LspServer {
                     true,
                 )),
                 execute_command_provider: Some(lsp::ExecuteCommandOptions {
-                    commands: vec![],
+                    commands: commands::LspServerCommand::iter().map(|command| command.into()).collect::<Vec<String>>(),
                     work_done_progress_options: lsp::WorkDoneProgressOptions {
                         work_done_progress: None,
                     }


### PR DESCRIPTION
This patch adds a dependency that allows us to iterate over an enum, and
applies it to the `LspServerCommand` enum, and then iterates over them
in the initialization of the server.

Fixes #587