### PR TITLE
fix: use RwLock instead of Mutex for server state

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,7 +3,7 @@ mod store;
 mod types;
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 
 use flux::ast::walk::Node as AstNode;
 use flux::ast::{self, Expression as AstExpression};
@@ -157,7 +157,7 @@ pub struct LspServer {
     client: Arc<Mutex<Option<Client>>>,
     diagnostics: Vec<Diagnostic>,
     store: store::Store,
-    state: Mutex<LspServerState>,
+    state: RwLock<LspServerState>,
 }
 
 impl LspServer {
@@ -171,7 +171,7 @@ impl LspServer {
                 super::diagnostics::prefer_camel_case,
             ],
             store: store::Store::default(),
-            state: Mutex::new(LspServerState::default()),
+            state: RwLock::new(LspServerState::default()),
         }
     }
 
@@ -569,7 +569,7 @@ impl LanguageServer for LspServer {
                     buckets,
                 )) = settings.get("buckets")
                 {
-                    match self.state.lock() {
+                    match self.state.write() {
                         Ok(mut state) => {
                             state.set_buckets(
                                 buckets

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3798,7 +3798,7 @@ async fn workspace_state_buckets() {
         settings: json!({"settings": {"buckets": ["my-bucket", "your-bucket", "our-bucket"]}})
     }).await;
 
-    let buckets = server.state.lock().unwrap().buckets().clone();
+    let buckets = server.state.read().unwrap().buckets().clone();
 
     let expected: Vec<String> =
         vec!["my-bucket", "your-bucket", "our-bucket"]


### PR DESCRIPTION
This patch moves the server state from using `Mutex` to using `RwLock`.
The server state is currently unused (it was an idea spike that never
got the rest of its feature fully scheduled). In this case, though,
`RwLock` would be more appropriate, as it would be written once and read
in a number of other places.