### PR TITLE
feat(ui-6063): apply edit with imports

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -208,9 +208,6 @@ fn chained_binary_eq_expr(
 }
 
 macro_rules! filter {
-    ($values:expr, $operator:expr) => {
-        filter!(None, $values, $operator, chained_exists_expr($operator, $values).unwrap())
-    };
     ($key:expr, $values:expr, $operator:expr) => {
         filter!($key, $values, $operator, chained_binary_eq_expr($operator, $key, $values).unwrap())
     };

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -643,23 +643,17 @@ impl Composition {
         };
 
         if let Some(expr_statement) = visitor.statement {
-            self.file.body = self
-                .file
-                .body
-                .iter()
-                .filter(|statement| match statement {
-                    ast::Statement::Expr(expression) => {
-                        if expr_statement == *expression.as_ref() {
-                            start_position =
-                                expression.base.location.start;
-                            return false;
-                        }
-                        true
+            self.file.body.retain(|statement| match statement {
+                ast::Statement::Expr(expression) => {
+                    if expr_statement == *expression.as_ref() {
+                        start_position =
+                            expression.base.location.start;
+                        return false;
                     }
-                    _ => true,
-                })
-                .cloned()
-                .collect();
+                    true
+                }
+                _ => true,
+            });
         }
 
         let mut analyzer = CompositionQueryAnalyzer {

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -637,7 +637,7 @@ impl Composition {
             (Some(stmt), _) => stmt.base().location.start,
             (None, Some(import)) => ast::Position {
                 line: import.base.location.end.line + 1,
-                column: 0,
+                column: 1,
             },
             _ => ast::Position::default(),
         };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1506,14 +1506,7 @@ impl LanguageServer for LspServer {
 
                 if let Some(client) = self.get_client() {
                     match client.apply_edit(edit, None).await {
-                        Ok(response) => {
-                            if response.applied {
-                                self.store.put(
-                                    &command_params.text_document.uri,
-                                    composition.to_string().as_str(),
-                                );
-                            }
-                        }
+                        Ok(_) => {}
                         Err(err) => {
                             return Err(LspError::InternalError(
                                 format!("{:?}", err),
@@ -1593,14 +1586,7 @@ impl LanguageServer for LspServer {
 
                 if let Some(client) = self.get_client() {
                     match client.apply_edit(edit, None).await {
-                        Ok(response) => {
-                            if response.applied {
-                                self.store.put(
-                                    &command_params.text_document.uri,
-                                    composition.to_string().as_str(),
-                                );
-                            }
-                        }
+                        Ok(_) => {}
                         Err(err) => {
                             return Err(LspError::InternalError(
                                 format!("{:?}", err),
@@ -1680,14 +1666,7 @@ impl LanguageServer for LspServer {
 
                 if let Some(client) = self.get_client() {
                     match client.apply_edit(edit, None).await {
-                        Ok(response) => {
-                            if response.applied {
-                                self.store.put(
-                                    &command_params.text_document.uri,
-                                    composition.to_string().as_str(),
-                                );
-                            }
-                        }
+                        Ok(_) => {}
                         Err(err) => {
                             return Err(LspError::InternalError(
                                 format!("{:?}", err),
@@ -1767,14 +1746,7 @@ impl LanguageServer for LspServer {
 
                 if let Some(client) = self.get_client() {
                     match client.apply_edit(edit, None).await {
-                        Ok(response) => {
-                            if response.applied {
-                                self.store.put(
-                                    &command_params.text_document.uri,
-                                    composition.to_string().as_str(),
-                                );
-                            }
-                        }
+                        Ok(_) => {}
                         Err(err) => {
                             return Err(LspError::InternalError(
                                 format!("{:?}", err),
@@ -1856,14 +1828,7 @@ impl LanguageServer for LspServer {
 
                 if let Some(client) = self.get_client() {
                     match client.apply_edit(edit, None).await {
-                        Ok(response) => {
-                            if response.applied {
-                                self.store.put(
-                                    &command_params.text_document.uri,
-                                    composition.to_string().as_str(),
-                                );
-                            }
-                        }
+                        Ok(_) => {}
                         Err(err) => {
                             return Err(LspError::InternalError(
                                 format!("{:?}", err),
@@ -1945,14 +1910,7 @@ impl LanguageServer for LspServer {
 
                 if let Some(client) = self.get_client() {
                     match client.apply_edit(edit, None).await {
-                        Ok(response) => {
-                            if response.applied {
-                                self.store.put(
-                                    &command_params.text_document.uri,
-                                    composition.to_string().as_str(),
-                                );
-                            }
-                        }
+                        Ok(_) => {}
                         Err(err) => {
                             return Err(LspError::InternalError(
                                 format!("{:?}", err),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1474,26 +1474,25 @@ impl LanguageServer for LspServer {
                     .composition_string()
                     .expect("bad composition state");
 
-                // index 0 is line 1, char 1 for line_col::LineColLookup.
-                // Will need to convert to zero indexing for applyEdit. (Range is zero indexed.)
-                // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range
                 let last_pos = match old_text {
-                    Some(text) => line_col::LineColLookup::new(&text)
-                        .get(text.len()),
-                    None => line_col::LineColLookup::new(&new_text)
-                        .get(new_text.len()),
+                    Some((_, range_pos)) => range_pos,
+                    // applyEdit insertion point should be at Postion.start for new_text
+                    None => (new_text.1 .0, new_text.1 .1),
                 };
 
                 let edit = lsp::WorkspaceEdit {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: new_text.clone(),
+                            new_text: new_text.0.clone(),
                             range: lsp::Range {
-                                start: lsp::Position::default(),
+                                start: lsp::Position {
+                                    line: last_pos.0.line,
+                                    character: last_pos.0.column,
+                                },
                                 end: lsp::Position {
-                                    line: last_pos.0 as u32 - 1,
-                                    character: last_pos.1 as u32 - 1,
+                                    line: last_pos.1.line,
+                                    character: last_pos.1.column,
                                 },
                             },
                         }],
@@ -1557,26 +1556,27 @@ impl LanguageServer for LspServer {
                     .composition_string()
                     .expect("bad composition state");
 
-                // index 0 is line 1, char 1 for line_col::LineColLookup.
-                // Will need to convert to zero indexing for applyEdit. (Range is zero indexed.)
-                // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range
                 let last_pos = match old_text {
-                    Some(text) => line_col::LineColLookup::new(&text)
-                        .get(text.len()),
-                    None => line_col::LineColLookup::new(&new_text)
-                        .get(new_text.len()),
+                    Some((_, range_pos)) => range_pos,
+                    None => (
+                        ast::Position::default(),
+                        ast::Position::default(),
+                    ),
                 };
 
                 let edit = lsp::WorkspaceEdit {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: new_text.clone(),
+                            new_text: new_text.0.clone(),
                             range: lsp::Range {
-                                start: lsp::Position::default(),
+                                start: lsp::Position {
+                                    line: last_pos.0.line,
+                                    character: last_pos.0.column,
+                                },
                                 end: lsp::Position {
-                                    line: last_pos.0 as u32 - 1,
-                                    character: last_pos.1 as u32 - 1,
+                                    line: last_pos.1.line,
+                                    character: last_pos.1.column,
                                 },
                             },
                         }],
@@ -1640,26 +1640,27 @@ impl LanguageServer for LspServer {
                     .composition_string()
                     .expect("bad composition state");
 
-                // index 0 is line 1, char 1 for line_col::LineColLookup.
-                // Will need to convert to zero indexing for applyEdit. (Range is zero indexed.)
-                // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range
                 let last_pos = match old_text {
-                    Some(text) => line_col::LineColLookup::new(&text)
-                        .get(text.len()),
-                    None => line_col::LineColLookup::new(&new_text)
-                        .get(new_text.len()),
+                    Some((_, range_pos)) => range_pos,
+                    None => (
+                        ast::Position::default(),
+                        ast::Position::default(),
+                    ),
                 };
 
                 let edit = lsp::WorkspaceEdit {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: new_text.clone(),
+                            new_text: new_text.0.clone(),
                             range: lsp::Range {
-                                start: lsp::Position::default(),
+                                start: lsp::Position {
+                                    line: last_pos.0.line,
+                                    character: last_pos.0.column,
+                                },
                                 end: lsp::Position {
-                                    line: last_pos.0 as u32 - 1,
-                                    character: last_pos.1 as u32 - 1,
+                                    line: last_pos.1.line,
+                                    character: last_pos.1.column,
                                 },
                             },
                         }],
@@ -1723,26 +1724,27 @@ impl LanguageServer for LspServer {
                     .composition_string()
                     .expect("bad composition state");
 
-                // index 0 is line 1, char 1 for line_col::LineColLookup.
-                // Will need to convert to zero indexing for applyEdit. (Range is zero indexed.)
-                // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range
                 let last_pos = match old_text {
-                    Some(text) => line_col::LineColLookup::new(&text)
-                        .get(text.len()),
-                    None => line_col::LineColLookup::new(&new_text)
-                        .get(new_text.len()),
+                    Some((_, range_pos)) => range_pos,
+                    None => (
+                        ast::Position::default(),
+                        ast::Position::default(),
+                    ),
                 };
 
                 let edit = lsp::WorkspaceEdit {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: new_text.clone(),
+                            new_text: new_text.0.clone(),
                             range: lsp::Range {
-                                start: lsp::Position::default(),
+                                start: lsp::Position {
+                                    line: last_pos.0.line,
+                                    character: last_pos.0.column,
+                                },
                                 end: lsp::Position {
-                                    line: last_pos.0 as u32 - 1,
-                                    character: last_pos.1 as u32 - 1,
+                                    line: last_pos.1.line,
+                                    character: last_pos.1.column,
                                 },
                             },
                         }],
@@ -1808,26 +1810,27 @@ impl LanguageServer for LspServer {
                     .composition_string()
                     .expect("bad composition state");
 
-                // index 0 is line 1, char 1 for line_col::LineColLookup.
-                // Will need to convert to zero indexing for applyEdit. (Range is zero indexed.)
-                // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range
                 let last_pos = match old_text {
-                    Some(text) => line_col::LineColLookup::new(&text)
-                        .get(text.len()),
-                    None => line_col::LineColLookup::new(&new_text)
-                        .get(new_text.len()),
+                    Some((_, range_pos)) => range_pos,
+                    None => (
+                        ast::Position::default(),
+                        ast::Position::default(),
+                    ),
                 };
 
                 let edit = lsp::WorkspaceEdit {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: new_text.clone(),
+                            new_text: new_text.0.clone(),
                             range: lsp::Range {
-                                start: lsp::Position::default(),
+                                start: lsp::Position {
+                                    line: last_pos.0.line,
+                                    character: last_pos.0.column,
+                                },
                                 end: lsp::Position {
-                                    line: last_pos.0 as u32 - 1,
-                                    character: last_pos.1 as u32 - 1,
+                                    line: last_pos.1.line,
+                                    character: last_pos.1.column,
                                 },
                             },
                         }],
@@ -1893,26 +1896,27 @@ impl LanguageServer for LspServer {
                     .composition_string()
                     .expect("bad composition state");
 
-                // index 0 is line 1, char 1 for line_col::LineColLookup.
-                // Will need to convert to zero indexing for applyEdit. (Range is zero indexed.)
-                // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range
                 let last_pos = match old_text {
-                    Some(text) => line_col::LineColLookup::new(&text)
-                        .get(text.len()),
-                    None => line_col::LineColLookup::new(&new_text)
-                        .get(new_text.len()),
+                    Some((_, range_pos)) => range_pos,
+                    None => (
+                        ast::Position::default(),
+                        ast::Position::default(),
+                    ),
                 };
 
                 let edit = lsp::WorkspaceEdit {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: new_text.clone(),
+                            new_text: new_text.0.clone(),
                             range: lsp::Range {
-                                start: lsp::Position::default(),
+                                start: lsp::Position {
+                                    line: last_pos.0.line,
+                                    character: last_pos.0.column,
+                                },
                                 end: lsp::Position {
-                                    line: last_pos.0 as u32 - 1,
-                                    character: last_pos.1 as u32 - 1,
+                                    line: last_pos.1.line,
+                                    character: last_pos.1.column,
                                 },
                             },
                         }],

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1508,7 +1508,7 @@ impl LanguageServer for LspServer {
                             if response.applied {
                                 self.store.put(
                                     &command_params.text_document.uri,
-                                    &new_text,
+                                    composition.to_string().as_str(),
                                 );
                             }
                         }
@@ -1591,7 +1591,7 @@ impl LanguageServer for LspServer {
                             if response.applied {
                                 self.store.put(
                                     &command_params.text_document.uri,
-                                    &new_text,
+                                    composition.to_string().as_str(),
                                 );
                             }
                         }
@@ -1674,7 +1674,7 @@ impl LanguageServer for LspServer {
                             if response.applied {
                                 self.store.put(
                                     &command_params.text_document.uri,
-                                    &new_text,
+                                    composition.to_string().as_str(),
                                 );
                             }
                         }
@@ -1757,7 +1757,7 @@ impl LanguageServer for LspServer {
                             if response.applied {
                                 self.store.put(
                                     &command_params.text_document.uri,
-                                    &new_text,
+                                    composition.to_string().as_str(),
                                 );
                             }
                         }
@@ -1842,7 +1842,7 @@ impl LanguageServer for LspServer {
                             if response.applied {
                                 self.store.put(
                                     &command_params.text_document.uri,
-                                    &new_text,
+                                    composition.to_string().as_str(),
                                 );
                             }
                         }
@@ -1927,7 +1927,7 @@ impl LanguageServer for LspServer {
                             if response.applied {
                                 self.store.put(
                                     &command_params.text_document.uri,
-                                    &new_text,
+                                    composition.to_string().as_str(),
                                 );
                             }
                         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1455,7 +1455,7 @@ impl LanguageServer for LspServer {
                 )?;
                 let mut composition =
                     composition::Composition::new(file);
-                let old_text = composition.composition_string();
+                let old_text = composition.source_location();
 
                 let status = composition.initialize(
                     command_params.bucket,
@@ -1471,20 +1471,23 @@ impl LanguageServer for LspServer {
                     .into());
                 }
                 let new_text = composition
-                    .composition_string()
+                    .source_location()
                     .expect("bad composition state");
 
                 let last_pos = match old_text {
-                    Some((_, range_pos)) => range_pos,
-                    // applyEdit insertion point should be at Postion.start for new_text
-                    None => (new_text.1 .0, new_text.1 .1),
+                    Some(ast::SourceLocation {
+                        start, end, ..
+                    }) => (start, end),
+                    // This is the initialize() method, which is the only place where we may not have old_text.
+                    // In that case --> the new_text has the position we should use.
+                    None => (new_text.start, new_text.end),
                 };
 
                 let edit = lsp::WorkspaceEdit {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: new_text.0.clone(),
+                            new_text: new_text.source.expect("composition source_location is missing the source"),
                             range: lsp::Range {
                                 start: lsp::Position {
                                     line: last_pos.0.line,
@@ -1541,7 +1544,7 @@ impl LanguageServer for LspServer {
                 )?;
                 let mut composition =
                     composition::Composition::new(file);
-                let old_text = composition.composition_string();
+                let old_text = composition.source_location();
 
                 let status =
                     composition.add_measurement(command_params.value);
@@ -1553,11 +1556,14 @@ impl LanguageServer for LspServer {
                     .into());
                 }
                 let new_text = composition
-                    .composition_string()
+                    .source_location()
                     .expect("bad composition state");
 
                 let last_pos = match old_text {
-                    Some((_, range_pos)) => range_pos,
+                    Some(ast::SourceLocation {
+                        start, end, ..
+                    }) => (start, end),
+                    // applyEdit insertion point should be at Postion.start for new_text
                     None => (
                         ast::Position::default(),
                         ast::Position::default(),
@@ -1568,7 +1574,7 @@ impl LanguageServer for LspServer {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: new_text.0.clone(),
+                            new_text: new_text.source.expect("composition source_location is missing the source"),
                             range: lsp::Range {
                                 start: lsp::Position {
                                     line: last_pos.0.line,
@@ -1625,7 +1631,7 @@ impl LanguageServer for LspServer {
                 )?;
                 let mut composition =
                     composition::Composition::new(file);
-                let old_text = composition.composition_string();
+                let old_text = composition.source_location();
 
                 let status =
                     composition.add_field(command_params.value);
@@ -1637,11 +1643,14 @@ impl LanguageServer for LspServer {
                     .into());
                 }
                 let new_text = composition
-                    .composition_string()
+                    .source_location()
                     .expect("bad composition state");
 
                 let last_pos = match old_text {
-                    Some((_, range_pos)) => range_pos,
+                    Some(ast::SourceLocation {
+                        start, end, ..
+                    }) => (start, end),
+                    // applyEdit insertion point should be at Postion.start for new_text
                     None => (
                         ast::Position::default(),
                         ast::Position::default(),
@@ -1652,7 +1661,7 @@ impl LanguageServer for LspServer {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: new_text.0.clone(),
+                            new_text: new_text.source.expect("composition source_location is missing the source"),
                             range: lsp::Range {
                                 start: lsp::Position {
                                     line: last_pos.0.line,
@@ -1709,7 +1718,7 @@ impl LanguageServer for LspServer {
                 )?;
                 let mut composition =
                     composition::Composition::new(file);
-                let old_text = composition.composition_string();
+                let old_text = composition.source_location();
 
                 let status =
                     composition.remove_field(command_params.value);
@@ -1721,11 +1730,14 @@ impl LanguageServer for LspServer {
                     .into());
                 }
                 let new_text = composition
-                    .composition_string()
+                    .source_location()
                     .expect("bad composition state");
 
                 let last_pos = match old_text {
-                    Some((_, range_pos)) => range_pos,
+                    Some(ast::SourceLocation {
+                        start, end, ..
+                    }) => (start, end),
+                    // applyEdit insertion point should be at Postion.start for new_text
                     None => (
                         ast::Position::default(),
                         ast::Position::default(),
@@ -1736,7 +1748,7 @@ impl LanguageServer for LspServer {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: new_text.0.clone(),
+                            new_text: new_text.source.expect("composition source_location is missing the source"),
                             range: lsp::Range {
                                 start: lsp::Position {
                                     line: last_pos.0.line,
@@ -1793,7 +1805,7 @@ impl LanguageServer for LspServer {
                 )?;
                 let mut composition =
                     composition::Composition::new(file);
-                let old_text = composition.composition_string();
+                let old_text = composition.source_location();
 
                 let status = composition.add_tag_value(
                     command_params.tag,
@@ -1807,11 +1819,14 @@ impl LanguageServer for LspServer {
                     .into());
                 }
                 let new_text = composition
-                    .composition_string()
+                    .source_location()
                     .expect("bad composition state");
 
                 let last_pos = match old_text {
-                    Some((_, range_pos)) => range_pos,
+                    Some(ast::SourceLocation {
+                        start, end, ..
+                    }) => (start, end),
+                    // applyEdit insertion point should be at Postion.start for new_text
                     None => (
                         ast::Position::default(),
                         ast::Position::default(),
@@ -1822,7 +1837,7 @@ impl LanguageServer for LspServer {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: new_text.0.clone(),
+                            new_text: new_text.source.expect("composition source_location is missing the source"),
                             range: lsp::Range {
                                 start: lsp::Position {
                                     line: last_pos.0.line,
@@ -1879,7 +1894,7 @@ impl LanguageServer for LspServer {
                 )?;
                 let mut composition =
                     composition::Composition::new(file);
-                let old_text = composition.composition_string();
+                let old_text = composition.source_location();
 
                 let status = composition.remove_tag_value(
                     command_params.tag,
@@ -1893,11 +1908,14 @@ impl LanguageServer for LspServer {
                     .into());
                 }
                 let new_text = composition
-                    .composition_string()
+                    .source_location()
                     .expect("bad composition state");
 
                 let last_pos = match old_text {
-                    Some((_, range_pos)) => range_pos,
+                    Some(ast::SourceLocation {
+                        start, end, ..
+                    }) => (start, end),
+                    // applyEdit insertion point should be at Postion.start for new_text
                     None => (
                         ast::Position::default(),
                         ast::Position::default(),
@@ -1908,7 +1926,7 @@ impl LanguageServer for LspServer {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: new_text.0.clone(),
+                            new_text: new_text.source.expect("composition source_location is missing the source"),
                             range: lsp::Range {
                                 start: lsp::Position {
                                     line: last_pos.0.line,


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/6063

## Done:
* allow composition block to co-exist with the presence of import statements
* pick the optimal start Position, then calc the end Position.
* make code testable
  * this is why the start and end position calculations are in the composition mod, not the server
* server mod only cares about which position to use.
  * if composition is existing --> use positions from the previous block, for the replacement applyEdit.
  * if new composition --> has an order of precedence for where to insert. (See code comments.)
* remove update to store after applyEdit is created
  * should wait for monaco-editor `onChange` message  