### PR TITLE
chore: support multi tag value selection

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -326,7 +326,7 @@ struct CompositionQueryAnalyzer {
     bucket: String,
     measurement: Option<String>,
     fields: Vec<String>,
-    tag_values: Vec<(String, Vec<String>)>, // [(TagName, [TagValue1s])]
+    tag_values: Vec<(String, Vec<String>)>, // [(TagName, [TagValues])]
 }
 
 impl CompositionQueryAnalyzer {

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -1643,7 +1643,8 @@ from(bucket: "an-composition")
         let fluxscript = r#"from(bucket: "an-composition")
         |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
         |> filter(fn: (r) => r._measurement == "anMeasurement")
-        |> filter(fn: (r) => r.tagKey1 == "tagValue1" and r.tagKey3 == "tagValue3")
+        |> filter(fn: (r) => r.tagKey1 == "tagValue1")
+        |> filter(fn: (r) => r.tagKey3 == "tagValue3")
         |> yield(name: "_editor_composition")
     "#;
         let ast = flux::parser::parse_string("".into(), &fluxscript);

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -1020,6 +1020,7 @@ from(bucket: "an-composition")
 |> filter(fn: (r) => exists r.anTag)
 |> filter(fn: (r) => r.myTag == "anValue" or r.myTag == "anotherValue")
 |> filter(fn: (r) => r.myOtherTag == "anotherValue")
+|> filter(fn: (r) => r.myOldTag1 == "myOldTagValue1" and r.myOldTag1 == "myOldTagValue2" and r.myOldTag2 == "myOldTagValue")
 |> filter(fn: (r) => exists r.anotherTag)
 |> yield(name: "_editor_composition")"#;
         let ast = flux::parser::parse_string("".into(), &fluxscript);
@@ -1055,6 +1056,17 @@ from(bucket: "an-composition")
                 (
                     "myOtherTag".to_string(),
                     vec!["anotherValue".to_string()],
+                ),
+                (
+                    "myOldTag1".to_string(),
+                    vec![
+                        "myOldTagValue1".to_string(),
+                        "myOldTagValue2".to_string(),
+                    ]
+                ),
+                (
+                    "myOldTag2".to_string(),
+                    vec!["myOldTagValue".to_string()]
                 ),
             ],
             analyzer.tag_values

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -887,7 +887,6 @@ impl Composition {
         let mut analyzer = CompositionQueryAnalyzer::default();
         analyzer.analyze(expr_statement.clone());
 
-        let previous_len = analyzer.tag_values[&tag_key].len();
         match analyzer.tag_values.get_mut(&tag_key) {
             Some(tag_values) => {
                 tag_values.retain(|value| value.ne(&tag_value))
@@ -895,6 +894,7 @@ impl Composition {
             None => return Err(()),
         }
 
+        let previous_len = analyzer.tag_values[&tag_key].len();
         if previous_len == analyzer.tag_values[&tag_key].len() {
             return Err(());
         }

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -1418,7 +1418,7 @@ from(bucket: "an-composition")
     }
 
     #[test]
-    fn composition_add_tag_value_second_tag_value() {
+    fn composition_add_tag_value_new_tagset() {
         let fluxscript = r#"from(bucket: "an-composition")
         |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
         |> filter(fn: (r) => r._measurement == "anMeasurement")
@@ -1440,7 +1440,39 @@ from(bucket: "an-composition")
             r#"from(bucket: "an-composition")
     |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
     |> filter(fn: (r) => r._measurement == "anMeasurement")
-    |> filter(fn: (r) => r.tagKey1 == "tagValue1" and r.tagKey2 == "tagValue2")
+    |> filter(fn: (r) => r.tagKey1 == "tagValue1")
+    |> filter(fn: (r) => r.tagKey2 == "tagValue2")
+    |> yield(name: "_editor_composition")
+"#
+            .to_string(),
+            composition.to_string()
+        )
+    }
+
+    #[test]
+    fn composition_add_tag_value_same_tag_key() {
+        let fluxscript = r#"from(bucket: "an-composition")
+        |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+        |> filter(fn: (r) => r._measurement == "anMeasurement")
+        |> filter(fn: (r) => r.tagKey1 == "tagValue1")
+        |> yield(name: "_editor_composition")
+    "#;
+        let ast = flux::parser::parse_string("".into(), &fluxscript);
+
+        let mut composition = Composition::new(ast);
+        // DON'T INITIALIZE THIS! WE'RE SIMULATING AN ALREADY INITIALIZED QUERY.
+        composition
+            .add_tag_value(
+                String::from("tagKey1"),
+                String::from("tagValue2"),
+            )
+            .unwrap();
+
+        assert_eq!(
+            r#"from(bucket: "an-composition")
+    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+    |> filter(fn: (r) => r._measurement == "anMeasurement")
+    |> filter(fn: (r) => r.tagKey1 == "tagValue1" or r.tagKey1 == "tagValue2")
     |> yield(name: "_editor_composition")
 "#
             .to_string(),

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -847,10 +847,9 @@ impl Composition {
             match analyzer.tag_values.get_mut(&tag_key) {
                 Some(tag_values) => tag_values.push(tag_value),
                 None => {
-                    analyzer.tag_values.insert(
-                        tag_key.clone(),
-                        vec![tag_value.clone()],
-                    );
+                    analyzer
+                        .tag_values
+                        .insert(tag_key.clone(), vec![tag_value]);
                     analyzer.tag_keys_order.push(tag_key);
                 }
             }

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -845,15 +845,13 @@ impl Composition {
             return Err(());
         } else {
             match analyzer.tag_values.get_mut(&tag_key) {
-                Some(tag_values) => {
-                    tag_values.push(tag_value.clone())
-                }
+                Some(tag_values) => tag_values.push(tag_value),
                 None => {
                     analyzer.tag_values.insert(
                         tag_key.clone(),
                         vec![tag_value.clone()],
                     );
-                    analyzer.tag_keys_order.push(tag_key.clone());
+                    analyzer.tag_keys_order.push(tag_key);
                 }
             }
         }


### PR DESCRIPTION
Close influxdata/ui#5949

This PR updates the AST for multi tag values in the following rules:

* If adding a tag value where the tag key already exists in the flux file, use `or`.
* If adding a tag value with a new tag key, append a new `filter(...)` function. This function as implicit `and`.