### PR TITLE
chore: remove didSave

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -425,8 +425,12 @@ impl LanguageServer for LspServer {
                     },
                 ),
                 text_document_sync: Some(
-                    lsp::TextDocumentSyncCapability::Kind(
-                        lsp::TextDocumentSyncKind::FULL,
+                    lsp::TextDocumentSyncCapability::Options(
+                        lsp::TextDocumentSyncOptions {
+                            open_close: Some(true),
+                            change: Some(lsp::TextDocumentSyncKind::FULL),
+                            ..Default::default()
+                        }
                     ),
                 ),
                 ..Default::default()
@@ -491,17 +495,6 @@ impl LanguageServer for LspServer {
                 key,
                 err
             ),
-        }
-    }
-
-    async fn did_save(
-        &self,
-        params: lsp::DidSaveTextDocumentParams,
-    ) -> () {
-        if let Some(text) = params.text {
-            let key = params.text_document.uri;
-            self.store.put(&key, &text);
-            self.publish_diagnostics(&key).await;
         }
     }
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -182,28 +182,6 @@ async fn test_did_change_multiple() {
 }
 
 #[test]
-async fn test_did_save() {
-    let server = create_server();
-    open_file(
-        &server,
-        r#"from(bucket: "test") |> count()"#.to_string(),
-        None,
-    )
-    .await;
-
-    let uri = lsp::Url::parse("file:///home/user/file.flux").unwrap();
-
-    let params = lsp::DidSaveTextDocumentParams {
-        text_document: lsp::TextDocumentIdentifier::new(uri.clone()),
-        text: Some(r#"from(bucket: "test2")"#.to_string()),
-    };
-    server.did_save(params).await;
-
-    let contents = server.store.get(&uri).unwrap();
-    assert_eq!(r#"from(bucket: "test2")"#.to_string(), contents);
-}
-
-#[test]
 async fn test_did_close() {
     let server = create_server();
     open_file(&server, "from(".to_string(), None).await;


### PR DESCRIPTION
In more lsp initialization auditing, we don't signal support for
`textDocument/didSave`. Our `textDocumentSync` capabilities used the
"kind" path rather than the specific options. This patch switches to
using the options, but doesn't use the `textDocument/didSave` event
because it would only do the same as the `textDocument/didChange` event,
which we already handle. This way, we aren't locking the store to set
the same value already set in `textDocument/didChange`.