### PR TITLE
chore: update to rust 1.65

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.64"
+channel = "1.65"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown", ]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -999,7 +999,7 @@ impl LanguageServer for LspServer {
                 {
                     Ok(client_capabilities) => {
                         if let Some(text_document) =
-                            (*client_capabilities)
+                            (client_capabilities)
                                 .text_document
                                 .as_ref()
                         {


### PR DESCRIPTION
New rust is out. Use new rust. Fix new clippy lints.