### PR TITLE
feat(615): basic composition coordination with UI

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -561,6 +561,12 @@ impl Composition {
         }
     }
 
+    // Return a cloned copy of the composition file.
+    #[allow(dead_code)]
+    pub(crate) fn get_file(&self) -> ast::File {
+        self.file.clone()
+    }
+
     /// Sync the composition statement with the analyzer.
     // This is, for obvious reasons, inefficient. It moves the items in the vec
     // around a lot. Premature optimization and blah blah blah.
@@ -922,6 +928,17 @@ from(bucket: "myBucket")
             vec![],
             vec![],
         );
+
+        assert_eq!(
+            composition.to_string(),
+            r#"from(bucket: "myBucket")
+    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+    |> filter(fn: (r) => r._measurement == "myMeasurement")
+"#
+            .to_string()
+        );
+
+        // introduce range change (e.g. did_change)
         let fluxscript = r#"from(bucket: "myBucket")
     |> range(start: -24h)
     |> filter(fn: (r) => r._measurement == "myMeasurement")

--- a/src/server/commands.rs
+++ b/src/server/commands.rs
@@ -5,7 +5,7 @@ use strum_macros::EnumIter;
 #[derive(EnumIter)]
 pub enum LspServerCommand {
     CompositionInitialize,
-    AddMeasurementFilter,
+    SetMeasurementFilter,
     AddFieldFilter,
     RemoveFieldFilter,
     AddTagValueFilter,
@@ -21,8 +21,8 @@ impl TryFrom<String> for LspServerCommand {
             "fluxComposition/initialize" => {
                 Ok(LspServerCommand::CompositionInitialize)
             }
-            "fluxComposition/addMeasurementFilter" => {
-                Ok(LspServerCommand::AddMeasurementFilter)
+            "fluxComposition/setMeasurementFilter" => {
+                Ok(LspServerCommand::SetMeasurementFilter)
             }
             "fluxComposition/addFieldFilter" => {
                 Ok(LspServerCommand::AddFieldFilter)
@@ -53,8 +53,8 @@ impl From<LspServerCommand> for String {
             LspServerCommand::CompositionInitialize => {
                 "fluxComposition/initialize".into()
             }
-            LspServerCommand::AddMeasurementFilter => {
-                "fluxComposition/addMeasurementFilter".into()
+            LspServerCommand::SetMeasurementFilter => {
+                "fluxComposition/setMeasurementFilter".into()
             }
             LspServerCommand::AddFieldFilter => {
                 "fluxComposition/addFieldFilter".into()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1479,7 +1479,7 @@ impl LanguageServer for LspServer {
                 };
                 Ok(None)
             }
-            Ok(LspServerCommand::AddMeasurementFilter) => {
+            Ok(LspServerCommand::SetMeasurementFilter) => {
                 let command_params: ValueFilterParams =
                     match serde_json::value::from_value(
                         params.arguments[0].clone(),
@@ -1511,7 +1511,7 @@ impl LanguageServer for LspServer {
                 };
 
                 if composition
-                    .add_measurement(command_params.value)
+                    .set_measurement(command_params.value)
                     .is_err()
                 {
                     return Err(LspError::InternalError(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,7 +6,9 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 
 use flux::ast::walk::Node as AstNode;
-use flux::ast::{self, Expression as AstExpression};
+use flux::ast::{
+    self, Expression as AstExpression, Position, SourceLocation,
+};
 use flux::semantic::nodes::{
     ErrorKind as SemanticNodeErrorKind, Package as SemanticPackage,
 };
@@ -1450,17 +1452,24 @@ impl LanguageServer for LspServer {
                     command_params.tag_values.unwrap_or_default(),
                 );
 
+                let file = self.store.get_ast_file(
+                    &command_params.text_document.uri,
+                )?;
+                let mut location = file.base.location;
+                if !location.is_valid() {
+                    location = SourceLocation {
+                        start: Position { line: 1, column: 1 },
+                        end: Position { line: 1, column: 1 },
+                        ..SourceLocation::default()
+                    };
+                }
+
                 let edit = lsp::WorkspaceEdit {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
                             new_text: composition.to_string(),
-                            range: {
-                                let file = self.store.get_ast_file(
-                                    &command_params.text_document.uri,
-                                )?;
-                                file.base.location.into()
-                            },
+                            range: location.into(),
                         }],
                     )])),
                     document_changes: None,
@@ -1525,7 +1534,10 @@ impl LanguageServer for LspServer {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: composition.to_string(),
+                            new_text: composition
+                                .to_string()
+                                .trim_end()
+                                .to_owned(),
                             range: {
                                 let file = self.store.get_ast_file(
                                     &command_params.text_document.uri,
@@ -1596,7 +1608,10 @@ impl LanguageServer for LspServer {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: composition.to_string(),
+                            new_text: composition
+                                .to_string()
+                                .trim_end()
+                                .to_owned(),
                             range: {
                                 let file = self.store.get_ast_file(
                                     &command_params.text_document.uri,
@@ -1667,7 +1682,10 @@ impl LanguageServer for LspServer {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: composition.to_string(),
+                            new_text: composition
+                                .to_string()
+                                .trim_end()
+                                .to_owned(),
                             range: {
                                 let file = self.store.get_ast_file(
                                     &command_params.text_document.uri,
@@ -1741,7 +1759,10 @@ impl LanguageServer for LspServer {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: composition.to_string(),
+                            new_text: composition
+                                .to_string()
+                                .trim_end()
+                                .to_owned(),
                             range: {
                                 let file = self.store.get_ast_file(
                                     &command_params.text_document.uri,
@@ -1815,7 +1836,10 @@ impl LanguageServer for LspServer {
                     changes: Some(HashMap::from([(
                         command_params.text_document.uri.clone(),
                         vec![lsp::TextEdit {
-                            new_text: composition.to_string(),
+                            new_text: composition
+                                .to_string()
+                                .trim_end()
+                                .to_owned(),
                             range: {
                                 let file = self.store.get_ast_file(
                                     &command_params.text_document.uri,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -185,8 +185,7 @@ async fn test_did_change_updates_composition_file() {
     .to_string();
     let params = lsp::DidChangeTextDocumentParams {
         text_document: lsp::VersionedTextDocumentIdentifier {
-            uri: lsp::Url::parse("file:///home/user/file.flux")
-                .unwrap(),
+            uri: uri.clone(),
             version: -2,
         },
         content_changes: vec![lsp::TextDocumentContentChangeEvent {


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/6334
Closes https://github.com/influxdata/flux-lsp/issues/615

Note: this is part of a chain of PRs, which should be merged together. These PRs will handle the [3 basic tasks outlined here in this Epic](https://github.com/influxdata/ui/issues/6334).

This PR is the `FIRST_TASK`, which has both UI and flux-lsp changes. The ui changes [are here](https://github.com/influxdata/ui/pull/6344).


## DONE:

Closes #615  (`FIRST TASK` on the epic, lsp side changes).
That^^ issue ticket describes in detail, on why these changes were required. Also includes video evidence as each step, when finding all the bugs.

Broke out each commit, to correlate to a bug/issue listed in ticket 615:
* change to use `executeCommand/setMeasurement`
* two bugs found in the applyEdit response.
* edit in the `textDocument/didChange` not updating the state.