### PR TITLE
feat(609/610/ui-6334): LSP notification sent to UI with ActionItems

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -449,6 +449,9 @@ impl<'a> ast::walk::Visitor<'a> for CompositionStatementAnalyzer {
                             return false;
                         }
                     }
+                } else {
+                    self.calls.push(call_expr.clone());
+                    return false;
                 }
             }
             ast::walk::Node::BinaryExpr(binary_expr) => {

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -1,10 +1,12 @@
+use std::collections::HashMap;
+
 /// Composition functionality
 ///
 /// This module covers all the functionality that comes from the Composition feature of the
 /// LSP server. It's spec can be found in the docs/ folder of source control.
 ///
 /// This module _only_ operates on an AST. It will never operate on semantic graph.
-use flux::ast;
+use flux::ast::{self, SourceLocation};
 use itertools::Itertools;
 
 macro_rules! from {
@@ -565,6 +567,41 @@ impl Composition {
     #[allow(dead_code)]
     pub(crate) fn get_file(&self) -> ast::File {
         self.file.clone()
+    }
+
+    pub(crate) fn get_stmt_position(&self) -> Option<SourceLocation> {
+        self.file.body.get(self.statement_index).map(
+            |composition_stmt| {
+                composition_stmt.base().location.clone()
+            },
+        )
+    }
+
+    pub(crate) fn get_serialized_composition_state(
+        &self,
+    ) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(HashMap::from([
+            (
+                "bucket",
+                serde_json::to_value(self.analyzer.bucket.clone())?,
+            ),
+            (
+                "measurement",
+                serde_json::to_value(
+                    self.analyzer.measurement.clone(),
+                )?,
+            ),
+            (
+                "fields",
+                serde_json::to_value(self.analyzer.fields.clone())?,
+            ),
+            (
+                "tag_values",
+                serde_json::to_value(
+                    self.analyzer.tag_values.clone(),
+                )?,
+            ),
+        ]))
     }
 
     /// Sync the composition statement with the analyzer.

--- a/src/server/commands.rs
+++ b/src/server/commands.rs
@@ -87,6 +87,7 @@ pub enum LspClientCommand {
     UpdateComposition,
     CompositionDropped,
     CompositionNotFound,
+    AlreadyExists,
 }
 
 impl ToString for LspClientCommand {
@@ -100,6 +101,9 @@ impl ToString for LspClientCommand {
             }
             LspClientCommand::CompositionNotFound => {
                 "fluxComposition/compositionNotFound".into()
+            }
+            LspClientCommand::AlreadyExists => {
+                "fluxComposition/alreadyInitialized".into()
             }
         }
     }

--- a/src/server/commands.rs
+++ b/src/server/commands.rs
@@ -1,4 +1,4 @@
-use lspower::lsp;
+use lspower::lsp::{self, notification::Notification};
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumIter};
 
@@ -75,6 +75,13 @@ impl From<LspServerCommand> for String {
     }
 }
 
+pub struct ClientCommandNotification;
+
+impl Notification for ClientCommandNotification {
+    type Params = lsp::ShowMessageRequestParams;
+    const METHOD: &'static str = "window/showMessageRequest";
+}
+
 #[derive(Debug)]
 pub enum LspClientCommand {
     UpdateComposition,
@@ -92,7 +99,7 @@ impl ToString for LspClientCommand {
                 "fluxComposition/compositionEnded".into()
             }
             LspClientCommand::CompositionNotFound => {
-                "fluxComposition/compositionSyncFailed".into()
+                "fluxComposition/compositionNotFound".into()
             }
         }
     }

--- a/src/server/commands.rs
+++ b/src/server/commands.rs
@@ -87,6 +87,7 @@ pub enum LspClientCommand {
     UpdateComposition,
     CompositionDropped,
     CompositionNotFound,
+    ExecuteCommandFailed,
     AlreadyExists,
 }
 
@@ -101,6 +102,9 @@ impl ToString for LspClientCommand {
             }
             LspClientCommand::CompositionNotFound => {
                 "fluxComposition/compositionNotFound".into()
+            }
+            LspClientCommand::ExecuteCommandFailed => {
+                "fluxComposition/executeCommandFailed".into()
             }
             LspClientCommand::AlreadyExists => {
                 "fluxComposition/alreadyInitialized".into()

--- a/src/server/commands.rs
+++ b/src/server/commands.rs
@@ -1,6 +1,6 @@
 use lspower::lsp;
 use serde::{Deserialize, Serialize};
-use strum_macros::EnumIter;
+use strum_macros::{Display, EnumIter};
 
 #[derive(EnumIter)]
 pub enum LspServerCommand {
@@ -73,6 +73,35 @@ impl From<LspServerCommand> for String {
             }
         }
     }
+}
+
+#[derive(Debug)]
+pub enum LspClientCommand {
+    UpdateComposition,
+    CompositionDropped,
+    CompositionNotFound,
+}
+
+impl ToString for LspClientCommand {
+    fn to_string(&self) -> String {
+        match &self {
+            LspClientCommand::UpdateComposition => {
+                "fluxComposition/compositionState".into()
+            }
+            LspClientCommand::CompositionDropped => {
+                "fluxComposition/compositionEnded".into()
+            }
+            LspClientCommand::CompositionNotFound => {
+                "fluxComposition/compositionSyncFailed".into()
+            }
+        }
+    }
+}
+
+#[derive(Debug, Display)]
+pub enum LspMessageActionItem {
+    CompositionRange,
+    CompositionState,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -572,7 +572,7 @@ impl LanguageServer for LspServer {
                                     message: LspClientCommand::UpdateComposition.to_string(),
                                     actions: Some(vec![range_action_item, composition_state_action_item]),
                                 };
-                                let _ = client.send_custom_notification::<ClientCommandNotification>(params).await;
+                                client.send_custom_notification::<ClientCommandNotification>(params).await;
                             }
                             Err(error_type) => {
                                 let params =
@@ -582,7 +582,7 @@ impl LanguageServer for LspServer {
                                             .to_string(),
                                         actions: None,
                                     };
-                                let _ = client.send_custom_notification::<ClientCommandNotification>(params).await;
+                                client.send_custom_notification::<ClientCommandNotification>(params).await;
                             }
                         };
                     } else {
@@ -1532,7 +1532,7 @@ impl LanguageServer for LspServer {
                         actions: Some(vec![range_action_item]),
                     };
                     if let Some(client) = self.get_client() {
-                        let _ = client.send_custom_notification::<ClientCommandNotification>(params).await;
+                        client.send_custom_notification::<ClientCommandNotification>(params).await;
                     };
                 } else {
                     let edit = lsp::WorkspaceEdit {
@@ -1555,7 +1555,17 @@ impl LanguageServer for LspServer {
                         change_annotations: None,
                     };
                     if let Some(client) = self.get_client() {
-                        let _ = client.apply_edit(edit, None).await;
+                        let edit_applied =
+                            client.apply_edit(edit, None).await;
+                        if edit_applied.is_err() {
+                            let params =
+                                    lsp::ShowMessageRequestParams {
+                                        typ: lsp::MessageType::ERROR,
+                                        message: LspClientCommand::ExecuteCommandFailed.to_string(),
+                                        actions: None,
+                                    };
+                            client.send_custom_notification::<ClientCommandNotification>(params).await;
+                        }
                     };
                 }
 
@@ -1631,7 +1641,18 @@ impl LanguageServer for LspServer {
                 };
 
                 if let Some(client) = self.get_client() {
-                    let _ = client.apply_edit(edit, None).await;
+                    let edit_applied =
+                        client.apply_edit(edit, None).await;
+                    if edit_applied.is_err() {
+                        let params = lsp::ShowMessageRequestParams {
+                            typ: lsp::MessageType::ERROR,
+                            message:
+                                LspClientCommand::ExecuteCommandFailed
+                                    .to_string(),
+                            actions: None,
+                        };
+                        client.send_custom_notification::<ClientCommandNotification>(params).await;
+                    }
                 };
                 Ok(None)
             }
@@ -1698,7 +1719,18 @@ impl LanguageServer for LspServer {
                 };
 
                 if let Some(client) = self.get_client() {
-                    let _ = client.apply_edit(edit, None).await;
+                    let edit_applied =
+                        client.apply_edit(edit, None).await;
+                    if edit_applied.is_err() {
+                        let params = lsp::ShowMessageRequestParams {
+                            typ: lsp::MessageType::ERROR,
+                            message:
+                                LspClientCommand::ExecuteCommandFailed
+                                    .to_string(),
+                            actions: None,
+                        };
+                        client.send_custom_notification::<ClientCommandNotification>(params).await;
+                    }
                 };
                 Ok(None)
             }
@@ -1765,7 +1797,18 @@ impl LanguageServer for LspServer {
                 };
 
                 if let Some(client) = self.get_client() {
-                    let _ = client.apply_edit(edit, None).await;
+                    let edit_applied =
+                        client.apply_edit(edit, None).await;
+                    if edit_applied.is_err() {
+                        let params = lsp::ShowMessageRequestParams {
+                            typ: lsp::MessageType::ERROR,
+                            message:
+                                LspClientCommand::ExecuteCommandFailed
+                                    .to_string(),
+                            actions: None,
+                        };
+                        client.send_custom_notification::<ClientCommandNotification>(params).await;
+                    }
                 };
                 Ok(None)
             }
@@ -1835,7 +1878,18 @@ impl LanguageServer for LspServer {
                 };
 
                 if let Some(client) = self.get_client() {
-                    let _ = client.apply_edit(edit, None).await;
+                    let edit_applied =
+                        client.apply_edit(edit, None).await;
+                    if edit_applied.is_err() {
+                        let params = lsp::ShowMessageRequestParams {
+                            typ: lsp::MessageType::ERROR,
+                            message:
+                                LspClientCommand::ExecuteCommandFailed
+                                    .to_string(),
+                            actions: None,
+                        };
+                        client.send_custom_notification::<ClientCommandNotification>(params).await;
+                    }
                 };
                 Ok(None)
             }
@@ -1905,7 +1959,18 @@ impl LanguageServer for LspServer {
                 };
 
                 if let Some(client) = self.get_client() {
-                    let _ = client.apply_edit(edit, None).await;
+                    let edit_applied =
+                        client.apply_edit(edit, None).await;
+                    if edit_applied.is_err() {
+                        let params = lsp::ShowMessageRequestParams {
+                            typ: lsp::MessageType::ERROR,
+                            message:
+                                LspClientCommand::ExecuteCommandFailed
+                                    .to_string(),
+                            actions: None,
+                        };
+                        client.send_custom_notification::<ClientCommandNotification>(params).await;
+                    }
                 };
                 Ok(None)
             }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -24,8 +24,9 @@ use strum::IntoEnumIterator;
 use crate::{completion, composition, lang, visitors::semantic};
 
 use self::commands::{
-    CompositionInitializeParams, LspServerCommand,
-    TagValueFilterParams, ValueFilterParams,
+    CompositionInitializeParams, LspClientCommand,
+    LspMessageActionItem, LspServerCommand, TagValueFilterParams,
+    ValueFilterParams,
 };
 use self::types::LspError;
 
@@ -513,28 +514,78 @@ impl LanguageServer for LspServer {
                 self.store.put(&key, &new_contents.clone());
                 self.publish_diagnostics(&key).await;
 
+                // let mut composition_position = None;
                 if self.store.get_package_errors(&key).is_none() {
-                    match self.state.lock() {
+                    let composition_state = match self.state.lock() {
                         Ok(mut state) => {
                             if let Some(composition) =
                                 state.get_mut_composition(&key)
                             {
                                 match self.store.get_ast_file(&key) {
-                                Ok(file) => {
-                                    let result = composition.resolve_with_ast(file);
-                                    if result.is_err() {
-                                        state.drop_composition(&key);
-                                        if let Some(client) = &self.get_client() {
-                                            let _ = client.show_message(lsp::MessageType::ERROR, "A conflict has occured in the query composition. The composition has been aborted.");
+                                    Ok(file) => {
+                                        let result = composition
+                                            .resolve_with_ast(file);
+                                        if result.is_err() {
+                                            state.drop_composition(
+                                                &key,
+                                            );
+                                            Err(LspClientCommand::CompositionDropped)
+                                        } else {
+                                            Ok(composition.clone())
                                         }
                                     }
+                                    Err(_) => {
+                                        log::error!("Found composition but did not find ast for key: {}", key);
+                                        Err(LspClientCommand::CompositionNotFound)
+                                    }
                                 }
-                                Err(_) => log::error!("Found composition but did not find ast for key: {}", key),
-                            }
+                            } else {
+                                Err(LspClientCommand::CompositionNotFound)
                             }
                         }
                         Err(err) => panic!("{}", err),
-                    }
+                    };
+
+                    if let Some(client) = self.get_client() {
+                        match composition_state {
+                            Ok(composition) => {
+                                let position = composition
+                                    .get_stmt_position()
+                                    .expect("Bad stmt position.");
+                                let range_action_item = lsp::MessageActionItem {
+                                    title: LspMessageActionItem::CompositionRange.to_string(),
+                                    properties: HashMap::from([("range".to_string(), lsp::MessageActionItemProperty::Object(
+                                        serde_json::to_value(HashMap::from([
+                                            ("start", position.start),
+                                            ("end", position.end)
+                                        ])).expect("Bad stmt position")
+                                    ))])
+                                };
+                                let composition_state_action_item = lsp::MessageActionItem {
+                                    title: LspMessageActionItem::CompositionState.to_string(),
+                                    properties: HashMap::from([
+                                        ("state".to_string(), lsp::MessageActionItemProperty::Object(
+                                        composition.get_serialized_composition_state().expect("Bad composition state")))])
+                                };
+                                let _ = client.show_message_request(
+                                    lsp::MessageType::INFO,
+                                    LspClientCommand::UpdateComposition.to_string(),
+                                    Some(vec![range_action_item, composition_state_action_item])
+                                ).await;
+                            }
+                            Err(error_type) => {
+                                let _ = client
+                                    .show_message_request(
+                                        lsp::MessageType::ERROR,
+                                        error_type.to_string(),
+                                        None,
+                                    )
+                                    .await;
+                            }
+                        };
+                    } else {
+                        log::error!("Failed to acquire client.");
+                    };
                 }
             }
             Err(err) => log::error!(


### PR DESCRIPTION
Part of Epic https://github.com/influxdata/ui/issues/6334

Closes #609 — `fluxComposition/compositionEnded`
Closes #610 -- ` fluxComposition/compositionState`

Note: this is the last in a chain of PRs, which should be merged together. These PRs will handle the [3 basic tasks outlined here in this Epic](https://github.com/influxdata/ui/issues/6334).

This PR is the `THIRD_TASK`, which has both UI and flux-lsp changes. The ui changes are here.

## Specific changes made:
Each commit details exactly which changes, and why. If summary, these are:
1. send a `window/showMessageRequest` with an array of ActionItem for the ui to consume. Spec [is here](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessageRequest).
2. switched to using a custom_notification, since the previous server-initiated-request would hang and never resolve the promise
3. handle the re-attachment of existing compositions on page reloads (which trigger a `fluxComposition/initialize`
4. fix bug on persisting (in stateful composition) all the other calls.

## QA'ed e2e with UI:
TODO: insert final vid.