### PR TITLE
chore: update LspServer logging level to Info (not debug)

### DIFF
--- a/src/wasm/lsp.rs
+++ b/src/wasm/lsp.rs
@@ -2,6 +2,7 @@ use std::mem;
 
 use crate::LspServer;
 use futures::prelude::*;
+use log::Level;
 use lspower::{LspService, MessageStream};
 use tower_service::Service;
 use wasm_bindgen::prelude::*;
@@ -67,7 +68,7 @@ impl Default for Lsp {
         #[cfg(feature = "console_error_panic_hook")]
         console_error_panic_hook::set_once();
 
-        wasm_logger::init(wasm_logger::Config::default());
+        wasm_logger::init(wasm_logger::Config::new(Level::Info));
 
         let (service, messages) =
             lspower::LspService::new(|client| {


### PR DESCRIPTION
Forgot to appropriately set the logging level to Info and higher.
(Was spamming the UI browser console with debug messages. lol)



Here is what the Info (and higher) looks like in the browser console:

![Screen Shot 2022-12-13 at 11 07 33 AM](https://user-images.githubusercontent.com/10232835/207427722-014fc670-31f5-4d92-81f0-c092566c743e.png)
