### PR TITLE
fix(618): handle remaining wasm panics, and expose is_valid_flux() API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,16 +397,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
-dependencies = [
- "log",
- "web-sys",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,7 +681,6 @@ dependencies = [
  "clap 3.2.6",
  "combinations",
  "console_error_panic_hook",
- "console_log",
  "criterion",
  "env_logger",
  "expect-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = true
 default = ["cmd"]
 strict = []
 cmd = ["clap", "simplelog", "tokio", "tower-service", "lspower/runtime-tokio"]
-wasm = ["futures", "js-sys", "lspower/runtime-agnostic", "tower-service", "wasm-bindgen", "wasm-bindgen-futures"]
+wasm = ["futures", "js-sys", "fluxlang", "lspower/runtime-agnostic", "tower-service", "wasm-bindgen", "wasm-bindgen-futures"]
 fluxlang = []
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ async-trait = "0.1.53"
 clap = { version = "3.1.9", features = ["derive"], optional = true }
 combinations = "0.1.0"
 console_error_panic_hook = { version = "0.1.7", optional = true }
-console_log = { version = "0.2", optional = true }
 flux = { git = "https://github.com/influxdata/flux", tag= "v0.191.0", features = ["lsp"], default-features = false }
 futures = { version = "0.3.21", optional = true }
 Inflector = "0.11.4"

--- a/integration/lsp.test.ts
+++ b/integration/lsp.test.ts
@@ -133,6 +133,10 @@ describe('LSP Server', () => {
 });
 
 describe('module', () => {
+    beforeAll(async () => {
+        const { initLog } = await import('@influxdata/flux-lsp-node');
+        initLog();
+    })
 
     it('can parse Flux source' , async () => {
         const { parse } = await import('@influxdata/flux-lsp-node');

--- a/integration/lsp.test.ts
+++ b/integration/lsp.test.ts
@@ -155,17 +155,33 @@ describe('module', () => {
         expect(src).toBe('x = 2\n');
     })
 
-    it('always parses, even if invalid flux' , async () => {
-        const { parse } = await import('@influxdata/flux-lsp-node');
-        const ast = parse('from(bucket: " |>');
-        expect(ast.body.length == 1);
+    it('can recognize valid flux', async () => {
+        const { is_valid_flux } = await import('@influxdata/flux-lsp-node');
+        const res = is_valid_flux('from(bucket: "foo")');
+        expect(res);
     })
 
-    it('will fail to stringify ast if invalid flux' , async () => {
-        const { parse, format_from_js_file } = await import('@influxdata/flux-lsp-node');
-        const ast = parse('from(bucket: " |>');
-        expect(() => {
-            format_from_js_file(ast)
-        }).toThrow();
+    describe('invalid flux', () => {
+        const script = 'from(bucket: " |>';
+
+        it('always parses' , async () => {
+            const { parse } = await import('@influxdata/flux-lsp-node');
+            const ast = parse(script);
+            expect(ast.body.length == 1);
+        })
+
+        it('will fail to stringify ast if invalid flux' , async () => {
+            const { parse, format_from_js_file } = await import('@influxdata/flux-lsp-node');
+            const ast = parse(script);
+            expect(() => {
+                format_from_js_file(ast)
+            }).toThrow();
+        })
+
+        it('will fail is_valid_flux', async () => {
+            const { is_valid_flux } = await import('@influxdata/flux-lsp-node');
+            const res = is_valid_flux(script);
+            expect(res == false);
+        })
     })
 })

--- a/integration/lsp.test.ts
+++ b/integration/lsp.test.ts
@@ -131,6 +131,7 @@ describe('LSP Server', () => {
         expect(diagnostics[0]).toStrictEqual({"message": "undefined identifier x", "range": {"end": {"character": 14, "line": 0}, "start": {"character": 13, "line": 0}}, "severity": 1, "source": "flux"});
     });
 });
+
 describe('module', () => {
 
     it('can parse Flux source' , async () => {
@@ -152,5 +153,19 @@ describe('module', () => {
         // Format into new source
         const src = format_from_js_file(ast);
         expect(src).toBe('x = 2\n');
+    })
+
+    it('always parses, even if invalid flux' , async () => {
+        const { parse } = await import('@influxdata/flux-lsp-node');
+        const ast = parse('from(bucket: " |>');
+        expect(ast.body.length == 1);
+    })
+
+    it('will fail to stringify ast if invalid flux' , async () => {
+        const { parse, format_from_js_file } = await import('@influxdata/flux-lsp-node');
+        const ast = parse('from(bucket: " |>');
+        expect(() => {
+            format_from_js_file(ast)
+        }).toThrow();
     })
 })

--- a/integration/lsp.test.ts
+++ b/integration/lsp.test.ts
@@ -1,11 +1,6 @@
 describe('LSP Server', () => {
     let server;
 
-    beforeAll(async () => {
-        const { initLog } = await import('@influxdata/flux-lsp-node');
-        initLog();
-    });
-
     beforeEach(async () => {
         const { Lsp } = await import('@influxdata/flux-lsp-node');
         server = new Lsp();

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -16,7 +16,7 @@ use wasm_bindgen::prelude::*;
 use wasm_logger;
 
 #[wasm_bindgen(start)]
-pub fn main() {
+pub fn init() {
     wasm_logger::init(wasm_logger::Config::new(Level::Info));
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -11,16 +11,13 @@ pub use self::lang::Flux;
 pub use self::lsp::Lsp;
 
 use flux::{ast, formatter, parser};
+use log::Level;
 use wasm_bindgen::prelude::*;
+use wasm_logger;
 
-/// Initialize logging - this requires the "console_log" feature to function,
-/// as this library adds 180k to the wasm binary being shipped.
-#[allow(non_snake_case, dead_code)]
-#[wasm_bindgen]
-pub fn initLog() {
-    #[cfg(feature = "console_log")]
-    console_log::init_with_level(log::Level::Trace)
-        .expect("error initializing log");
+#[wasm_bindgen(start)]
+pub fn main() {
+    wasm_logger::init(wasm_logger::Config::new(Level::Info));
 }
 
 /// Parse flux into an AST representation. The AST will be generated regardless

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -15,8 +15,10 @@ use log::Level;
 use wasm_bindgen::prelude::*;
 use wasm_logger;
 
-#[wasm_bindgen(start)]
-pub fn init() {
+/// Initialize logging
+#[allow(non_snake_case, dead_code)]
+#[wasm_bindgen]
+pub fn initLog() {
     wasm_logger::init(wasm_logger::Config::new(Level::Info));
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -57,6 +57,13 @@ pub fn format_from_js_file(
     }
 }
 
+/// Validate flux script.
+#[wasm_bindgen]
+pub fn is_valid_flux(script: &str) -> bool {
+    let flux = Flux::new(&script);
+    flux.is_valid()
+}
+
 #[cfg(test)]
 #[allow(deprecated, clippy::wildcard_imports, clippy::unwrap_used)]
 mod test {

--- a/src/wasm/lsp.rs
+++ b/src/wasm/lsp.rs
@@ -2,10 +2,12 @@ use std::mem;
 
 use crate::LspServer;
 use futures::prelude::*;
+use log::Level;
 use lspower::{LspService, MessageStream};
 use tower_service::Service;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
+use wasm_logger;
 
 // MessageProcessor calls handlers for recieved messages.
 struct MessageProcessor {
@@ -65,6 +67,8 @@ impl Default for Lsp {
     fn default() -> Self {
         #[cfg(feature = "console_error_panic_hook")]
         console_error_panic_hook::set_once();
+
+        wasm_logger::init(wasm_logger::Config::new(Level::Info));
 
         let (service, messages) =
             lspower::LspService::new(|client| {

--- a/src/wasm/lsp.rs
+++ b/src/wasm/lsp.rs
@@ -2,12 +2,10 @@ use std::mem;
 
 use crate::LspServer;
 use futures::prelude::*;
-use log::Level;
 use lspower::{LspService, MessageStream};
 use tower_service::Service;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
-use wasm_logger;
 
 // MessageProcessor calls handlers for recieved messages.
 struct MessageProcessor {
@@ -67,8 +65,6 @@ impl Default for Lsp {
     fn default() -> Self {
         #[cfg(feature = "console_error_panic_hook")]
         console_error_panic_hook::set_once();
-
-        wasm_logger::init(wasm_logger::Config::new(Level::Info));
 
         let (service, messages) =
             lspower::LspService::new(|client| {

--- a/wasm-build.sh
+++ b/wasm-build.sh
@@ -16,7 +16,6 @@ case $BUILD_MODE in
         ;;
     "dev")
         BUILD_FLAG="--dev"
-        BUILD_MODE_ARGS="${BUILD_MODE_ARGS}"
         ;;
     *)
         echo "Invalid build mode: ${BUILD_MODE}"

--- a/wasm-build.sh
+++ b/wasm-build.sh
@@ -16,7 +16,7 @@ case $BUILD_MODE in
         ;;
     "dev")
         BUILD_FLAG="--dev"
-        BUILD_MODE_ARGS="${BUILD_MODE_ARGS},console_log"
+        BUILD_MODE_ARGS="${BUILD_MODE_ARGS}"
         ;;
     *)
         echo "Invalid build mode: ${BUILD_MODE}"


### PR DESCRIPTION
Closes #618 

## Done:
* wasm start now triggers logger setting at the wasm root (on load in browser). Confirmed will allow logging in LspServer and utils module.
* update test fixtures, to make more explicit what the `parse()` contract does.
   * note: we are misusing `parse()` as a validation method in the UI. Which is wrong.
* expose an `is_valid_flux()` method which can be used for validation in the UI

## Payload comparison:
The size of our wasm can impact network load times. With the changes made here, the release build has an increase in 25kB size.
<img width="613" alt="Screen Shot 2022-12-13 at 10 34 31 PM" src="https://user-images.githubusercontent.com/10232835/207524305-fd921002-dd9d-4e7d-a703-dd540a39a7cf.png">

  